### PR TITLE
several bug fixes for windows + logic bugs

### DIFF
--- a/src/assembler/assembler.c
+++ b/src/assembler/assembler.c
@@ -405,9 +405,9 @@ uint8_t sib_base(uint8_t base_bits) { return (base_bits & 0b111 ); }
 uint8_t sib_index(uint8_t index_bits) { return (index_bits & 0b111) << 3; }
 uint8_t sib_ss(uint8_t ss_bits) { return (ss_bits & 0b11) << 6; }
 
-uint8_t rex_reg_ext(uint8_t bit) { return (bit & 0b1); }
+uint8_t rex_rm_ext(uint8_t bit) { return (bit & 0b1); }
 uint8_t rex_sb_ext(uint8_t bit) { return (bit & 0b1) << 1; }
-uint8_t rex_rm_ext(uint8_t bit) { return (bit & 0b1) << 2; }
+uint8_t rex_reg_ext(uint8_t bit) { return (bit & 0b1) << 2; }
 
 
 #pragma GCC diagnostic push
@@ -529,7 +529,7 @@ AsmResult build_binary_op(Assembler* assembler, BinaryOp op, Location dest, Loca
     } else {
         if (be.order == OI)  {
             opcode_byte |= (dest.reg & 0b111);
-            rex_byte |= rex_reg_ext((dest.reg & 0b1000) >> 3);
+            rex_byte |= rex_rm_ext((dest.reg & 0b1000) >> 3);
         } else {
             throw_error(point, mv_string("Unrecognized binary op operand order encoding"));
         }

--- a/src/pico/analysis/unify.c
+++ b/src/pico/analysis/unify.c
@@ -17,21 +17,21 @@ Result unify(PiType* lhs, PiType* rhs, Allocator* a) {
 
     // Note that this is left-biased: if lhs and RHS are both uvars, lhs is
     // instantiated to be the same as RHS
-    if (lhs->sort == TUVarDefaulted) {
-        out = assert_maybe_integral(rhs);
-        if (out.type == Ok) rhs->uvar->subst = lhs;
-    }
-    else if (rhs->sort == TUVarDefaulted) {
-        out = assert_maybe_integral(lhs);
-        if (out.type == Ok) lhs->uvar->subst = rhs;
-    }
-    else if (lhs->sort == TUVar) {
+    if (lhs->sort == TUVar) {
         lhs->uvar->subst = rhs;
         out.type = Ok;
     }
     else if (rhs->sort == TUVar) {
         rhs->uvar->subst = lhs;
         out.type = Ok;
+    }
+    else if (lhs->sort == TUVarDefaulted) {
+        out = assert_maybe_integral(rhs);
+        if (out.type == Ok) lhs->uvar->subst = rhs;
+    }
+    else if (rhs->sort == TUVarDefaulted) {
+        out = assert_maybe_integral(lhs);
+        if (out.type == Ok) rhs->uvar->subst = lhs;
     }
     else if (rhs->sort == lhs->sort)
         out = unify_eq(lhs, rhs, a);

--- a/src/pico/codegen/polymorphic.c
+++ b/src/pico/codegen/polymorphic.c
@@ -93,7 +93,6 @@ void generate_polymorphic(SymbolArray types, Syntax syn, AddressEnv* env, Assemb
 
     // 4. Move RSP to end of value & restore old RBP
     build_binary_op(ass, Mov, reg(RSP), reg(RDX), a, point);
-    //build_binary_op(ass, Mov, reg(RBP), reg(RDX), a, point);
 
     // 5. push return address
     build_unary_op(ass, Push, reg(RCX), a, point); 
@@ -601,11 +600,16 @@ void generate_poly_stack_move(Location dest, Location src, Location size, Assemb
     build_binary_op(ass, Mov, reg(RCX), dest, a, point);
     build_binary_op(ass, Mov, reg(RDX), src, a, point);
     build_binary_op(ass, Mov, reg(R8), size, a, point);
+    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
 #else
 #error "Unknown calling convention"
 #endif
 
     // copy memcpy into RCX & call
-    build_binary_op(ass, Mov, reg(RCX), imm64((uint64_t)&memcpy), a, point);
-    build_unary_op(ass, Call, reg(RCX), a, point);
+    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&memcpy), a, point);
+    build_unary_op(ass, Call, reg(RAX), a, point);
+
+#if ABI == WIN_64
+    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+#endif
 }

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -38,22 +38,23 @@ EvalResult pico_run_toplevel(TopLevel top, Assembler* ass, SymSArrAMap* backlink
     }
     case TLDef:
         // copy into module
-        res.type = ERValue;
+        res = (EvalResult) {
+            .type = ERDef,
+            .def.name = top.def.bind,
+            .def.type = top.def.value->ptype,
+        };
         switch (top.def.value->ptype->sort) {
         case TAll:
         case TProc:
             add_fn_def(module, top.def.bind, *top.def.value->ptype, ass, backlinks);
-            res.def.name = top.def.bind;
-            res.def.type = top.def.value->ptype;
             break;
         case TEnum:
         case TStruct:
         case TKind:
         case TPrim: {
             // assume int64 for now!
-            res.val.type = top.def.value->ptype;
-            res.val.val = pico_run_expr(ass, pi_size_of(*top.def.value->ptype), a, point);
-            add_def(module, top.def.bind, *top.def.value->ptype, res.val.val);
+            void* val = pico_run_expr(ass, pi_size_of(*top.def.value->ptype), a, point);
+            add_def(module, top.def.bind, *top.def.value->ptype, val);
             break;
         }
         default:

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -60,7 +60,7 @@ void set_exit_callback(jmp_buf* buf) {
 }
 
 void exit_callback() {
-    longjmp(m_buf, 1);
+    longjmp(*m_buf, 1);
 }
 
 void build_exit_callback(Assembler* ass, Allocator* a, ErrorPoint* point) {
@@ -75,10 +75,6 @@ Module* base_module(Assembler* ass, Allocator* a) {
     PiType type;
     PiType type_val;
     PiType* type_data = &type_val;
-    type = (PiType) {
-        .sort = TKind,
-        .kind.nargs = 0,
-    };
     ErrorPoint point;
     if (catch_error(point)) {
         panic(point.error_message);
@@ -150,9 +146,6 @@ Module* base_module(Assembler* ass, Allocator* a) {
     sym = string_to_symbol(mv_string("is"));
     add_def(module, sym, type, &former);
 
-    // ------------------------------------------------------------------------
-    // Types 
-    // ------------------------------------------------------------------------
     former = FProcType;
     sym = string_to_symbol(mv_string("Proc"));
     add_def(module, sym, type, &former);
@@ -169,8 +162,15 @@ Module* base_module(Assembler* ass, Allocator* a) {
     sym = string_to_symbol(mv_string("All"));
     add_def(module, sym, type, &former);
 
+    // ------------------------------------------------------------------------
+    // Types 
+    // ------------------------------------------------------------------------
 
-    // Types
+    type = (PiType) {
+        .sort = TKind,
+        .kind.nargs = 0,
+    };
+
     type_val = mk_prim_type(Unit);
     sym = string_to_symbol(mv_string("Unit"));
     add_def(module, sym, type, &type_data);


### PR DESCRIPTION
Bugs fixed include:

assembler:
- Correcting REX byte extensions for reg vs rm
- Correcting encoding for OI instructions

codegen:
- correctly invoke memcpy on windows in poly_stack_move

evaluation:
- correctly output evaluation result for all definitions (regardless of type)

stdlib:
- Types have correct type - now have type kind rather than former.