### PR TITLE
Added Distinct and Opaque Types

### DIFF
--- a/include/pico/codegen/internal.h
+++ b/include/pico/codegen/internal.h
@@ -11,9 +11,7 @@
 
 #include "pico/codegen/codegen.h"
 
-/* Utility functions shared across code generation  
- * 
- */
+/* Utility functions shared across code generation */
 
 typedef struct {
     size_t offset;
@@ -53,6 +51,7 @@ void gen_mk_type_var(Symbol var, Assembler* ass, Allocator* a, ErrorPoint* point
 void gen_mk_forall_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint* point);
 void gen_mk_fam_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint* point);
 void gen_mk_distinct_ty(Assembler* ass, Allocator* a, ErrorPoint* point);
+void gen_mk_opaque_ty(Assembler* ass, Allocator* a, ErrorPoint* point);
 
 
 #endif

--- a/include/pico/codegen/internal.h
+++ b/include/pico/codegen/internal.h
@@ -52,6 +52,7 @@ void gen_mk_dynamic_ty(Assembler* ass, Allocator* a, ErrorPoint* point);
 void gen_mk_type_var(Symbol var, Assembler* ass, Allocator* a, ErrorPoint* point);
 void gen_mk_forall_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint* point);
 void gen_mk_fam_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint* point);
+void gen_mk_distinct_ty(Assembler* ass, Allocator* a, ErrorPoint* point);
 
 
 #endif

--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -56,6 +56,8 @@ typedef enum {
 
     // Special
     SIs,
+    SInTo,
+    SOutOf,
     SDynAlloc,
     SModule,
 
@@ -65,6 +67,7 @@ typedef enum {
     SEnumType,
     SResetType,
     SDynamicType,
+    SDistinctType,
     SAllType,
     SExistsType,
     STypeFamily,
@@ -275,6 +278,8 @@ struct Syntax {
         SynSequence sequence;
 
         SynIs is;
+        SynIs into;
+        SynIs out_of;
         Syntax* size;
 
         SynProcType proc_type;
@@ -283,15 +288,13 @@ struct Syntax {
         SynResetType reset_type;
         Syntax* dynamic_type;
         SynBind bind_type;
+        Syntax* distinct_type;
         PiType* type_val;
     };
     PiType* ptype;
 };
 
 
-/* The Syntax Destructor */
-void delete_syntax(Syntax syntax, Allocator* a);
-void delete_syntax_pointer(Syntax* syntax, Allocator* a);
 
 
 /* Other instances */
@@ -318,9 +321,6 @@ typedef struct {
         Syntax* expr;
     };
 } TopLevel;
-
-void delete_def(Definition def, Allocator* a);
-void delete_toplevel(TopLevel top, Allocator* a);
 
 Document* pretty_def(Definition* def, Allocator* a);
 Document* pretty_toplevel(TopLevel* TopLevel, Allocator* a);

--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -68,6 +68,7 @@ typedef enum {
     SResetType,
     SDynamicType,
     SDistinctType,
+    SOpaqueType,
     SAllType,
     SExistsType,
     STypeFamily,
@@ -289,6 +290,7 @@ struct Syntax {
         Syntax* dynamic_type;
         SynBind bind_type;
         Syntax* distinct_type;
+        Syntax* opaque_type;
         PiType* type_val;
     };
     PiType* ptype;

--- a/include/pico/values/stdlib.h
+++ b/include/pico/values/stdlib.h
@@ -10,15 +10,16 @@
 void set_exit_callback(jump_buf* buf);
 
 // Set the default value of dynamic variables
-void set_current_module(Module* current);
+
+Module* get_std_current_module();
+Module* set_std_current_module(Module* al);
+
 void set_current_package(Package* current);
 void set_std_istream(IStream* current);
 void set_std_ostream(OStream* current);
 
-
 Allocator* get_std_tmp_allocator();
-void bind_std_tmp_allocator(Allocator* al);
-void release_std_tmp_allocator(Allocator* al);
+Allocator* set_std_tmp_allocator(Allocator* al);
 
 Allocator* get_std_allocator();
 

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -95,6 +95,7 @@ typedef struct {
     PiType* type;
     uint64_t id;
     void* source_module;
+    PtrArray* args;
 } DistinctType;
 
 typedef struct {

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -37,6 +37,9 @@ typedef enum {
     TResumeMark,
     TDynamic,
 
+    // Distinct is kinda special?
+    TDistinct,
+
     // Quantified Types
     TVar,
     TAll,
@@ -45,6 +48,7 @@ typedef enum {
     // Used by Sytem-Fω (type constructors)
     TCApp,
     TFam,
+
 
     // Kinds (higher kinds not supported)
     TKind,
@@ -88,6 +92,19 @@ typedef struct {
 } TypeBinder;
 
 typedef struct {
+    PiType* type;
+    uint64_t id;
+    void* source_module;
+} DistinctType;
+
+typedef struct {
+    PiType* body;
+    uint64_t id;
+    PtrArray* args;
+    void* source_module;
+} DistinctTypeApp;
+
+typedef struct {
     size_t nargs;
 } PiKind;
 
@@ -106,6 +123,9 @@ struct PiType {
         uint64_t var;
         TAppType app;
         TypeBinder binder;
+
+        DistinctType distinct;
+        DistinctTypeApp distinct_app;
 
         PiKind kind;
 
@@ -138,6 +158,7 @@ void delete_gen(UVarGenerator* gen, Allocator* a);
 
 // Misc. and utility
 // Utilities for generating or manipulating types
+uint64_t distinct_id();
 
 PiType* type_app (PiType family, PtrArray args, Allocator* a);
 
@@ -149,5 +170,6 @@ PiType mk_struct_type(Allocator* a, size_t nfields, ...);
 // Types from the standard library
 // Struct [.len U64] [.capacity U64] [.bytes Address]
 PiType mk_string_type(Allocator* a);
+
 
 #endif

--- a/include/pico/values/values.h
+++ b/include/pico/values/values.h
@@ -60,11 +60,13 @@ typedef enum TermFormer {
     FWithReset,
     FResetTo,
     FSequence,
+    FModule,
 
     // Special Term formers
     FIs,
+    FInTo,
+    FOutOf,
     FDynAlloc,
-    FModule,
 
     // Type formers
     FProcType,
@@ -72,6 +74,7 @@ typedef enum TermFormer {
     FEnumType,
     FResetType,
     FDynamicType,
+    FDistinctType,
     FAllType,
     FFamily,
 } TermFormer;

--- a/include/pico/values/values.h
+++ b/include/pico/values/values.h
@@ -75,6 +75,7 @@ typedef enum TermFormer {
     FResetType,
     FDynamicType,
     FDistinctType,
+    FOpaqueType,
     FAllType,
     FFamily,
 } TermFormer;

--- a/include/pretty/document.h
+++ b/include/pretty/document.h
@@ -30,6 +30,8 @@ Document* mk_sep_doc(const PtrArray docs, Allocator* a);
 Document* mv_vsep_doc(const PtrArray docs, Allocator* a);
 Document* mk_vsep_doc(const PtrArray docs, Allocator* a);
 
+Document* mk_paren_doc(const char* lhs, const char* rhs, Document* inner, Allocator* a);
+
 /* The Document Destructor */
 void delete_doc(Document* Document, Allocator* a);
 

--- a/src/main.c
+++ b/src/main.c
@@ -166,7 +166,7 @@ int main(int argc, char** argv) {
 
     Module* module = get_module(string_to_symbol(mv_string("user")), base);
 
-    set_current_module(module);
+    set_std_current_module(module);
     set_current_package(base);
     set_std_istream(cin);
     set_std_ostream(cout);

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,4 @@
 ﻿#include "platform/error.h"
-
 #include "platform/memory/std_allocator.h"
 #include "platform/memory/executable.h"
 #include "platform/memory/arena.h"

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -781,6 +781,34 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         };
         break;
     }
+    case FInTo: {
+        if (raw.nodes.len != 3) {
+            throw_error(point, mv_string("Term former 'into' expects precisely 2 arguments!"));
+        }
+
+        Syntax* type = abstract_expr_i(*(RawTree*)raw.nodes.data[1], env, a, point);
+        Syntax* term = abstract_expr_i(*(RawTree*)raw.nodes.data[2], env, a, point);
+        
+        *res = (Syntax) {
+            .type = SInTo,
+            .into = {.val = term, .type = type},
+        };
+        break;
+    }
+    case FOutOf: {
+        if (raw.nodes.len != 3) {
+            throw_error(point, mv_string("Term former 'out-of' expects precisely 2 arguments!"));
+        }
+
+        Syntax* type = abstract_expr_i(*(RawTree*)raw.nodes.data[1], env, a, point);
+        Syntax* term = abstract_expr_i(*(RawTree*)raw.nodes.data[2], env, a, point);
+        
+        *res = (Syntax) {
+            .type = SOutOf,
+            .into = {.val = term, .type = type},
+        };
+        break;
+    }
     case FDynAlloc: {
         if (raw.nodes.len != 2) {
             throw_error(point, mv_string("Term former 'dynamic-alloc' expects precisely 1 arguments!"));
@@ -912,6 +940,18 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         *res = (Syntax) {
             .type = SDynamicType,
             .dynamic_type = dyn_ty,
+        };
+        break;
+    }
+    case FDistinctType: {
+        if (raw.nodes.len != 2) {
+            throw_error(point, mv_string("Malformed distinct expression."));
+        }
+        Syntax* distinct = abstract_expr_i(*(RawTree*)raw.nodes.data[1], env, a, point);
+
+        *res = (Syntax) {
+            .type = SDistinctType,
+            .distinct_type = distinct,
         };
         break;
     }

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -955,6 +955,18 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         };
         break;
     }
+    case FOpaqueType: {
+        if (raw.nodes.len != 2) {
+            throw_error(point, mv_string("Malformed opaque expression."));
+        }
+        Syntax* opaque = abstract_expr_i(*(RawTree*)raw.nodes.data[1], env, a, point);
+
+        *res = (Syntax) {
+            .type = SOpaqueType,
+            .opaque_type = opaque,
+        };
+        break;
+    }
     case FAllType: {
         if (raw.nodes.len < 3) {
             throw_error(point, mk_string("All term former requires at least 2 arguments!", a));

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -129,7 +129,7 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
             }
         } else {
             String* sym = symbol_to_string(untyped->variable);
-            String msg = mv_string("Couldn't find type of variable: ");
+            String msg = string_cat(mv_string("Couldn't find type of variable: "), *sym, a);
             throw_error(point, string_cat(msg, *sym, a));
         }
         break;
@@ -160,8 +160,7 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
         break;
     }
     case SAll: {
-        // give each arg type kind.
-
+        // Give each arg type kind.
         PiType* all_ty = mem_alloc(sizeof(PiType), a);
         untyped->ptype = all_ty;
         all_ty->sort = TAll;
@@ -985,7 +984,8 @@ void eval_type(Syntax* untyped, TypeEnv* env, Allocator* a, ErrorPoint* point) {
             untyped->ptype = e.ptype;
             untyped->type_val = e.value;
         } else {
-            throw_error(point, mv_string("Variable expected to be type, was not!"));
+            String var = *symbol_to_string(untyped->variable);
+            throw_error(point, string_cat(mv_string("Variable expected to be type, was not: "), var, a));
         }
         break;
     }

--- a/src/pico/analysis/unify.c
+++ b/src/pico/analysis/unify.c
@@ -103,10 +103,10 @@ Result unify_eq(PiType* lhs, PiType* rhs, Allocator* a) {
     } else if (lhs->sort == TDynamic && rhs->sort == TDynamic) {
         return unify(lhs->dynamic, rhs->dynamic, a);
     } else if (lhs->sort == TDistinct && rhs->sort == TDistinct) {
-        if (lhs->distinct.id != rhs->distinct.id) {
+        if (lhs->distinct.id != rhs->distinct.id || lhs->distinct.source_module != rhs->distinct.source_module) {
             return (Result) {
                 .type = Err,
-                .error_message = mk_string("Cannot Unify two distinct types of unequal IDs", a),
+                .error_message = mk_string("Cannot Unify two distinct types of unequal IDs or source modules", a),
             };
         }
         return unify(lhs->distinct.type, rhs->distinct.type, a);

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -1164,7 +1164,6 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         generate(*(Syntax*)syn.reset_type.out, env, ass, links, a, point);
         gen_mk_reset_ty(ass, a, point);
         address_stack_shrink(env, ADDRESS_SIZE);
-
         break;
     case SDynamicType:
         generate(*(Syntax*)syn.dynamic_type, env, ass, links, a, point);
@@ -1194,6 +1193,10 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
     case SDistinctType:
         generate(*(Syntax*)syn.distinct_type, env, ass, links, a, point);
         gen_mk_distinct_ty(ass, a, point);
+        break;
+    case SOpaqueType:
+        generate(*(Syntax*)syn.opaque_type, env, ass, links, a, point);
+        gen_mk_opaque_ty(ass, a, point);
         break;
     default: {
         panic(mv_string("Invalid abstract supplied to monomorphic codegen."));

--- a/src/pico/codegen/internal.c
+++ b/src/pico/codegen/internal.c
@@ -430,7 +430,6 @@ void gen_mk_forall_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint
     build_unary_op(ass, Push, reg(RAX), a, point);
 }
 
-
 void* mk_fam_ty(size_t len, Symbol* syms, PiType* body) {
     Allocator* a = get_std_tmp_allocator();
 
@@ -445,7 +444,6 @@ void* mk_fam_ty(size_t len, Symbol* syms, PiType* body) {
     };
     return ty;
 }
-
 
 void gen_mk_fam_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint* point) {
     // Note: this allocation is fine for definitions as types get copied,
@@ -476,3 +474,49 @@ void gen_mk_fam_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint* p
 #endif 
     build_unary_op(ass, Push, reg(RAX), a, point);
 }
+
+void* mk_distinct_ty(PiType* body) {
+    Allocator* a = get_std_tmp_allocator();
+
+    PiType* ty = mem_alloc(sizeof(PiType), a);
+    *ty = (PiType) {
+        .sort = TDistinct,
+        .distinct.type = body,
+        .distinct.id = distinct_id(),
+    };
+    return ty;
+}
+
+void gen_mk_distinct_ty(Assembler* ass, Allocator* a, ErrorPoint* point) {
+#if ABI == SYSTEM_V_64
+    build_unary_op(ass, Pop, reg(RDI), a, point);
+#elif ABI == WIN_64
+    build_unary_op(ass, Pop, reg(RCX), a, point);
+    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+#else 
+    #error "Unknown calling convention"
+#endif
+
+    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&mk_distinct_ty), a, point);
+    build_unary_op(ass, Call, reg(RAX), a, point);
+
+#if ABI == WIN_64
+    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+#endif 
+    build_unary_op(ass, Push, reg(RAX), a, point);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/pico/codegen/internal.c
+++ b/src/pico/codegen/internal.c
@@ -115,7 +115,9 @@ PiType* internal_type_app(PiType* val, PiType** args_rev, size_t num_args) {
     for (size_t i = 0; i < num_args; i++){
         args[i] = args_rev[(num_args - 1) - i];
     }
-    return type_app (*val, (PtrArray){.data = (void**)args, .len = num_args, .size = num_args}, a);
+    PiType fam = *val;
+    PtrArray arr = (PtrArray){.data = (void**)args, .len = num_args, .size = num_args};
+    return type_app (fam, arr, a);
 }
 
 void gen_mk_family_app(size_t nfields, Assembler* ass, Allocator* a, ErrorPoint* point) {
@@ -483,6 +485,8 @@ void* mk_distinct_ty(PiType* body) {
         .sort = TDistinct,
         .distinct.type = body,
         .distinct.id = distinct_id(),
+        .distinct.source_module = NULL,
+        .distinct.args = NULL,
     };
     return ty;
 }

--- a/src/pico/codegen/polymorphic.c
+++ b/src/pico/codegen/polymorphic.c
@@ -143,6 +143,9 @@ void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, LinkDat
 
             generate_poly_stack_move(reg(RSP), reg(R9), reg(RAX), ass, a, point);
             break;
+        case ATypeVar:
+            throw_error(point, mv_string("Codegen not implemented for ATypeVar"));
+            break;
         case AGlobal:
             // Use RAX as a temp
             // Note: casting void* to uint64_t only works for 64-bit systems...
@@ -197,6 +200,34 @@ void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, LinkDat
     case SApplication: {
         // Generate the arguments
         for (size_t i = 0; i < syn.application.args.len; i++) {
+            Syntax* arg = (Syntax*) syn.application.args.data[i];
+            generate_polymorphic_i(*arg, env, ass, links, a, point);
+        }
+
+        // This will push a function pointer onto the stack
+        generate_polymorphic_i(*syn.application.function, env, ass, links, a, point);
+        
+        // Regular Function Call
+        // Pop the function into RCX; call the function
+        build_unary_op(ass, Pop, reg(RCX), a, point);
+        build_unary_op(ass, Call, reg(RCX), a, point);
+        break;
+    }
+    case SAllApplication: {
+        throw_error(point, mv_string("Internal error: cannot generate all application inside polymorphic code"));
+        // Generate the arguments
+        /*
+
+        for (size_t i = 0; i < syn.all_application.types.len; i++) {
+            src_offset += pi_runtime_size_of(*((Syntax*)syn.structure.fields.data[j].val)->ptype); 
+        }
+
+        for (size_t i = 0; i < syn.all_application.types.len; i++) {
+            PiType* type = *((Syntax*)syn.all_application.args.data[i])->ptype;
+            generate_polymorphic_type(*type, env, ass, links, a, point);
+        }
+
+        for (size_t i = 0; i < syn.all_application.args.len; i++) {
             Syntax* arg = (Syntax*) syn.application.args.data[i];
             generate_polymorphic_i(*arg, env, ass, links, a, point);
         }

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -112,8 +112,7 @@ void* pico_run_expr(Assembler* ass, size_t rsize, Allocator* a, ErrorPoint* poin
     void* dvars = get_dynamic_memory();
     void* dynamic_memory_space = mem_alloc(4096, a);
 
-    Allocator* old_tmp_alloc = get_std_tmp_allocator();
-    bind_std_tmp_allocator(a);
+    Allocator* old_tmp_alloc = set_std_tmp_allocator(a);
 
     int64_t out;
     __asm__ __volatile__(
@@ -134,7 +133,7 @@ void* pico_run_expr(Assembler* ass, size_t rsize, Allocator* a, ErrorPoint* poin
         , "r" (dvars)
         , "r"(dynamic_memory_space)) ;
 
-    release_std_tmp_allocator(old_tmp_alloc);
+    set_std_tmp_allocator(old_tmp_alloc);
     mem_free(dynamic_memory_space, a);
     return value;
 }

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -722,6 +722,14 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
     sym = string_to_symbol(mv_string("is"));
     add_def(module, sym, type, &former);
 
+    former = FInTo;
+    sym = string_to_symbol(mv_string("into"));
+    add_def(module, sym, type, &former);
+
+    former = FOutOf;
+    sym = string_to_symbol(mv_string("out-of"));
+    add_def(module, sym, type, &former);
+
     former = FDynAlloc;
     sym = string_to_symbol(mv_string("dyn-alloc"));
     add_def(module, sym, type, &former);
@@ -744,6 +752,10 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
     former = FDynamicType;
     sym = string_to_symbol(mv_string("Dynamic"));
+    add_def(module, sym, type, &former);
+
+    former = FDistinctType;
+    sym = string_to_symbol(mv_string("Distinct"));
     add_def(module, sym, type, &former);
 
     former = FAllType;

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -319,10 +319,10 @@ void build_size_of_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
 #endif 
 
-    build_unary_op(ass, Pop, reg(RBX), a, point);
+    build_unary_op(ass, Pop, reg(RCX), a, point);
     build_binary_op(ass, Add, reg(RSP), imm32(8), a, point);
     build_unary_op(ass, Push, reg(RAX), a, point);
-    build_unary_op(ass, Push, reg(RBX), a, point);
+    build_unary_op(ass, Push, reg(RCX), a, point);
     build_nullary_op(ass, Ret, a, point);
 }
 

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -525,7 +525,11 @@ Document* pretty_type(PiType* type, Allocator* a) {
     }
     case TDistinct:  {
         PtrArray nodes = mk_ptr_array(5, a);
-        push_ptr(mk_str_doc(mv_string("Distinct #" ), a), &nodes);
+        if (type->distinct.source_module) {
+            push_ptr(mk_str_doc(mv_string("Opaque #" ), a), &nodes);
+        } else {
+            push_ptr(mk_str_doc(mv_string("Distinct #" ), a), &nodes);
+        }
         push_ptr(pretty_u64(type->distinct.id, a), &nodes);
         push_ptr(mk_str_doc(mv_string(" " ), a), &nodes);
         push_ptr(pretty_type(type->distinct.type, a), &nodes);

--- a/src/pico/values/values.c
+++ b/src/pico/values/values.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "platform/signals.h"
 #include "platform/memory/std_allocator.h"
 #include "platform/threads.h"
 
@@ -271,15 +272,21 @@ Document* pretty_former(TermFormer op, Allocator* a) {
     case FSequence:
         out = mk_str_doc(mv_string("::sequence"), a);
         break;
+    case FModule:
+        out = mk_str_doc(mv_string("::module"), a);
+        break;
 
     case FIs:
         out = mk_str_doc(mv_string("::is"), a);
         break;
+    case FInTo:
+        out = mk_str_doc(mv_string("::into"), a);
+        break;
+    case FOutOf:
+        out = mk_str_doc(mv_string("::out-of"), a);
+        break;
     case FDynAlloc:
         out = mk_str_doc(mv_string("::dynamic-allocate"), a);
-        break;
-    case FModule:
-        out = mk_str_doc(mv_string("::module"), a);
         break;
 
         // Type formers
@@ -298,11 +305,18 @@ Document* pretty_former(TermFormer op, Allocator* a) {
     case FDynamicType:
         out = mk_str_doc(mv_string("::DynamicType"), a);
         break;
+    case FDistinctType:
+        out = mk_str_doc(mv_string("::DistinctType"), a);
+        break;
     case FAllType:
         out = mk_str_doc(mv_string("::AllType"), a);
         break;
     case FFamily:
         out = mk_str_doc(mv_string("::Family"), a);
+        break;
+
+    default:
+        panic(mv_string("Unrecognized term former to pretty-former"));
         break;
     }
     return out;

--- a/src/pico/values/values.c
+++ b/src/pico/values/values.c
@@ -308,6 +308,9 @@ Document* pretty_former(TermFormer op, Allocator* a) {
     case FDistinctType:
         out = mk_str_doc(mv_string("::DistinctType"), a);
         break;
+    case FOpaqueType:
+        out = mk_str_doc(mv_string("::OpaqueType"), a);
+        break;
     case FAllType:
         out = mk_str_doc(mv_string("::AllType"), a);
         break;

--- a/src/pretty/document.c
+++ b/src/pretty/document.c
@@ -98,6 +98,14 @@ Document* mk_vsep_doc(const PtrArray source, Allocator* a) {
     return doc;
 }
 
+Document* mk_paren_doc(const char* lhs, const char* rhs, Document* inner, Allocator* a) {
+    PtrArray nodes = mk_ptr_array(3, a);
+    push_ptr(mk_str_doc(mv_string(lhs), a), &nodes);
+    push_ptr(inner, &nodes);
+    push_ptr(mk_str_doc(mv_string(lhs),a), &nodes);
+    return mv_cat_doc(nodes, a);
+}
+
 void delete_doc(Document* doc, Allocator* a) {
     switch (doc->doc_type) {
     case StringDocument:

--- a/test/src/test.c
+++ b/test/src/test.c
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
 
     Module* module = get_module(string_to_symbol(mv_string("user")), base);
 
-    set_current_module(module);
+    set_std_current_module(module);
     set_current_package(base);
     set_std_istream(cin);
     set_std_ostream(cout);

--- a/test/src/test.c
+++ b/test/src/test.c
@@ -21,29 +21,14 @@
  */
 
 
-#include "platform/error.h"
-
 #include "platform/memory/std_allocator.h"
 #include "platform/memory/executable.h"
-#include "platform/memory/arena.h"
-#include "platform/jump.h"
 
 #include "data/string.h"
 #include "data/stream.h"
 
 #include "assembler/assembler.h"
-#include "pretty/stream_printer.h"
-#include "pretty/document.h"
-
-#include "pico/syntax/concrete.h"
-#include "pico/parse/parse.h"
-#include "pico/binding/environment.h"
-#include "pico/analysis/abstraction.h"
-#include "pico/analysis/typecheck.h"
-#include "pico/codegen/codegen.h"
-#include "pico/eval/call.h"
 #include "pico/values/stdlib.h"
-#include "pico/values/types.h"
 
 #include "test/command_line_opts.h"
 #include "test_pico/pico.h"


### PR DESCRIPTION
This PR adds two new types:
+ Distinct types, which have a nominal rather than structural equality. Can convert between distinct types and there respective structural types with `into` and `out-of`.
+ Opaque types, which are like distinct types, except that `into` and `out-of` only work if the current module is the same as the module in which they were created.

It also fixes some undefined behavior in the `base` package and when binding dynamic variables