### PR TITLE
Bugfix: invalid usage of RBX

### DIFF
--- a/src/assembler/assembler.c
+++ b/src/assembler/assembler.c
@@ -642,7 +642,9 @@ AsmResult build_unary_op(Assembler* assembler, UnaryOp op, Location loc, Allocat
                 num_immediate_bytes = 1;
             } else if (loc.immediate_32 <= 256 * 256) {
                 opcode = 0x68;
-                num_immediate_bytes = 2;
+                // Encoding for 16 & 32 bit immediate are the same, 
+                // meaning a "16 bit immediate" is actually a padded 32-bit immediate!
+                num_immediate_bytes = 4;
             } else {
                 opcode = 0x68;
                 num_immediate_bytes = 4;

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -99,15 +99,15 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
             // Use RAX as a temp
             // Note: casting void* to uint64_t only works for 64-bit systems...
             if (syn.ptype->sort == TProc || syn.ptype->sort == TAll) {
-                AsmResult out = build_binary_op(ass, Mov, reg(RBX), imm64((uint64_t)e.value), a, point);
+                AsmResult out = build_binary_op(ass, Mov, reg(R9), imm64((uint64_t)e.value), a, point);
                 backlink_global(syn.variable, out.backlink, links, a);
 
-                build_unary_op(ass, Push, reg(RBX), a, point);
+                build_unary_op(ass, Push, reg(R9), a, point);
             } else if (syn.ptype->sort == TPrim) {
                 AsmResult out = build_binary_op(ass, Mov, reg(RCX), imm64((uint64_t)e.value), a, point);
                 backlink_global(syn.variable, out.backlink, links, a);
-                build_binary_op(ass, Mov, reg(RBX), rref(RCX, 0), a, point);
-                build_unary_op(ass, Push, reg(RBX), a, point);
+                build_binary_op(ass, Mov, reg(R9), rref(RCX, 0), a, point);
+                build_unary_op(ass, Push, reg(R9), a, point);
             } else if (syn.ptype->sort == TKind) {
                 AsmResult out = build_binary_op(ass, Mov, reg(RCX), imm64((uint64_t)e.value), a, point);
                 backlink_global(syn.variable, out.backlink, links, a);
@@ -176,7 +176,7 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         build_unary_op(ass, Pop, reg(RAX), a, point);
         build_unary_op(ass, Pop, reg(RBP), a, point);
         // storage of return address
-        build_unary_op(ass, Pop, reg(RBX), a, point);
+        build_unary_op(ass, Pop, reg(R9), a, point);
         
         // pop args
         build_binary_op(ass, Add, reg(RSP), imm32(syn.procedure.args.len * 8), a, point);
@@ -184,7 +184,7 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         // push value
         build_unary_op(ass, Push, reg(RAX), a, point);
         // push return address 
-        build_unary_op(ass, Push, reg(RBX), a, point);
+        build_unary_op(ass, Push, reg(R9), a, point);
         build_nullary_op(ass, Ret, a, point);
         break;
     }
@@ -507,9 +507,9 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         // generate the condition
         generate(*syn.if_expr.condition, env, ass, links, a, point);
 
-        // Pop the bool into RBX; compare with 0
-        build_unary_op(ass, Pop, reg(RBX), a, point);
-        build_binary_op(ass, Cmp, reg(RBX), imm32(0), a, point);
+        // Pop the bool into R9; compare with 0
+        build_unary_op(ass, Pop, reg(R9), a, point);
+        build_binary_op(ass, Cmp, reg(R9), imm32(0), a, point);
         address_stack_shrink(env, pi_size_of((PiType) {.sort = TPrim, .prim = Bool}));
 
         // ---------- CONDITIONAL JUMP ----------
@@ -658,8 +658,8 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         generate(*syn.is.val, env, ass, links, a, point);
         break;
     case SCheckedType: {
-        build_binary_op(ass, Mov, reg(RBX), imm64((uint64_t)syn.type_val), a, point);
-        build_unary_op(ass, Push, reg(RBX), a, point);
+        build_binary_op(ass, Mov, reg(R9), imm64((uint64_t)syn.type_val), a, point);
+        build_unary_op(ass, Push, reg(R9), a, point);
         address_stack_grow(env, pi_size_of(*syn.ptype));
         break;
     }

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -39,9 +39,9 @@ PiType mk_null_proc_type(Allocator* a) {
 
 void build_binary_fun(Assembler* ass, BinaryOp op, Allocator* a, ErrorPoint* point) {
     build_unary_op (ass, Pop, reg(RCX), a, point);
-    build_unary_op (ass, Pop, reg(RBX), a, point);
+    build_unary_op (ass, Pop, reg(R9), a, point);
     build_unary_op (ass, Pop, reg(RAX), a, point);
-    build_binary_op (ass, op, reg(RAX), reg(RBX), a, point);
+    build_binary_op (ass, op, reg(RAX), reg(R9), a, point);
     build_unary_op (ass, Push, reg(RAX), a, point);
     build_unary_op (ass, Push, reg(RCX), a, point);
     build_nullary_op (ass, Ret, a, point);
@@ -49,9 +49,9 @@ void build_binary_fun(Assembler* ass, BinaryOp op, Allocator* a, ErrorPoint* poi
 
 void build_comp_fun(Assembler* ass, UnaryOp op, Allocator* a, ErrorPoint* point) {
     build_unary_op (ass, Pop, reg(RCX), a, point);
-    build_unary_op (ass, Pop, reg(RBX), a, point);
+    build_unary_op (ass, Pop, reg(R9), a, point);
     build_unary_op (ass, Pop, reg(RAX), a, point);
-    build_binary_op (ass, Cmp, reg(RAX), reg(RBX), a, point);
+    build_binary_op (ass, Cmp, reg(RAX), reg(R9), a, point);
     build_unary_op (ass, op, reg(RAX), a, point);
     build_unary_op (ass, Push, reg(RAX), a, point);
     build_unary_op (ass, Push, reg(RCX), a, point);
@@ -113,29 +113,29 @@ void build_store_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // Note: as there is only two args, we can guarantee that RSP = pointer to SRC
     // also note that size = RBP + 0x10
     // Store the return address in RBP + 8
-    build_unary_op(ass, Pop, reg(RBX), a, point);
-    build_binary_op(ass, Mov, rref(RBP, 8), reg(RBX), a, point);
+    build_unary_op(ass, Pop, reg(R9), a, point);
+    build_binary_op(ass, Mov, rref(RBP, 8), reg(R9), a, point);
 
     // Store Dest address (located @ RBP - 8)
     build_binary_op(ass, Mov, reg(RDI), rref(RBP, -8), a, point);
 
     // SRC address = RSP 
 
-    // Store size in RBX
-    build_binary_op(ass, Mov, reg(RBX), rref(RBP, 4*ADDRESS_SIZE), a, point); 
+    // Store size in R9
+    build_binary_op(ass, Mov, reg(R9), rref(RBP, 4*ADDRESS_SIZE), a, point); 
 
 #if ABI == SYSTEM_V_64
     // memcpy (dest = rdi, src = rsi, size = rdx)
     // copy size into RDX
     //build_binary_op(ass, Add, reg(RDI), reg(RAX), a, point);
     build_binary_op(ass, Mov, reg(RSI), reg(RSP), a, point);
-    build_binary_op(ass, Mov, reg(RDX), reg(RBX), a, point);
+    build_binary_op(ass, Mov, reg(RDX), reg(R9), a, point);
 
 #elif ABI == WIN_64
     // memcpy (dest = rcx, src = rdx, size = r8)
     build_binary_op(ass, Mov, reg(RCX), reg(RDI), a, point);
     build_binary_op(ass, Mov, reg(RDX), reg(RSP), a, point);
-    build_binary_op(ass, Mov, reg(R8), reg(RBX), a, point);
+    build_binary_op(ass, Mov, reg(R8), reg(R9), a, point);
 
     build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
 #else
@@ -150,8 +150,8 @@ void build_store_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
 #endif
 
-    // Store return address in RBX
-    build_binary_op(ass, Mov, reg(RBX), rref(RBP, 8), a, point);
+    // Store return address in R9
+    build_binary_op(ass, Mov, reg(R9), rref(RBP, 8), a, point);
 
     // set RSP = current RBP + 5*ADDRESS
     build_binary_op(ass, Mov, reg(RSP), reg(RBP), a, point);
@@ -161,7 +161,7 @@ void build_store_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_binary_op(ass, Mov, reg(RBP), rref(RBP, 0), a, point);
 
     // push return address
-    build_unary_op(ass, Push, reg(RBX), a, point);
+    build_unary_op(ass, Push, reg(R9), a, point);
 
     build_nullary_op(ass, Ret, a, point);
 }
@@ -215,8 +215,8 @@ void build_load_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // 4. Set RBP = [RBP]
     // 5. Push return address
 
-    // Store size in RBX
-    build_binary_op(ass, Mov, reg(RBX), rref(RBP, 3*ADDRESS_SIZE), a, point); 
+    // Store size in R9
+    build_binary_op(ass, Mov, reg(R9), rref(RBP, 3*ADDRESS_SIZE), a, point); 
 
     // Stash return address in RAX
     build_unary_op(ass, Pop, reg(RAX), a, point); 
@@ -226,7 +226,7 @@ void build_load_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 
     // Set RSP = RBP + 4 Addresses - Size (note that at this point, RSP = RBP
     build_binary_op(ass, Add, reg(RSP), imm8(4*ADDRESS_SIZE), a, point);
-    build_binary_op(ass, Sub, reg(RSP), reg(RBX), a, point);
+    build_binary_op(ass, Sub, reg(RSP), reg(R9), a, point);
 
     // Set RBP = [RBP]
     build_binary_op(ass, Mov, reg(RBP), rref(RBP, 0), a, point);
@@ -240,7 +240,7 @@ void build_load_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_binary_op(ass, Add, reg(RDI), imm8(ADDRESS_SIZE), a, point);
 
     //build_binary_op(ass, Mov, reg(RSI), reg(RSP), a, point);
-    build_binary_op(ass, Mov, reg(RDX), reg(RBX), a, point);
+    build_binary_op(ass, Mov, reg(RDX), reg(R9), a, point);
 
 #elif ABI == WIN_64
     // memcpy (dest = rcx, src = rdx, size = r8)
@@ -248,7 +248,7 @@ void build_load_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_binary_op(ass, Add, reg(RCX), imm8(ADDRESS_SIZE), a, point);
 
     build_binary_op(ass, Mov, reg(RDX), reg(RSI), a, point);
-    build_binary_op(ass, Mov, reg(R8), reg(RBX), a, point);
+    build_binary_op(ass, Mov, reg(R8), reg(R9), a, point);
     build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
 #else
 #error "Unknown calling convention"
@@ -309,9 +309,9 @@ void build_realloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
 #endif
 
-    build_unary_op(ass, Pop, reg(RBX), a, point);
+    build_unary_op(ass, Pop, reg(R9), a, point);
     build_unary_op(ass, Push, reg(RAX), a, point);
-    build_unary_op(ass, Push, reg(RBX), a, point);
+    build_unary_op(ass, Push, reg(R9), a, point);
 
     build_nullary_op(ass, Ret, a, point);
     
@@ -355,9 +355,9 @@ void build_malloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
 #endif
 
-    build_unary_op(ass, Pop, reg(RBX), a, point);
+    build_unary_op(ass, Pop, reg(R9), a, point);
     build_unary_op(ass, Push, reg(RAX), a, point);
-    build_unary_op(ass, Push, reg(RBX), a, point);
+    build_unary_op(ass, Push, reg(R9), a, point);
 
     build_nullary_op(ass, Ret, a, point);
 }

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -292,15 +292,16 @@ void build_realloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // copy size into RDX
     build_unary_op(ass, Pop, reg(RSI), a, point);
     build_unary_op(ass, Pop, reg(RDI), a, point);
+    build_unary_op(ass, Push, reg(RAX), a, point);
 
 #elif ABI == WIN_64
     // realloc (ptr = RCX, size = RDX)
     build_unary_op(ass, Pop, reg(RDX), a, point);
     build_unary_op(ass, Pop, reg(RCX), a, point);
+    build_unary_op(ass, Push, reg(RAX), a, point);
     build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
 #endif
 
-    build_unary_op(ass, Push, reg(RAX), a, point);
 
     build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&realloc),  a, point);
     build_unary_op(ass, Call, reg(RAX), a, point);
@@ -340,13 +341,13 @@ void build_malloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // memcpy (dest = rdi, src = rsi, size = rdx)
     // copy size into RDX
     build_unary_op(ass, Pop, reg(RDI), a, point);
+    build_unary_op(ass, Push, reg(RAX), a, point);
 
 #elif ABI == WIN_64
     build_unary_op(ass, Pop, reg(RCX), a, point);
+    build_unary_op(ass, Push, reg(RAX), a, point);
     build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
 #endif
-
-    build_unary_op(ass, Push, reg(RAX), a, point);
 
     build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&malloc),  a, point);
     build_unary_op(ass, Call, reg(RAX), a, point);
@@ -385,15 +386,15 @@ void build_free_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // free (dest = rdi)
     // copy address into RDI
     build_unary_op(ass, Pop, reg(RDI), a, point);
+    build_unary_op(ass, Push, reg(RAX), a, point);
 
 #elif ABI == WIN_64
     // free (addr = rcx)
     // copy address into RCX
     build_unary_op(ass, Pop, reg(RCX), a, point);
+    build_unary_op(ass, Push, reg(RAX), a, point);
     build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
 #endif
-
-    build_unary_op(ass, Push, reg(RAX), a, point);
 
     build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&free),  a, point);
     build_unary_op(ass, Call, reg(RAX), a, point);


### PR DESCRIPTION
In the Win64 and SystemV 64 (for x86_64) calling conventions, `RBX` is considered a callee-saved register, which means that relic code would have to save RBX as part of it's prelude. To avoid this, all usages of `RBX` have been replaced with R9.

In addition, this patch fixes a windows-specific bug when calling the native malloc/realloc/free functions.