### PR TITLE
Fixed preprocessor bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ INC_FLAGS := $(addprefix -I ,$(INC_DIRS))
 
 # The -MMD and -MP flags together generate Makefiles for us!
 # These files will have .d instead of .o as the output.
-CFLAGS := $(CFLAGS) $(INC_FLAGS) -MMD -MP -Wall -Wextra -g -std=$(C_VERSION) -D_GNU_SOURCE
+CFLAGS := $(CFLAGS) $(INC_FLAGS) -MMD -MP -Wall -Wextra -Wundef -g -std=$(C_VERSION) -D_GNU_SOURCE
 
 # The final build step.
 $(RELEASE_DIR)/$(TARGET_EXEC): $(RELEASE_OBJS) $(MAIN_RELEASE_OBJ)

--- a/src/platform/jump.c
+++ b/src/platform/jump.c
@@ -1,4 +1,5 @@
 #include "platform/jump.h"
+#include "platform/machine_info.h"
 
 // We use the naked attribute to instruct gcc to avoid geneating a prolog/epilog
 // We store all registers (even ones that are caller saved) to avoid generating


### PR DESCRIPTION
This fixed an issue caused by a missing include causing the wrong code to be conditionally compiled.

To ensure this doesn't happen again, a Warning has been enabled for undefined macros. 