### PR TITLE
Added a size-of function + dynamic allocation

### DIFF
--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -56,7 +56,7 @@ typedef enum {
 
     // Special
     SIs,
-    SSize,
+    SDynAlloc,
     SModule,
 
     // Types & Type formers

--- a/include/pico/values/stdlib.h
+++ b/include/pico/values/stdlib.h
@@ -1,18 +1,13 @@
 #ifndef __PICO_VALUES_STDLIB_H
 #define __PICO_VALUES_STDLIB_H
 
+#include "platform/jump.h"
 #include "data/stream.h"
+
 #include "pico/values/modular.h"
 
-// We use our own setjmp/longjmp because the Windows implementation crashes the
-// program if it has to jump over a pico stackframe.
-
-typedef void *pi_jmp_buf[17];
-int pi_setjmp(pi_jmp_buf buf);
-void pi_longjmp(pi_jmp_buf buf, int val);
-
 // Set the default value of dynamic variables
-void set_exit_callback(pi_jmp_buf* buf);
+void set_exit_callback(jump_buf* buf);
 void set_current_module(Module* current);
 void set_current_package(Package* current);
 void set_std_istream(IStream* current);

--- a/include/pico/values/values.h
+++ b/include/pico/values/values.h
@@ -63,7 +63,7 @@ typedef enum TermFormer {
 
     // Special Term formers
     FIs,
-    FSize,
+    FDynAlloc,
     FModule,
 
     // Type formers

--- a/include/platform/error.h
+++ b/include/platform/error.h
@@ -1,15 +1,15 @@
 #ifndef __PLATFORM_ERROR_H
 #define __PLATFORM_ERROR_H
 
-#include <setjmp.h>
+#include "platform/jump.h"
 #include "data/string.h"
 
 typedef struct {
     volatile String error_message; 
-    jmp_buf buf; 
+    jump_buf buf; 
 } ErrorPoint;
 
-#define catch_error(error) setjmp(error.buf)
+#define catch_error(error) set_jump(error.buf)
 
 _Noreturn void throw_error(ErrorPoint* point, String err); 
 

--- a/include/platform/jump.h
+++ b/include/platform/jump.h
@@ -1,0 +1,11 @@
+#ifndef __PLATFORM_JUMP_H
+#define __PLATFORM_JUMP_H
+
+// We use our own setjmp/longjmp because the Windows implementation crashes the
+// program if it has to jump over a pico stackframe.
+
+typedef void *jump_buf[17];
+int set_jump(jump_buf buf);
+_Noreturn void long_jump(jump_buf buf, int val);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -3,6 +3,7 @@
 #include "platform/memory/std_allocator.h"
 #include "platform/memory/executable.h"
 #include "platform/memory/arena.h"
+#include "platform/jump.h"
 
 #include "data/string.h"
 #include "data/stream.h"
@@ -37,8 +38,8 @@ bool repl_iter(IStream* cin, OStream* cout, Allocator* a, Assembler* ass, Module
     clear_assembler(ass);
     Environment* env = env_from_module(module, &arena);
 
-    pi_jmp_buf exit_point;
-    if (pi_setjmp(exit_point)) goto on_exit;
+    jump_buf exit_point;
+    if (set_jump(exit_point)) goto on_exit;
     set_exit_callback(&exit_point);
 
     ErrorPoint point;

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -781,6 +781,19 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         };
         break;
     }
+    case FDynAlloc: {
+        if (raw.nodes.len != 2) {
+            throw_error(point, mv_string("Term former 'dynamic-alloc' expects precisely 1 arguments!"));
+        }
+
+        Syntax* term = abstract_expr_i(*(RawTree*)raw.nodes.data[1], env, a, point);
+        
+        *res = (Syntax) {
+            .type = SDynAlloc,
+            .size = term,
+        };
+        break;
+    }
     case FProcType: {
         if (raw.nodes.len != 3) {
             throw_error(point, mv_string("Wrong number of terms to proc type former."));

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -585,6 +585,16 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
                      env, gen, a, point);
         untyped->ptype = untyped->is.type->type_val; 
         break;
+    case SDynAlloc: {
+        PiType* t = mem_alloc(sizeof(PiType), a);
+        *t = (PiType){.sort = TPrim, .prim = UInt_64};
+        type_check_i(untyped->is.val, t, env, gen, a, point);
+
+        PiType* out = mem_alloc(sizeof(PiType), a);
+        *out = (PiType){.sort = TPrim, .prim = Address};
+        untyped->ptype = out; 
+        break;
+    }
     case SProcType:
     case SStructType:
     case SEnumType:
@@ -730,6 +740,9 @@ void squash_types(Syntax* typed, Allocator* a, ErrorPoint* point) {
     case SIs:
         squash_type(typed->is.type->type_val);
         squash_types(typed->is.val, a, point);
+        break;
+    case SDynAlloc:
+        squash_types(typed->size, a, point);
         break;
     case SCheckedType:
         squash_type(typed->type_val);

--- a/src/pico/analysis/unify.c
+++ b/src/pico/analysis/unify.c
@@ -102,6 +102,14 @@ Result unify_eq(PiType* lhs, PiType* rhs, Allocator* a) {
         return unify(lhs->reset.out, rhs->reset.out, a);
     } else if (lhs->sort == TDynamic && rhs->sort == TDynamic) {
         return unify(lhs->dynamic, rhs->dynamic, a);
+    } else if (lhs->sort == TKind && rhs->sort == TKind) {
+        if (lhs->kind.nargs == rhs->kind.nargs)
+            return (Result) {.type = Ok};
+        else 
+            return (Result) {
+                .type = Err,
+                .error_message = mk_string("Cannot Unify two kinds of unequal nags", a),
+            };
     } else if (lhs->sort == rhs->sort) {
         return (Result) {
             .type = Err,

--- a/src/pico/syntax/syntax.c
+++ b/src/pico/syntax/syntax.c
@@ -314,19 +314,19 @@ Document* pretty_syntax(Syntax* syntax, Allocator* a) {
 
     case SIs: {
         PtrArray nodes = mk_ptr_array(4, a);
-        push_ptr(mk_str_doc(mv_string("(is"), a), &nodes);
+        push_ptr(mk_str_doc(mv_string("(is "), a), &nodes);
         push_ptr(pretty_syntax(syntax->is.val, a), &nodes);
         push_ptr(pretty_syntax(syntax->is.type, a), &nodes);
         push_ptr(mv_str_doc(mk_string(")", a), a), &nodes);
-        out = mv_sep_doc(nodes, a);
+        out = mv_cat_doc(nodes, a);
         break;
     }
-    case SSize: {
+    case SDynAlloc: {
         PtrArray nodes = mk_ptr_array(4, a);
-        push_ptr(mk_str_doc(mv_string("(size"), a), &nodes);
+        push_ptr(mk_str_doc(mv_string("(dyn-alloc "), a), &nodes);
         push_ptr(pretty_syntax(syntax->size, a), &nodes);
         push_ptr(mv_str_doc(mk_string(")", a), a), &nodes);
-        out = mv_sep_doc(nodes, a);
+        out = mv_cat_doc(nodes, a);
         break;
     }
     case SModule: {

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -3,8 +3,9 @@
 #include <stdio.h>
 
 #include "platform/machine_info.h"
-#include "platform/signals.h"
 #include "platform/memory/std_allocator.h"
+#include "platform/signals.h"
+#include "platform/jump.h"
 
 #include "pico/values/stdlib.h"
 #include "app/module_load.h"
@@ -13,125 +14,8 @@
 // Implementatino of C API 
 //------------------------------------------------------------------------------
 
-
-// We use the naked attribute to instruct gcc to avoid geneating a prolog/epilog
-// We store all registers (even ones that are caller saved) to avoid generating
-// different code for different ABIs,
-
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-__attribute__((naked))
-int pi_setjmp(pi_jmp_buf buf) {
-#if ABI == SYSTEM_V_64
-    __asm(
-          // Store the return RIP address (Currently @ top of stack) first
-          // element of BUF, which is located in RCX (as per SYSTEM_V_64)
-          "mov (%rsp), %rax\n"
-          "mov %rax,  0(%rdi)\n"
-
-          // Now, store the return stack pointer in the second element of buf
-          "lea 8(%rsp), %rax\n"
-          "mov %rax,  8(%rdi)\n"
-
-          // For the other registers, we can directly write each into their
-          // respective indices in the buffer
-          "mov %rbp, 16(%rdi)\n"
-          "mov %rbx, 24(%rdi)\n"
-          /* "mov %rdi, 32(%rdi)\n" */
-          /* "mov %rsi, 40(%rdi)\n" */
-          "mov %r12, 48(%rdi)\n"
-          "mov %r13, 56(%rdi)\n"
-          "mov %r14, 64(%rdi)\n"
-          "mov %r15, 72(%rdi)\n"
-
-          // Set the return value to 0
-          // Note: we use eax as int is 32-bit!
-          "xor %eax, %eax\n"
-          "ret\n"
-          );
-#elif ABI == WIN_64
-    __asm(
-          // Store the return RIP address (Currently @ top of stack) first
-          // element of BUF, which is located in RCX (as per SYSTEM_V_64)
-          "mov (%rsp), %rax\n"
-          "mov %rax,  0(%rcx)\n"
-
-          // Now, store the return stack pointer in the second element of buf
-          "lea 8(%rsp), %rax\n"
-          "mov %rax,  8(%rcx)\n"
-
-          // For the other registers, we can directly write each into their
-          // respective indices in the buffer
-          "mov %rbp, 16(%rcx)\n"
-          "mov %rbx, 24(%rcx)\n"
-          "mov %rdi, 32(%rcx)\n"
-          "mov %rsi, 40(%rcx)\n"
-          "mov %r12, 48(%rcx)\n"
-          "mov %r13, 56(%rcx)\n"
-          "mov %r14, 64(%rcx)\n"
-          "mov %r15, 72(%rcx)\n"
-
-          // Set the return value to 0
-          // Note: we use eax as int is 32-bit!
-          "xor %eax, %eax\n"
-          "ret\n"
-          );
-#else
-#error "Unknown calling convention"
-#endif
-}
-
-__attribute__((naked,noreturn))
-void pi_longjmp(pi_jmp_buf buf, int val) {
-    // avoid unused parameter warnings
-#if ABI == SYSTEM_V_64
-    __asm(
-          // Restore the registers in inverse order of how they were pushed
-          // This is completely arbitrary and therefore for aesthetic reasons only!
-          "mov 72(%rdi), %r15\n"
-          "mov 64(%rdi), %r14\n"
-          "mov 56(%rdi), %r13\n"
-          "mov 48(%rdi), %r12\n"
-          /* "mov 40(%rdi), %rsi\n" */
-          /* "mov 32(%rdi), %rdi\n" */
-          "mov 24(%rdi), %rbx\n"
-          "mov 16(%rdi), %rbp\n"
-          "mov  8(%rdi), %rsp\n"
-
-          // longjmp will 'return' (in eax) it's second argument (passed in esi)
-          "mov %esi, %eax\n"
-
-          // jmp to the cached RIP, making it look as if setjmp just returned!
-          "jmp *0(%rdi)\n"
-    );
-#elif ABI == WIN_64
-    __asm(
-          // Restore the registers in inverse order of how they were pushed
-          // This is completely arbitrary and therefore for aesthetic reasons only!
-          "mov 72(%rcx), %r15\n"
-          "mov 64(%rcx), %r14\n"
-          "mov 56(%rcx), %r13\n"
-          "mov 48(%rcx), %r12\n"
-          "mov 40(%rcx), %rsi\n"
-          "mov 32(%rcx), %rdi\n"
-          "mov 24(%rcx), %rbx\n"
-          "mov 16(%rcx), %rbp\n"
-          "mov  8(%rcx), %rsp\n"
-
-          // longjmp will 'return' (in eax) it's second argument (passed in edx)
-          "mov %edx, %eax\n"
-
-          // jmp to the cached RIP, making it look as if setjmp just returned!
-          "jmp *0(%rcx)\n"
-    );
-#else
-#error "Unknown calling convention"
-#endif
-}
-#pragma GCC diagnostic pop
-
-static pi_jmp_buf* m_buf;
-void set_exit_callback(pi_jmp_buf* buf) { m_buf = buf; }
+static jump_buf* m_buf;
+void set_exit_callback(jump_buf* buf) { m_buf = buf; }
 
 static Module* current_module;
 void set_current_module(Module* current) { current_module = current; }
@@ -387,7 +271,7 @@ void build_run_script_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
 }
 
 void exit_callback() {
-    pi_longjmp(*m_buf, 1);
+    long_jump(*m_buf, 1);
 }
 
 void build_exit_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {

--- a/src/pico/values/values.c
+++ b/src/pico/values/values.c
@@ -275,8 +275,8 @@ Document* pretty_former(TermFormer op, Allocator* a) {
     case FIs:
         out = mk_str_doc(mv_string("::is"), a);
         break;
-    case FSize:
-        out = mk_str_doc(mv_string("::size"), a);
+    case FDynAlloc:
+        out = mk_str_doc(mv_string("::dynamic-allocate"), a);
         break;
     case FModule:
         out = mk_str_doc(mv_string("::module"), a);

--- a/src/platform/error.c
+++ b/src/platform/error.c
@@ -2,5 +2,5 @@
 
 void throw_error(ErrorPoint* point, String err) {
     point->error_message = err;
-    longjmp(point->buf, 1);
+    long_jump(point->buf, 1);
 }

--- a/src/platform/jump.c
+++ b/src/platform/jump.c
@@ -1,0 +1,118 @@
+#include "platform/jump.h"
+
+// We use the naked attribute to instruct gcc to avoid geneating a prolog/epilog
+// We store all registers (even ones that are caller saved) to avoid generating
+// different code for different ABIs,
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+__attribute__((naked))
+int set_jump(jump_buf buf) {
+#if ABI == SYSTEM_V_64
+    __asm(
+          // Store the return RIP address (Currently @ top of stack) first
+          // element of BUF, which is located in RCX (as per SYSTEM_V_64)
+          "mov (%rsp), %rax\n"
+          "mov %rax,  0(%rdi)\n"
+
+          // Now, store the return stack pointer in the second element of buf
+          "lea 8(%rsp), %rax\n"
+          "mov %rax,  8(%rdi)\n"
+
+          // For the other registers, we can directly write each into their
+          // respective indices in the buffer
+          "mov %rbp, 16(%rdi)\n"
+          "mov %rbx, 24(%rdi)\n"
+          /* "mov %rdi, 32(%rdi)\n" */
+          /* "mov %rsi, 40(%rdi)\n" */
+          "mov %r12, 48(%rdi)\n"
+          "mov %r13, 56(%rdi)\n"
+          "mov %r14, 64(%rdi)\n"
+          "mov %r15, 72(%rdi)\n"
+
+          // Set the return value to 0
+          // Note: we use eax as int is 32-bit!
+          "xor %eax, %eax\n"
+          "ret\n"
+          );
+#elif ABI == WIN_64
+    __asm(
+          // Store the return RIP address (Currently @ top of stack) first
+          // element of BUF, which is located in RCX (as per SYSTEM_V_64)
+          "mov (%rsp), %rax\n"
+          "mov %rax,  0(%rcx)\n"
+
+          // Now, store the return stack pointer in the second element of buf
+          "lea 8(%rsp), %rax\n"
+          "mov %rax,  8(%rcx)\n"
+
+          // For the other registers, we can directly write each into their
+          // respective indices in the buffer
+          "mov %rbp, 16(%rcx)\n"
+          "mov %rbx, 24(%rcx)\n"
+          "mov %rdi, 32(%rcx)\n"
+          "mov %rsi, 40(%rcx)\n"
+          "mov %r12, 48(%rcx)\n"
+          "mov %r13, 56(%rcx)\n"
+          "mov %r14, 64(%rcx)\n"
+          "mov %r15, 72(%rcx)\n"
+
+          // Set the return value to 0
+          // Note: we use eax as int is 32-bit!
+          "xor %eax, %eax\n"
+          "ret\n"
+          );
+#else
+#error "Unknown calling convention"
+#endif
+}
+
+__attribute__((naked,noreturn))
+void long_jump(jump_buf buf, int val) {
+    // avoid unused parameter warnings
+#if ABI == SYSTEM_V_64
+    __asm(
+          // Restore the registers in inverse order of how they were pushed
+          // This is completely arbitrary and therefore for aesthetic reasons only!
+          "mov 72(%rdi), %r15\n"
+          "mov 64(%rdi), %r14\n"
+          "mov 56(%rdi), %r13\n"
+          "mov 48(%rdi), %r12\n"
+          /* "mov 40(%rdi), %rsi\n" */
+          /* "mov 32(%rdi), %rdi\n" */
+          "mov 24(%rdi), %rbx\n"
+          "mov 16(%rdi), %rbp\n"
+          "mov  8(%rdi), %rsp\n"
+
+          // longjmp will 'return' (in eax) it's second argument (passed in esi)
+          "mov %esi, %eax\n"
+
+          // jmp to the cached RIP, making it look as if setjmp just returned!
+          "jmp *0(%rdi)\n"
+    );
+#elif ABI == WIN_64
+    __asm(
+          // Restore the registers in inverse order of how they were pushed
+          // This is completely arbitrary and therefore for aesthetic reasons only!
+          "mov 72(%rcx), %r15\n"
+          "mov 64(%rcx), %r14\n"
+          "mov 56(%rcx), %r13\n"
+          "mov 48(%rcx), %r12\n"
+          "mov 40(%rcx), %rsi\n"
+          "mov 32(%rcx), %rdi\n"
+          "mov 24(%rcx), %rbx\n"
+          "mov 16(%rcx), %rbp\n"
+          "mov  8(%rcx), %rsp\n"
+
+          // longjmp will 'return' (in eax) it's second argument (passed in edx)
+          "mov %edx, %eax\n"
+
+          // jmp to the cached RIP, making it look as if setjmp just returned!
+          "jmp *0(%rcx)\n"
+    );
+#else
+#error "Unknown calling convention"
+#endif
+}
+#pragma GCC diagnostic pop
+


### PR DESCRIPTION
This PR adds a `dyn-alloc` special form to Pico, which allocates memory that lasts only as long as the current function frame. 

To assist with using this for mutable local variables, a size-of function has also been added.

Other minor fixes/changes:
- pretty-printing of is
- arena allocator - allocating the size of a block would cause UB
- moved setjmp & longjmp to their own files.