### PR TITLE
fixes for windows, tests & family appliction

### DIFF
--- a/test/src/test.c
+++ b/test/src/test.c
@@ -63,7 +63,7 @@ int main(int argc, char** argv) {
 
     Assembler* ass = mk_assembler(&exalloc);
     Assembler* ass_base = mk_assembler(&exalloc);
-    Package* base = base_package(ass_base, stdalloc);
+    Package* base = base_package(ass_base, stdalloc, stdalloc);
     delete_assembler(ass_base);
 
     Module* module = get_module(string_to_symbol(mv_string("user")), base);


### PR DESCRIPTION
This PR contains fixes for 4 bugs:

- A compile-time error on windows where there was an extra comma in windows-specific code.
- A compile-time error where the test base module was being instantiated with the wrong number of arguments 

- A runtime error on windows where the forall and family types were being constructed incorrectly
- A runtime error where the arguments to a type family instantiation were being provided in reverse.