### PR TITLE
Labels

### DIFF
--- a/include/data/meta/array_header.h
+++ b/include/data/meta/array_header.h
@@ -22,6 +22,6 @@
     void push_ ## fprefix(type val, tprefix##Array* arr);               \
     type pop_ ## fprefix(tprefix##Array* arr);                          \
                                                                         \
-    size_t find_ ## fprefix(type val, tprefix##Array* arr);             \
+    size_t find_ ## fprefix(type val, tprefix##Array arr);              \
 
 #endif

--- a/include/data/meta/array_impl.h
+++ b/include/data/meta/array_impl.h
@@ -3,7 +3,7 @@
 
 #include <string.h>
 
-#define ARRAY_COMMON_IMPL(type, fprefix, tprefix)                              \
+#define ARRAY_COMMON_IMPL(type, fprefix, tprefix)                       \
     tprefix##Array mk_ ## fprefix ## _array(const size_t size, Allocator* a) { \
         return (tprefix##Array){                                        \
             .data = (type*)mem_alloc(sizeof(type) * size, a),           \
@@ -16,11 +16,11 @@
         size_t memsize = sizeof(type) * source.size;                    \
         tprefix##Array out = (tprefix##Array) {                         \
             .data = mem_alloc(memsize, a),                              \
-            .len = source.len,                                          \
-            .size = source.size,                                        \
-            .gpa = a,                                                   \
+                .len = source.len,                                      \
+                .size = source.size,                                    \
+                .gpa = a,                                               \
         };                                                              \
-        for (size_t i = 0; i < out.len; i++) {                         \
+        for (size_t i = 0; i < out.len; i++) {                          \
             out.data[i] = copy_elt(source.data[i], a);                  \
         }                                                               \
         return out;                                                     \
@@ -66,23 +66,23 @@
     }
                                                                         
 
-#define ARRAY_IMPL(type, fprefix, tprefix)                      \
-    ARRAY_COMMON_IMPL(type, fprefix, tprefix)                          \
-    size_t find_ ## fprefix(type val, tprefix##Array* arr) {    \
-        for (size_t i = 0; i < arr->len; i++) {                 \
-            if (arr->data[i] == val) return i;                  \
-        }                                                       \
-        return arr->len;                                        \
-    }                                                           \
+#define ARRAY_IMPL(type, fprefix, tprefix)                          \
+    ARRAY_COMMON_IMPL(type, fprefix, tprefix)                       \
+         size_t find_ ## fprefix(type val, tprefix##Array arr) {    \
+        for (size_t i = 0; i < arr.len; i++) {                      \
+            if (arr.data[i] == val) return i;                       \
+        }                                                           \
+        return arr.len;                                             \
+    }                                                               \
 
-#define ARRAY_CMP_IMPL(type, cmpfun, fprefix, tprefix)          \
-    ARRAY_COMMON_IMPL(type, fprefix, tprefix)                   \
-    size_t find_ ## fprefix(type val, tprefix##Array* arr) {    \
-        for (size_t i = 0; i < arr->len; i++) {                 \
-            if (cmpfun(arr->data[i], val)) return i;            \
-        }                                                       \
-        return arr->len;                                        \
-    }                                                           \
+#define ARRAY_CMP_IMPL(type, cmpfun, fprefix, tprefix)              \
+    ARRAY_COMMON_IMPL(type, fprefix, tprefix)                       \
+         size_t find_ ## fprefix(type val, tprefix##Array arr) {    \
+        for (size_t i = 0; i < arr.len; i++) {                      \
+            if (cmpfun(arr.data[i], val)) return i;                 \
+        }                                                           \
+        return arr.len;                                             \
+    }                                                               \
 
 
 #endif

--- a/include/pico/binding/address_env.h
+++ b/include/pico/binding/address_env.h
@@ -37,6 +37,11 @@ typedef struct {
     };
 } AddressEntry;
 
+typedef struct {
+    Result_t type;
+    uint32_t stack_offset;
+} LabelEntry;
+
 AddressEnv* mk_address_env(Environment* env, Symbol* sym, Allocator* a);
 void delete_address_env(AddressEnv* env, Allocator* a);
 
@@ -55,6 +60,7 @@ void delete_address_env(AddressEnv* env, Allocator* a);
  */
 
 AddressEntry address_env_lookup(Symbol s, AddressEnv* env);
+LabelEntry label_env_lookup(Symbol s, AddressEnv* env);
 
 // Push and pop a new local environment to deal with procedure
 void address_start_proc(SymSizeAssoc vars, AddressEnv* env, Allocator* a);
@@ -67,8 +73,12 @@ void address_end_poly(AddressEnv* env, Allocator* a);
 // Binding assumes that an enum sits on top of the stack (i.e. at stack_head). 
 //   it establishes bindings for the members of the enum, but does not 
 // Unbind removes these bindings. Like bind, it does not adjust the stack head.
-void address_bind_enum_vars(SymSizeAssoc vars, AddressEnv* env, Allocator* a);
+void address_bind_enum_vars(SymSizeAssoc vars, AddressEnv* env);
 void address_unbind_enum_vars(AddressEnv* env);
+
+// Start/end 
+void address_start_labels(SymbolArray labels, AddressEnv* env);
+void address_end_labels(AddressEnv* env);
 
 // Inform the environment that values have been pushed/popped from the stack.
 void address_stack_grow(AddressEnv* env, size_t amount);

--- a/include/pico/binding/type_env.h
+++ b/include/pico/binding/type_env.h
@@ -6,13 +6,13 @@
 
 typedef struct TypeEnv TypeEnv;
 
-typedef enum TypeEntry_t {
+typedef enum {
     TELocal,
     TEGlobal,
     TENotFound,
 } TypeEntry_t;
 
-typedef struct TypeEntry {
+typedef struct {
     TypeEntry_t type;
     PiType* ptype;
     PiType* value;
@@ -22,9 +22,15 @@ TypeEnv* mk_type_env(Environment* env, Allocator* a);
 // No delete, as we expect allocation via an arena allocator
 
 TypeEntry type_env_lookup(Symbol s, TypeEnv* env);
+
 void type_var (Symbol var, PiType* type, TypeEnv* env);
 void type_qvar (Symbol var, PiType* type, TypeEnv* env);
+
 void pop_type(TypeEnv* env);
 void pop_types(TypeEnv* env, size_t n);
+
+bool label_present(Symbol s, TypeEnv* env);
+void add_labels (SymbolArray labels, TypeEnv* env);
+void pop_labels(TypeEnv* env, size_t n);
 
 #endif

--- a/include/pico/codegen/internal.h
+++ b/include/pico/codegen/internal.h
@@ -10,7 +10,14 @@
 /* Utility functions shared across code generation  
  */
 
-void backlink_global(Symbol sym, size_t offset, SymSArrAMap* links, Allocator* a);
+typedef struct {
+    SymSArrAMap backlinks;
+    SymSArrAMap gotolinks;
+} LinkData;
+
+void backlink_global(Symbol sym, size_t offset, LinkData* links, Allocator* a);
+void backlink_goto(Symbol sym, size_t offset, LinkData* links, Allocator* a);
+
 void generate_monomorphic_copy(Regname dest, Regname src, size_t size, Assembler* ass, Allocator* a, ErrorPoint* point);
 
 #endif

--- a/include/pico/codegen/polymorphic.h
+++ b/include/pico/codegen/polymorphic.h
@@ -8,7 +8,8 @@
 #include "pico/binding/address_env.h"
 #include "pico/syntax/syntax.h"
 #include "pico/data/sym_sarr_amap.h"
+#include "pico/codegen/internal.h"
 
-void generate_polymorphic(SymbolArray arr, Syntax syn, AddressEnv* env, Assembler* ass, SymSArrAMap* links, Allocator* a, ErrorPoint* point);
+void generate_polymorphic(SymbolArray arr, Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allocator* a, ErrorPoint* point);
 
 #endif

--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -44,6 +44,7 @@ typedef enum {
 
     // Control Flow & Binding
     SLabels,
+    SGoTo,
     SSequence,
     SLet,
     SIf,
@@ -133,8 +134,12 @@ typedef struct {
 } SynProjector;
 
 typedef struct {
-    SymPtrAssoc* terms;
+    SymPtrAssoc terms;
 } SynLabels;
+
+typedef struct {
+    Symbol label;
+} SynGoTo;
 
 typedef struct {
     SynArray terms;
@@ -198,6 +203,7 @@ struct Syntax {
         SynLet let_expr;
         SynIf if_expr;
         SynLabels labels;
+        SynGoTo go_to;
         SynSequence sequence;
 
         SynIs is;

--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -134,6 +134,7 @@ typedef struct {
 } SynProjector;
 
 typedef struct {
+    Syntax* entry;
     SymPtrAssoc terms;
 } SynLabels;
 

--- a/include/pico/values/values.h
+++ b/include/pico/values/values.h
@@ -40,6 +40,7 @@ typedef enum TermFormer {
     FLet,
     FIf,
     FLabels,
+    FGoTo,
     FSequence,
 
     // Special Term formers

--- a/src/pico/binding/type_env.c
+++ b/src/pico/binding/type_env.c
@@ -3,8 +3,13 @@
 
 #include "pico/binding/type_env.h"
 
+typedef enum {
+    LQVar,
+    LVar,
+} LocalSort;
+
 typedef struct {
-    bool is_qvar;
+    LocalSort sort;
     PiType* type;
 } Local;
 
@@ -13,12 +18,14 @@ ASSOC_IMPL(Symbol, Local, sym_local, SymLocal)
 
 struct TypeEnv {
     Environment* env;
-    SymLocalAssoc locals; // TODO: reset locals
+    SymLocalAssoc locals; // TODO: reset locals on new proc!
+    SymbolArray labels;
 };
 
 TypeEnv* mk_type_env(Environment* env, Allocator* a) {
     TypeEnv* t_env = (TypeEnv*)mem_alloc(sizeof(TypeEnv), a);
     t_env->locals = mk_sym_local_assoc(32, a);
+    t_env->labels= mk_u64_array(32, a);
     t_env->env = env;
     return t_env; 
 }
@@ -29,14 +36,15 @@ TypeEntry type_env_lookup(Symbol s, TypeEnv* env) {
     Local* lresult = sym_local_alookup(s, env->locals);
     if (lresult != NULL) {
         out.type = TELocal;
-        if (lresult->is_qvar) {
+        if (lresult->sort == LQVar) {
             out.ptype = NULL;
             out.value = lresult->type;
-        } else {
+            return out;
+        } else if (lresult -> sort == LVar) {
             out.ptype = lresult->type;
             out.value = NULL;
+            return out;
         }
-        return out;
     }
 
     // Now search globally
@@ -53,11 +61,11 @@ TypeEntry type_env_lookup(Symbol s, TypeEnv* env) {
 }
 
 void type_var (Symbol var, PiType* type, TypeEnv* env) {
-    sym_local_bind(var, (Local){.is_qvar = false, .type = type}, &env->locals);
+    sym_local_bind(var, (Local){.sort = LVar, .type = type}, &env->locals);
 }
 
 void type_qvar (Symbol var, PiType* type, TypeEnv* env) {
-    sym_local_bind(var, (Local){.is_qvar = true, .type = type}, &env->locals);
+    sym_local_bind(var, (Local){.sort = LQVar, .type = type}, &env->locals);
 }
 
 void pop_type(TypeEnv* env) {
@@ -65,5 +73,19 @@ void pop_type(TypeEnv* env) {
 }
 
 void pop_types(TypeEnv* env, size_t n) {
+    sym_local_unbindn(n, &env->locals);
+}
+
+bool label_present(Symbol s, TypeEnv* env) {
+    return (find_u64(s, env->labels) != env->labels.len);
+}
+
+void add_labels (SymbolArray labels, TypeEnv* env) {
+    for (size_t i = 0; i < labels.len; i++) {
+        push_u64(labels.data[i], &env->labels);
+    }
+}
+
+void pop_labels(TypeEnv* env, size_t n) {
     sym_local_unbindn(n, &env->locals);
 }

--- a/src/pico/codegen/internal.c
+++ b/src/pico/codegen/internal.c
@@ -1,13 +1,27 @@
 #include "pico/codegen/internal.h"
 
-void backlink_global(Symbol sym, size_t offset, SymSArrAMap* links, Allocator* a) {
+void backlink_global(Symbol sym, size_t offset, LinkData* links, Allocator* a) {
     // Step 1: Try lookup or else create & insert 
-    SizeArray* sarr = sym_sarr_lookup(sym, *links);
+    SizeArray* sarr = sym_sarr_lookup(sym, links->backlinks);
 
     if (!sarr) {
         // Create & Insert
-        sym_sarr_insert(sym, mk_size_array(4, a), links);
-        sarr = sym_sarr_lookup(sym, *links);
+        sym_sarr_insert(sym, mk_size_array(4, a), &links->backlinks);
+        sarr = sym_sarr_lookup(sym, links->backlinks);
+    }
+
+    // Step 2: insert offset into array
+    push_size(offset, sarr);
+}
+
+void backlink_goto(Symbol sym, size_t offset, LinkData* links, Allocator* a) {
+    // Step 1: Try lookup or else create & insert 
+    SizeArray* sarr = sym_sarr_lookup(sym, links->gotolinks);
+
+    if (!sarr) {
+        // Create & Insert
+        sym_sarr_insert(sym, mk_size_array(4, a), &links->gotolinks);
+        sarr = sym_sarr_lookup(sym, links->gotolinks);
     }
 
     // Step 2: insert offset into array

--- a/src/pico/codegen/polymorphic.c
+++ b/src/pico/codegen/polymorphic.c
@@ -9,11 +9,11 @@
 #include "pico/binding/address_env.h"
 
 // Implementation details
-void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, SymSArrAMap* links, Allocator* a, ErrorPoint* point);
+void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allocator* a, ErrorPoint* point);
 void generate_size_of(Regname dest, PiType* type, AddressEnv* env, Assembler* ass, Allocator* a, ErrorPoint* point);
 void generate_poly_stack_move(Location dest, Location src, Location size, Assembler* ass, Allocator* a, ErrorPoint* point);
 
-void generate_polymorphic(SymbolArray types, Syntax syn, AddressEnv* env, Assembler* ass, SymSArrAMap* links, Allocator* a, ErrorPoint* point) {
+void generate_polymorphic(SymbolArray types, Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allocator* a, ErrorPoint* point) {
     SymbolArray vars;
     Syntax body;
     if (syn.type == SProcedure) {
@@ -101,7 +101,7 @@ void generate_polymorphic(SymbolArray types, Syntax syn, AddressEnv* env, Assemb
     address_end_poly(env, a);
 }
 
-void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, SymSArrAMap* links, Allocator* a, ErrorPoint* point) {
+void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allocator* a, ErrorPoint* point) {
     switch (syn.type) {
     case SLitUntypedIntegral: {
         panic(mv_string("Cannot generate polymorphic code for untyped integral."));

--- a/src/pico/syntax/syntax.c
+++ b/src/pico/syntax/syntax.c
@@ -249,7 +249,31 @@ Document* pretty_syntax(Syntax* syntax, Allocator* a) {
         break;
     }
     case SLabels: {
-        out = mv_str_doc(mk_string("pretty_syntax not implemented for labels", a), a);
+        PtrArray nodes = mk_ptr_array(2 + syntax->labels.terms.len, a);
+        push_ptr(mk_str_doc(mv_string("(labels "), a), &nodes);
+
+        for (size_t i = 0; i < syntax->labels.terms.len; i++) {
+            PtrArray label_nodes = mk_ptr_array(4, a);
+            SymPtrACell cell = syntax->labels.terms.data[i];
+
+            push_ptr(mk_str_doc(mv_string("["), a), &label_nodes);
+            push_ptr(mk_str_doc(*symbol_to_string(cell.key), a), &label_nodes);
+            push_ptr(pretty_syntax(cell.val, a), &nodes);
+            push_ptr(mk_str_doc(mv_string("]"), a), &label_nodes);
+
+            push_ptr(mv_sep_doc(label_nodes, a), &nodes);
+        }
+
+        push_ptr(mk_str_doc(mv_string(")"), a), &nodes);
+        out = mv_cat_doc(nodes, a);
+        break;
+    }
+    case SGoTo: {
+        PtrArray nodes = mk_ptr_array(3, a);
+        push_ptr(mk_str_doc(mv_string("(go-to "), a), &nodes);
+        push_ptr(mk_str_doc(*symbol_to_string(syntax->go_to.label), a), &nodes);
+        push_ptr(mk_str_doc(mv_string(")"), a), &nodes);
+        out = mv_cat_doc(nodes, a);
         break;
     }
     case SSequence: {

--- a/src/pico/syntax/syntax.c
+++ b/src/pico/syntax/syntax.c
@@ -251,6 +251,7 @@ Document* pretty_syntax(Syntax* syntax, Allocator* a) {
     case SLabels: {
         PtrArray nodes = mk_ptr_array(2 + syntax->labels.terms.len, a);
         push_ptr(mk_str_doc(mv_string("(labels "), a), &nodes);
+        push_ptr(pretty_syntax(syntax->labels.entry, a), &nodes);
 
         for (size_t i = 0; i < syntax->labels.terms.len; i++) {
             PtrArray label_nodes = mk_ptr_array(4, a);
@@ -258,14 +259,14 @@ Document* pretty_syntax(Syntax* syntax, Allocator* a) {
 
             push_ptr(mk_str_doc(mv_string("["), a), &label_nodes);
             push_ptr(mk_str_doc(*symbol_to_string(cell.key), a), &label_nodes);
-            push_ptr(pretty_syntax(cell.val, a), &nodes);
+            push_ptr(pretty_syntax(cell.val, a), &label_nodes);
             push_ptr(mk_str_doc(mv_string("]"), a), &label_nodes);
 
             push_ptr(mv_sep_doc(label_nodes, a), &nodes);
         }
 
         push_ptr(mk_str_doc(mv_string(")"), a), &nodes);
-        out = mv_cat_doc(nodes, a);
+        out = mv_sep_doc(nodes, a);
         break;
     }
     case SGoTo: {

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -471,8 +471,8 @@ Module* base_module(Assembler* ass, Allocator* a) {
     sym = string_to_symbol(mv_string("labels"));
     add_def(module, sym, type, &former);
 
-    former = FLabels;
-    sym = string_to_symbol(mv_string("goto"));
+    former = FGoTo;
+    sym = string_to_symbol(mv_string("go-to"));
     add_def(module, sym, type, &former);
 
     former = FSequence;

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -471,6 +471,10 @@ Module* base_module(Assembler* ass, Allocator* a) {
     sym = string_to_symbol(mv_string("labels"));
     add_def(module, sym, type, &former);
 
+    former = FLabels;
+    sym = string_to_symbol(mv_string("goto"));
+    add_def(module, sym, type, &former);
+
     former = FSequence;
     sym = string_to_symbol(mv_string("seq"));
     add_def(module, sym, type, &former);

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -524,7 +524,7 @@ PiType* pi_type_subst_i(PiType* type, SymPtrAssoc binds, SymbolArray* shadow, Al
     }
     // Quantified Types
     case TVar: {
-        if (find_u64(type->var, shadow) == shadow->len) {
+        if (find_u64(type->var, *shadow) == shadow->len) {
             PiType** result = (PiType**)sym_ptr_alookup(type->var, binds);
             *out = result ? **result : *type;
         }

--- a/src/pico/values/values.c
+++ b/src/pico/values/values.c
@@ -105,6 +105,9 @@ Document* pretty_former(TermFormer op, Allocator* a) {
     case FLabels:
         out = mk_str_doc(mv_string("::labels"), a);
         break;
+    case FGoTo:
+        out = mk_str_doc(mv_string("::goto"), a);
+        break;
     case FSequence:
         out = mk_str_doc(mv_string("::sequence"), a);
         break;


### PR DESCRIPTION
Added labels construct: code-generation, typechecking and syntax

Labels functions like goto in c, but has an 'entry point' sample code:

```relic
;; sum numbers < n
(def triangle [n] 
  (let [total (ref 0)]
         [counter (ref 0]
   (labels (go-to loop-start)
    [loop-start seq
      (when (= counter n) (go-to loop-end))
      (set! total (+ !total counter))
      (set! counter (+ !counter 1))]

    [loop-end !total)])
```