### PR TITLE
Procedure related bugfixes

### DIFF
--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -290,7 +290,7 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
 
             raw_term->nodes.len = raw.nodes.len - 2;
             raw_term->nodes.size = raw.nodes.size - 2;
-            raw_term->nodes.data = raw.nodes.data + 2;
+            raw_term->nodes.data = ((void**)raw.nodes.data) + 2;
             raw_term->type = RawList;
         }
         Syntax* body = abstract_expr_i(*raw_term, env, a, point);
@@ -1026,7 +1026,7 @@ TopLevel mk_toplevel(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* 
 
             raw_term->nodes.len = raw.nodes.len - 2;
             raw_term->nodes.size = raw.nodes.size - 2;
-            raw_term->nodes.data = raw.nodes.data + 2;
+            raw_term->nodes.data = ((void**)raw.nodes.data) + 2;
             raw_term->type = RawList;
         }
 

--- a/src/pico/binding/address_env.c
+++ b/src/pico/binding/address_env.c
@@ -171,8 +171,8 @@ void address_start_proc(SymSizeAssoc vars, AddressEnv* env, Allocator* a) {
     SAddr padding;
     padding.type = SASentinel;
     padding.symbol = 0;
-    stack_offset += ADDRESS_SIZE; // We add the register size to account for the
-                                  // return address.
+    stack_offset += 2 * ADDRESS_SIZE; // We add 2x the register size to account for the
+                                      // return address and dynamic memory pointer.
     padding.stack_offset = stack_offset;
     push_saddr(padding, &new_local->vars);
 


### PR DESCRIPTION
This PR fixes two issues related to procedure code-generation:

- First is that the address environment had the wrong initial offset, causing it to get variables from the wrong location on stack
- Second is that procedures would return incorrectly if the argument was > 64 bits.