### PR TITLE
Memory Manipulation

### DIFF
--- a/include/data/meta/array_impl.h
+++ b/include/data/meta/array_impl.h
@@ -20,7 +20,7 @@
             .size = source.size,                                        \
             .gpa = a,                                                   \
         };                                                              \
-        for (size_t i = 0; i < out.size; i++) {                         \
+        for (size_t i = 0; i < out.len; i++) {                         \
             out.data[i] = copy_elt(source.data[i], a);                  \
         }                                                               \
         return out;                                                     \

--- a/include/memory/arena.h
+++ b/include/memory/arena.h
@@ -4,6 +4,9 @@
 #include "memory/allocator.h"
 
 Allocator mk_arena_allocator(size_t blocksize, Allocator* a);
+
+void reset_arena_allocator(Allocator a);
+
 void release_arena_allocator(Allocator a);
 
 #endif

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -23,10 +23,10 @@ typedef enum {
     Int_32 = 0b0110,
     Int_64 = 0b0111,
 
-    /* UInt_64, */
-    /* UInt_32, */
-    /* UInt_16, */
-    /* UInt_8, */
+    UInt_8  = 0b1100,
+    UInt_16 = 0b1101,
+    UInt_32 = 0b1110,
+    UInt_64 = 0b1111,
 } PrimType;
 
 typedef enum {

--- a/include/pico/values/values.h
+++ b/include/pico/values/values.h
@@ -42,9 +42,9 @@ typedef enum TermFormer {
     FLabels,
     FSequence,
 
-
-    // Special Term former
+    // Special Term formers
     FIs,
+    FSize,
 
     // Type formers
     FProcType,

--- a/src/memory/arena.c
+++ b/src/memory/arena.c
@@ -100,6 +100,20 @@ void delete_block(ArenaBlock block, Allocator* a) {
     mem_free(block.data, a);
 }
 
+void reset_arena_allocator(Allocator a) {
+    ArenaContext* ctx = (ArenaContext*)a.ctx;
+    Allocator* ialloc = ctx->internal_allocator;
+
+    for (size_t i = 1; i < ctx->memory_blocks.len; i++)
+        delete_block(ctx->memory_blocks.data[i], ialloc);
+
+    ctx->memory_blocks.len = 1;
+    ArenaBlock* initial_block = &ctx->memory_blocks.data[0];
+    initial_block->bmp = 0;
+    
+    mem_free(ctx, ialloc);
+}
+
 void release_arena_allocator(Allocator a) {
     ArenaContext* ctx = (ArenaContext*)a.ctx;
     Allocator* ialloc = ctx->internal_allocator;

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -290,13 +290,13 @@ void build_realloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #if ABI == SYSTEM_V_64
     // realloc (ptr = rdi, size = rsi)
     // copy size into RDX
-    build_unary_op(ass, Pop, reg(RDI), a, point);
     build_unary_op(ass, Pop, reg(RSI), a, point);
+    build_unary_op(ass, Pop, reg(RDI), a, point);
 
 #elif ABI == WIN_64
     // realloc (ptr = RCX, size = RDX)
-    build_unary_op(ass, Pop, reg(RCX), a, point);
     build_unary_op(ass, Pop, reg(RDX), a, point);
+    build_unary_op(ass, Pop, reg(RCX), a, point);
     build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
 #endif
 

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -196,22 +196,42 @@ Document* pretty_pi_value(void* val, PiType* type, Allocator* a) {
             break;
         }
         case Int_64: {
-            int64_t* uival = (int64_t*) val;
-            out =  pretty_i64(*uival, a);
+            int64_t* ival = (int64_t*) val;
+            out =  pretty_i64(*ival, a);
             break;
         }
         case Int_32: {
-            int32_t* uival = (int32_t*) val;
-            out =  pretty_i32(*uival, a);
+            int32_t* ival = (int32_t*) val;
+            out =  pretty_i32(*ival, a);
             break;
         }
         case Int_16: {
-            int16_t* uival = (int16_t*) val;
-            out =  pretty_i16(*uival, a);
+            int16_t* ival = (int16_t*) val;
+            out =  pretty_i16(*ival, a);
             break;
         }
         case Int_8: {
-            int8_t* uival = (int8_t*) val;
+            int8_t* ival = (int8_t*) val;
+            out =  pretty_i8(*ival, a);
+            break;
+        }
+        case UInt_64: {
+            uint64_t* uival = (uint64_t*) val;
+            out =  pretty_u64(*uival, a);
+            break;
+        }
+        case UInt_32: {
+            uint32_t* uival = (uint32_t*) val;
+            out =  pretty_u32(*uival, a);
+            break;
+        }
+        case UInt_16: {
+            uint16_t* uival = (uint16_t*) val;
+            out =  pretty_i16(*uival, a);
+            break;
+        }
+        case UInt_8: {
+            uint8_t* uival = (uint8_t*) val;
             out =  pretty_i8(*uival, a);
             break;
         }
@@ -366,6 +386,18 @@ Document* pretty_type(PiType* type, Allocator* a) {
             break;
         case Int_8: 
             out = mv_str_doc(mk_string("I8", a), a);
+            break;
+        case UInt_64: 
+            out = mv_str_doc(mk_string("U64", a), a);
+            break;
+        case UInt_32: 
+            out = mv_str_doc(mk_string("U32", a), a);
+            break;
+        case UInt_16: 
+            out = mv_str_doc(mk_string("U16", a), a);
+            break;
+        case UInt_8: 
+            out = mv_str_doc(mk_string("U8", a), a);
             break;
         case TFormer: 
             out = mv_str_doc(mk_string("Former", a), a);

--- a/src/pico/values/values.c
+++ b/src/pico/values/values.c
@@ -112,6 +112,9 @@ Document* pretty_former(TermFormer op, Allocator* a) {
     case FIs:
         out = mk_str_doc(mv_string("::is"), a);
         break;
+    case FSize:
+        out = mk_str_doc(mv_string("::size"), a);
+        break;
 
         // Type formers
     case FStructType:


### PR DESCRIPTION
This adds the following functions to the standard library for memory management:

- malloc : `Proc (U64) Address`
- realloc : `Proc (Address U64) Address`
- free : `Proc  (Address) Unit`

As well as functions for loading from/storing to a particular address:

- store: `All [A] Proc (Address A) Unit`
- load: `All [A] Proc (Address) A`