### PR TITLE
Minor Bugfix Patch (#3)

### DIFF
--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -637,6 +637,7 @@ void squash_types(Syntax* typed, Allocator* a, ErrorPoint* point) {
         break;
     case SResetTo:
         squash_types(typed->reset_to.point, a, point);
+        squash_types(typed->reset_to.arg, a, point);
         break;
     case SSequence:
         for (size_t i = 0; i < typed->sequence.terms.len; i++) {

--- a/src/pico/parse/parse.c
+++ b/src/pico/parse/parse.c
@@ -124,7 +124,7 @@ ParseResult parse_atom(IStream* is, SourcePos* parse_state, Allocator* a) {
     U32Array arr = mk_u32_array(10, a);
 
     PtrArray terms = mk_ptr_array(2, a);
-    RawTree* rhs;
+    RawTree* rhs = NULL;
 
     while (((result = peek(is, &codepoint)) == StreamSuccess)) {
         if (is_symchar(codepoint)) {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -659,7 +659,9 @@ size_t pi_size_of(PiType type) {
     case TKind: 
         return sizeof(void*);
     case TUVar:
-        return 0;
+        panic(mv_string("pi_size_of received invalid type: UVar."));
+    case TUVarDefaulted:
+        panic(mv_string("pi_size_of received invalid type: UVar with Default."));
     default:
         panic(mv_string("pi_size_of received invalid type."));
     }


### PR DESCRIPTION
Fixes the following bugs:

- Squash_types not squashing a =reset-to= correctly
- Warnings/UB related to the parser (uninitialized RHS)
- =pi_size_of= now correctly reports an error when called with an invalid type (either of the Unification variable sorts)