### PR TITLE
More primitives

### DIFF
--- a/include/assembler/assembler.h
+++ b/include/assembler/assembler.h
@@ -36,8 +36,8 @@ typedef enum {
     // ------------------
     //  Bit Manipulation
     // ------------------
-    LShift,
-    RShift,
+    SHL, // Left shift
+    SHR, // Right shift
 
     // ------------------
     //  Memory

--- a/include/assembler/assembler.h
+++ b/include/assembler/assembler.h
@@ -46,6 +46,13 @@ typedef enum {
     LEA,
 
     // ------------------
+    //  Conditional Moves
+    // ------------------
+    CMovE,
+    CMovL,
+    CMovG,
+
+    // ------------------
     //  Meta
     // ------------------
     Binary_Op_Count,
@@ -91,6 +98,7 @@ typedef enum {
 
 typedef enum {
     Ret,
+    Nullary_Op_Count,
 } NullaryOp;
 
 typedef enum {
@@ -181,5 +189,15 @@ AsmResult build_unary_op(Assembler* assembler, UnaryOp op, Location loc, Allocat
 AsmResult build_nullary_op(Assembler* assembler, NullaryOp op, Allocator* err_allocator, ErrorPoint* point);
 
 void asm_init();
+
+// Utility & Pretty
+Document* pretty_register(Regname reg, LocationSize sz, Allocator* a);
+Document* pretty_location(Location loc, Allocator* a);
+Document* pretty_binary_op(BinaryOp op, Allocator* a);
+Document* pretty_unary_op(UnaryOp op, Allocator* a);
+Document* pretty_nullary_op(NullaryOp op, Allocator* a);
+
+Document* pretty_binary_instruction(BinaryOp op, Location dest, Location src, Allocator* a);
+Document* pretty_unary_instruction(UnaryOp op, Location loc, Allocator* a);
 
 #endif

--- a/include/assembler/assembler.h
+++ b/include/assembler/assembler.h
@@ -79,8 +79,10 @@ typedef enum {
     //  Set Byte based on flag 
     // ------------------------
     SetE,
-    SetL,
-    SetG,
+    SetB, // Set below   (unsigned)
+    SetA, // Set above   (unsigned)
+    SetL, // Set lesser  (signed)
+    SetG, // Set greater (signed)
 
     // ------------------
     //  Arithmetic

--- a/include/assembler/assembler.h
+++ b/include/assembler/assembler.h
@@ -116,9 +116,9 @@ typedef enum {
 } Regname;
 
 typedef enum {
-    Register,
-    Deref,
-    Immediate,
+    Dest_Register,
+    Dest_Deref,
+    Dest_Immediate,
 } Dest_t;
 
 typedef enum {
@@ -160,12 +160,12 @@ typedef struct {
 } Location;
 
 // Location Constructors 
-Location reg(Regname name);
-Location rref8(Regname name, int8_t offset);
-Location rref32(Regname name, int32_t offset);
-Location sib(Regname base, Regname index, uint8_t scale);
-Location sib8(Regname base, Regname index, uint8_t scale, int8_t displacement);
-Location sib32(Regname base, Regname index, uint8_t scale, int32_t displacement);
+Location reg(Regname name, LocationSize sz);
+Location rref8(Regname name, int8_t offset, LocationSize sz);
+Location rref32(Regname name, int32_t offset, LocationSize sz);
+Location sib(Regname base, Regname index, uint8_t scale, LocationSize sz);
+Location sib8(Regname base, Regname index, uint8_t scale, int8_t displacement, LocationSize sz);
+Location sib32(Regname base, Regname index, uint8_t scale, int32_t displacement, LocationSize sz);
 Location imm8(int8_t immediate);
 Location imm16(int16_t immediate);
 Location imm32(int32_t immediate);

--- a/include/pico/binding/environment.h
+++ b/include/pico/binding/environment.h
@@ -20,6 +20,7 @@ typedef struct EnvCapture EnvCapture;
 
 typedef struct EnvEntry {
     Result_t success;
+    bool is_module;
     PiType* type;
     void* value;
 } EnvEntry;

--- a/include/pico/binding/type_env.h
+++ b/include/pico/binding/type_env.h
@@ -15,8 +15,12 @@ typedef enum {
 
 typedef struct {
     TypeEntry_t type;
+    bool is_module;
     PiType* ptype;
-    PiType* value;
+    union {
+        PiType* value;
+        Module* module;
+    };
 } TypeEntry;
 
 typedef enum {

--- a/include/pico/values/modular.h
+++ b/include/pico/values/modular.h
@@ -20,6 +20,7 @@ typedef struct Package Package;
 typedef struct Module  Module;
 typedef struct {
     void* value;
+    bool is_module;
     PiType type;
     SymSArrAMap* backlinks;
 } ModuleEntry;
@@ -43,6 +44,7 @@ void delete_module(Module* module);
 
 Result add_def(Module* module, Symbol name, PiType type, void* data); 
 Result add_fn_def(Module* module, Symbol name, PiType type, Assembler* fn, SymSArrAMap* backlinks); 
+Result add_module_def(Module* module, Symbol name, Module* child); 
 
 ModuleEntry* get_def(Symbol sym, Module* module);
 SymbolArray get_exported_symbols(Module* module, Allocator* a);

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -167,6 +167,10 @@ bool pi_type_eql(PiType* lhs, PiType* rhs);
 size_t pi_size_of(PiType type);
 size_t pi_align_of(PiType type);
 
+size_t pi_size_align(size_t size, size_t align);
+size_t pi_stack_round(size_t in);
+size_t pi_stack_size_of(PiType type);
+
 // Resource Management
 void delete_pi_type(PiType t, Allocator* a);
 void delete_pi_type_p(PiType* t, Allocator* a);

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -159,17 +159,13 @@ struct PiType {
 
 // Transform and Analyse
 Document* pretty_pi_value(void* val, PiType* types, Allocator* a);
-
 Document* pretty_type(PiType* type, Allocator* a);
 
 PiType* pi_type_subst(PiType* type, SymPtrAssoc binds, Allocator* a);
-
 bool pi_type_eql(PiType* lhs, PiType* rhs);
 
-size_t pi_size_of(PiType t);
-size_t pi_mono_size_of(PiType t);
-size_t runtime_size_of(PiType* t, void* data);
-
+size_t pi_size_of(PiType type);
+size_t pi_align_of(PiType type);
 
 // Resource Management
 void delete_pi_type(PiType t, Allocator* a);

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -168,7 +168,7 @@ size_t pi_size_of(PiType type);
 size_t pi_align_of(PiType type);
 
 size_t pi_size_align(size_t size, size_t align);
-size_t pi_stack_round(size_t in);
+size_t pi_stack_align(size_t in);
 size_t pi_stack_size_of(PiType type);
 
 // Resource Management

--- a/include/platform/machine_info.h
+++ b/include/platform/machine_info.h
@@ -11,6 +11,7 @@
 // This gives the following sizes
 #define REGISTER_SIZE 8
 #define ADDRESS_SIZE 8
+#define ADDRESS_ALIGN 8
 #define ADDRESSABLE_BITS 1
 
 #if defined(_WIN32) || defined(WIN32) || defined(__CYGWIN__)

--- a/include/platform/machine_info.h
+++ b/include/platform/machine_info.h
@@ -39,7 +39,7 @@
    * Nonvolatile: RBX, RSP, RBP, R12, R13, R14, R16
    * Volatile: RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11
    */
-  #define ABI SYSTEM_V_64
+#define ABI SYSTEM_V_64
 #else 
   #error "Callign convention: only recongized families are Windows and Unix"
 #endif

--- a/src/assembler/assembler.c
+++ b/src/assembler/assembler.c
@@ -324,11 +324,20 @@ void build_binary_table() {
         .valid = true,
         .use_size_override_prefix = false,
         .use_rex_byte = false,
-        .use_size_override_prefix = false,
-        .init_rex_byte = 0b01000000, // REX
         .use_modrm_byte = true,
         .num_immediate_bytes = 0,
         .order = RM,
+        .has_opcode_ext = false,
+    };
+
+    // r32, imm32
+    binary_table[bindex(Dest_Register, sz_32, Dest_Immediate, sz_32)] = (BinaryTableEntry){
+        .valid = true,
+        .use_size_override_prefix = false,
+        .use_rex_byte = false,
+        .use_modrm_byte = true,
+        .num_immediate_bytes = 4,
+        .order = MI,
         .has_opcode_ext = false,
     };
 
@@ -337,10 +346,20 @@ void build_binary_table() {
         .valid = true,
         .use_size_override_prefix = true,
         .use_rex_byte = false,
-        .init_rex_byte = 0b01000000, // REX
         .use_modrm_byte = true,
         .num_immediate_bytes = 0,
         .order = RM,
+        .has_opcode_ext = false,
+    };
+
+    // r16, imm16
+    binary_table[bindex(Dest_Register, sz_16, Dest_Immediate, sz_16)] = (BinaryTableEntry){
+        .valid = true,
+        .use_size_override_prefix = true,
+        .use_rex_byte = false,
+        .use_modrm_byte = true,
+        .num_immediate_bytes = 2,
+        .order = MI,
         .has_opcode_ext = false,
     };
 
@@ -355,6 +374,18 @@ void build_binary_table() {
         .order = RM,
         .has_opcode_ext = false,
     };
+    // r8, imm8
+    binary_table[bindex(Dest_Register, sz_8, Dest_Immediate, sz_8)] = (BinaryTableEntry){
+        .valid = true,
+        .use_size_override_prefix = false,
+        .use_rex_byte = true,
+        .init_rex_byte = 0b01000000, // REX
+        .use_modrm_byte = true,
+        .num_immediate_bytes = 1,
+        .order = MI,
+        .has_opcode_ext = false,
+    };
+
 }
 
 void build_binary_opcode_table() {
@@ -431,6 +462,11 @@ void build_binary_opcode_table() {
     binary_opcode_table[Cmp][bindex(Dest_Register, sz_64, Dest_Register, sz_64)][0] = 0x3B;
     binary_opcode_table[Cmp][bindex(Dest_Register, sz_64, Dest_Deref, sz_64)][0] = 0x3B;
 
+    // r32, r32 | r16, r16 | r8, r8
+    binary_opcode_table[Cmp][bindex(Dest_Register, sz_32, Dest_Register, sz_32)][0] = 0x3B;
+    binary_opcode_table[Cmp][bindex(Dest_Register, sz_16, Dest_Register, sz_16)][0] = 0x3B;
+    binary_opcode_table[Cmp][bindex(Dest_Register, sz_8, Dest_Register, sz_8)][0] = 0x3A;
+
     // ------------------
     //  Logic
     // ------------------
@@ -501,13 +537,41 @@ void build_binary_opcode_table() {
     binary_opcode_table[Mov][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_32)][0] = 0xC7;
     binary_opcode_table[Mov][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_32)][1] = 0x00;
 
-    // r/m64, r64
+    // r/m64, r64 then r64, r/m64
     binary_opcode_table[Mov][bindex(Dest_Register, sz_64, Dest_Register, sz_64)][0] = 0x89;
     binary_opcode_table[Mov][bindex(Dest_Deref, sz_64, Dest_Register, sz_64)][0] = 0x89;
-
-    // r64, r/m64
     binary_opcode_table[Mov][bindex(Dest_Register, sz_64, Dest_Register, sz_64)][0] = 0x8B;
     binary_opcode_table[Mov][bindex(Dest_Register, sz_64, Dest_Deref, sz_64)][0] = 0x8B;
+
+    // r/m32, r32 then r32, r/m32
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_32, Dest_Register, sz_32)][0] = 0x89;
+    binary_opcode_table[Mov][bindex(Dest_Deref, sz_32, Dest_Register, sz_32)][0] = 0x89;
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_32, Dest_Register, sz_32)][0] = 0x8B;
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_32, Dest_Deref, sz_32)][0] = 0x8B;
+    // r/m32, imm32
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_32, Dest_Immediate, sz_32)][0] = 0xC7;
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_32, Dest_Immediate, sz_32)][1] = 0x00;
+    binary_opcode_table[Mov][bindex(Dest_Deref, sz_32, Dest_Immediate, sz_32)][0] = 0xC7;
+    binary_opcode_table[Mov][bindex(Dest_Deref, sz_32, Dest_Immediate, sz_32)][1] = 0x00;
+
+    // r/m16, r16 then  r16, r/m16
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_16, Dest_Register, sz_16)][0] = 0x89;
+    binary_opcode_table[Mov][bindex(Dest_Deref, sz_16, Dest_Register, sz_16)][0] = 0x89;
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_16, Dest_Register, sz_16)][0] = 0x8B;
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_16, Dest_Deref, sz_16)][0] = 0x8B;
+    // r/m16, imm16
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_16, Dest_Immediate, sz_16)][0] = 0xC7;
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_16, Dest_Immediate, sz_16)][1] = 0x00;
+    binary_opcode_table[Mov][bindex(Dest_Deref, sz_16, Dest_Immediate, sz_16)][0] = 0xC7;
+    binary_opcode_table[Mov][bindex(Dest_Deref, sz_16, Dest_Immediate, sz_16)][1] = 0x00;
+
+    // r/m8, r8 thhen r8, r/m8 then r/m8, imm8
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_8, Dest_Register, sz_8)][0] = 0x88;
+    binary_opcode_table[Mov][bindex(Dest_Deref, sz_8, Dest_Register, sz_8)][0] = 0x88;
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_8, Dest_Register, sz_8)][0] = 0x8A;
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_8, Dest_Deref, sz_8)][0] = 0x8A;
+    binary_opcode_table[Mov][bindex(Dest_Register, sz_8, Dest_Immediate, sz_8)][0] = 0xC6;
+    binary_opcode_table[Mov][bindex(Dest_Deref, sz_8, Dest_Immediate, sz_8)][0] = 0xC6;
 
     //Lea,   // p 705.
     // Lea is much more limited in how it works - operand 1 is always a register
@@ -553,8 +617,6 @@ uint8_t rex_sb_ext(uint8_t bit) { return (bit & 0b1) << 1; }
 uint8_t rex_reg_ext(uint8_t bit) { return (bit & 0b1) << 2; }
 
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
 AsmResult build_binary_op(Assembler* assembler, BinaryOp op, Location dest, Location src, Allocator* err_allocator, ErrorPoint* point) {
     BinaryTableEntry be = binary_table[bindex(dest.type, dest.sz, src.type, src.sz)];
     if (!be.valid) {
@@ -761,7 +823,6 @@ AsmResult build_binary_op(Assembler* assembler, BinaryOp op, Location dest, Loca
 
     return out;
 }
-#pragma GCC diagnostic pop
 
 void modrm_reg_rm_rex(uint8_t* modrm_byte, uint8_t* rex_byte, Regname reg) {
     if (reg & 0b1000) set_bit(rex_byte, 0);
@@ -789,6 +850,7 @@ typedef enum UnaryEncOrder {
 
 typedef struct {
     bool valid;
+    bool use_size_prefix;
     bool use_modrm_byte;
     uint8_t num_immediate_bytes;
     UnaryEncOrder order;
@@ -827,12 +889,56 @@ void build_unary_table() {
     // r/m64
     unary_table[uindex(Dest_Register, sz_64)] = (UnaryTableEntry){
         .valid = true,
+        .use_size_prefix = false,
         .use_modrm_byte = true,
         .num_immediate_bytes = 0,
         .order = M,
     };
     unary_table[uindex(Dest_Deref, sz_64)] = (UnaryTableEntry){
         .valid = true,
+        .use_size_prefix = false,
+        .use_modrm_byte = true,
+        .num_immediate_bytes = 0,
+        .order = M,
+    };
+    unary_table[uindex(Dest_Register, sz_32)] = (UnaryTableEntry){
+        .valid = true,
+        .use_size_prefix = false,
+        .use_modrm_byte = true,
+        .num_immediate_bytes = 0,
+        .order = M,
+    };
+    unary_table[uindex(Dest_Deref, sz_32)] = (UnaryTableEntry){
+        .valid = true,
+        .use_size_prefix = false,
+        .use_modrm_byte = true,
+        .num_immediate_bytes = 0,
+        .order = M,
+    };
+    unary_table[uindex(Dest_Register, sz_16)] = (UnaryTableEntry){
+        .valid = true,
+        .use_size_prefix = true,
+        .use_modrm_byte = true,
+        .num_immediate_bytes = 0,
+        .order = M,
+    };
+    unary_table[uindex(Dest_Deref, sz_16)] = (UnaryTableEntry){
+        .valid = true,
+        .use_size_prefix = true,
+        .use_modrm_byte = true,
+        .num_immediate_bytes = 0,
+        .order = M,
+    };
+    unary_table[uindex(Dest_Register, sz_8)] = (UnaryTableEntry){
+        .valid = true,
+        .use_size_prefix = false,
+        .use_modrm_byte = true,
+        .num_immediate_bytes = 0,
+        .order = M,
+    };
+    unary_table[uindex(Dest_Deref, sz_8)] = (UnaryTableEntry){
+        .valid = true,
+        .use_size_prefix = false,
         .use_modrm_byte = true,
         .num_immediate_bytes = 0,
         .order = M,
@@ -840,18 +946,21 @@ void build_unary_table() {
 
     unary_table[uindex(Dest_Immediate, sz_8)] = (UnaryTableEntry){
         .valid = true,
+        .use_size_prefix = false,
         .use_modrm_byte = false,
         .num_immediate_bytes = 1,
         .order = I,
     };
     unary_table[uindex(Dest_Immediate, sz_16)] = (UnaryTableEntry){
         .valid = true,
+        .use_size_prefix = true,
         .use_modrm_byte = false,
         .num_immediate_bytes = 2,
         .order = I,
     };
     unary_table[uindex(Dest_Immediate, sz_32)] = (UnaryTableEntry){
         .valid = true,
+        .use_size_prefix = false,
         .use_modrm_byte = false,
         .num_immediate_bytes = 4,
         .order = I,
@@ -929,6 +1038,10 @@ void build_unary_opcode_table() {
     /* unary_opcode_table[SetE][uindex(Deref, sz_64)] = */
     /*     (UnaryOpEntry) {.opcode = 0xFF, .opcode_modrm = 0x4,}; */
 
+    unary_opcode_table[SetA][uindex(Dest_Register, sz_64)] =
+        (UnaryOpEntry) {.opcode_prefix = 0x0F, .opcode = 0x97,};
+    unary_opcode_table[SetB][uindex(Dest_Register, sz_64)] =
+        (UnaryOpEntry) {.opcode_prefix = 0x0F, .opcode = 0x92,};
     unary_opcode_table[SetL][uindex(Dest_Register, sz_64)] =
         (UnaryOpEntry) {.opcode_prefix = 0x0F, .opcode = 0x9C,};
     unary_opcode_table[SetG][uindex(Dest_Register, sz_64)] =
@@ -942,21 +1055,69 @@ void build_unary_opcode_table() {
         (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x04, .init_rex_byte = 0b01001000, /*REX.W*/};
     unary_opcode_table[Mul][uindex(Dest_Deref, sz_64)] =
         (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x04, .init_rex_byte = 0b01001000, /*REX.W*/};
+    unary_opcode_table[Mul][uindex(Dest_Register, sz_32)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x04,};
+    unary_opcode_table[Mul][uindex(Dest_Deref, sz_32)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x04, };
+    unary_opcode_table[Mul][uindex(Dest_Register, sz_16)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x04,};
+    unary_opcode_table[Mul][uindex(Dest_Deref, sz_16)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x04,};
+    unary_opcode_table[Mul][uindex(Dest_Register, sz_8)] =
+        (UnaryOpEntry) {.opcode = 0xF6, .opcode_modrm = 0x04, .init_rex_byte = 0b01000000, /*REX*/};
+    unary_opcode_table[Mul][uindex(Dest_Deref, sz_8)] =
+        (UnaryOpEntry) {.opcode = 0xF6, .opcode_modrm = 0x04, .init_rex_byte = 0b01000000, /*REX*/};
 
     unary_opcode_table[Div][uindex(Dest_Register, sz_64)] =
         (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x06, .init_rex_byte = 0b01001000, /*REX.W*/};
     unary_opcode_table[Div][uindex(Dest_Deref, sz_64)] =
         (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x06, .init_rex_byte = 0b01001000, /*REX.W*/};
+    unary_opcode_table[Div][uindex(Dest_Register, sz_32)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x06,};
+    unary_opcode_table[Div][uindex(Dest_Deref, sz_32)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x06,};
+    unary_opcode_table[Div][uindex(Dest_Register, sz_16)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x06,};
+    unary_opcode_table[Div][uindex(Dest_Deref, sz_16)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x06,};
+    unary_opcode_table[Div][uindex(Dest_Register, sz_8)] =
+        (UnaryOpEntry) {.opcode = 0xF6, .opcode_modrm = 0x06, .init_rex_byte = 0b01000000, /*REX*/};
+    unary_opcode_table[Div][uindex(Dest_Deref, sz_8)] =
+        (UnaryOpEntry) {.opcode = 0xF6, .opcode_modrm = 0x06, .init_rex_byte = 0b01000000, /*REX*/};
 
     unary_opcode_table[IMul][uindex(Dest_Register, sz_64)] =
         (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x05, .init_rex_byte = 0b01001000, /*REX.W*/};
-    unary_opcode_table[Mul][uindex(Dest_Deref, sz_64)] =
+    unary_opcode_table[IMul][uindex(Dest_Deref, sz_64)] =
         (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x05, .init_rex_byte = 0b01001000, /*REX.W*/};
+    unary_opcode_table[IMul][uindex(Dest_Register, sz_32)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x05,};
+    unary_opcode_table[IMul][uindex(Dest_Deref, sz_32)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x05,};
+    unary_opcode_table[IMul][uindex(Dest_Register, sz_16)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x05,};
+    unary_opcode_table[IMul][uindex(Dest_Deref, sz_16)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x05,};
+    unary_opcode_table[IMul][uindex(Dest_Register, sz_8)] =
+        (UnaryOpEntry) {.opcode = 0xF6, .opcode_modrm = 0x05, .init_rex_byte = 0b01000000, /*REX*/};
+    unary_opcode_table[IMul][uindex(Dest_Deref, sz_8)] =
+        (UnaryOpEntry) {.opcode = 0xF6, .opcode_modrm = 0x05, .init_rex_byte = 0b01000000, /*REX*/};
 
     unary_opcode_table[IDiv][uindex(Dest_Register, sz_64)] =
         (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x07, .init_rex_byte = 0b01001000, /*REX.W*/};
     unary_opcode_table[IDiv][uindex(Dest_Deref, sz_64)] =
         (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x07, .init_rex_byte = 0b01001000, /*REX.W*/};
+    unary_opcode_table[IDiv][uindex(Dest_Register, sz_32)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x07,};
+    unary_opcode_table[IDiv][uindex(Dest_Deref, sz_32)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x07,};
+    unary_opcode_table[IDiv][uindex(Dest_Register, sz_16)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x07,};
+    unary_opcode_table[IDiv][uindex(Dest_Deref, sz_16)] =
+        (UnaryOpEntry) {.opcode = 0xF7, .opcode_modrm = 0x07,};
+    unary_opcode_table[IDiv][uindex(Dest_Register, sz_8)] =
+        (UnaryOpEntry) {.opcode = 0xF6, .opcode_modrm = 0x07, .init_rex_byte = 0b01000000, /*REX*/};
+    unary_opcode_table[IDiv][uindex(Dest_Deref, sz_8)] =
+        (UnaryOpEntry) {.opcode = 0xF6, .opcode_modrm = 0x07, .init_rex_byte = 0b01000000, /*REX*/};
 }
 
 AsmResult build_unary_op(Assembler* assembler, UnaryOp op, Location loc, Allocator* err_allocator, ErrorPoint* point) {
@@ -1102,6 +1263,9 @@ AsmResult build_unary_op(Assembler* assembler, UnaryOp op, Location loc, Allocat
     // Step 5: write bytes
     AsmResult out = {.backlink = 0};
     U8Array* instructions = &assembler->instructions;
+    if (ue.use_size_prefix)
+        push_u8(0x66, instructions);
+
     if (rex_byte)
         push_u8(rex_byte, instructions);
 
@@ -1132,8 +1296,6 @@ AsmResult build_unary_op(Assembler* assembler, UnaryOp op, Location loc, Allocat
     return out;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
 AsmResult build_nullary_op(Assembler* assembler, NullaryOp op, Allocator* err_allocator, ErrorPoint* point) {
     uint8_t opcode;
     switch (op) {
@@ -1146,7 +1308,7 @@ AsmResult build_nullary_op(Assembler* assembler, NullaryOp op, Allocator* err_al
         push_ptr(pretty_nullary_op(op, err_allocator), &nodes);
         push_ptr(mk_str_doc(mv_string("/"), err_allocator), &nodes);
         push_ptr(pretty_i32(op, err_allocator), &nodes);
-        panic(doc_to_str(mv_sep_doc(nodes, err_allocator), err_allocator));
+        throw_error(point, doc_to_str(mv_sep_doc(nodes, err_allocator), err_allocator));
     }
     }
     U8Array* instructions = &assembler->instructions;
@@ -1154,8 +1316,6 @@ AsmResult build_nullary_op(Assembler* assembler, NullaryOp op, Allocator* err_al
     AsmResult out = {.backlink = 0};
     return out;
 }
-#pragma GCC diagnostic pop
-
 
 void asm_init() {
     build_unary_table();
@@ -1230,18 +1390,29 @@ Document* pretty_location(Location loc, Allocator* a) {
     }
 
     case Dest_Immediate: {
+        PtrArray nodes = mk_ptr_array(2, a);
         switch (loc.sz) {
         case sz_8:
-            return pretty_i8(loc.immediate_8, a);
+            push_ptr(pretty_i8(loc.immediate_8, a), &nodes);
+            push_ptr(mk_str_doc(mv_string("i8"), a), &nodes);
+            break;
         case sz_16:
-            return pretty_i64(loc.immediate_16, a);
+            push_ptr(pretty_i64(loc.immediate_16, a), &nodes);
+            push_ptr(mk_str_doc(mv_string("i16"), a), &nodes);
+            break;
         case sz_32:
-            return pretty_i64(loc.immediate_32, a);
+            push_ptr(pretty_i32(loc.immediate_32, a), &nodes);
+            push_ptr(mk_str_doc(mv_string("i32"), a), &nodes);
+            break;
         case sz_64:
-            return pretty_i64(loc.immediate_64, a);
+            push_ptr(pretty_i64(loc.immediate_64, a), &nodes);
+            push_ptr(mk_str_doc(mv_string("i64"), a), &nodes);
+            break;
             // TODO: handle default
+        default:
+            panic(mv_string("Invalid immediate size size to pretty_location."));
         }
-        panic(mv_string("Invalid immediate size size to pretty_location."));
+        return mv_cat_doc(nodes, a);
     }
 
     default:
@@ -1251,7 +1422,8 @@ Document* pretty_location(Location loc, Allocator* a) {
 
 Document* pretty_binary_op(BinaryOp op, Allocator* a) {
     char* names[Binary_Op_Count] = {
-        "Add", "Sub", "Cmp", "And", "Or", "LShift", "RShift", "Mov", "LEA",
+        "Add", "Sub", "Cmp", "And", "Or", "LShift", "RShift",
+        "Mov", "LEA", "CMovE", "CMovL", "CMovG",
     };
     // TODO BUG bounds check here.
     return mk_str_doc(mv_string(names[op]), a);
@@ -1259,7 +1431,9 @@ Document* pretty_binary_op(BinaryOp op, Allocator* a) {
 
 Document* pretty_unary_op(UnaryOp op, Allocator* a) {
     char* names[Unary_Op_Count] = {
-        "Call", "Push", "Pop", "JE", "JNE", "JMP", "SetE", "SetL", "SetG", "Mul", "Div", "IMul", "IDiv",
+        "Call", "Push", "Pop", "JE", "JNE", "JMP",
+        "SetE", "SetB", "SetA", "SetL", "SetG",
+        "Mul", "Div", "IMul", "IDiv",
     };
     // TODO BUG bounds check here.
     return mk_str_doc(mv_string(names[op]), a);

--- a/src/assembler/assembler.c
+++ b/src/assembler/assembler.c
@@ -577,17 +577,17 @@ void build_binary_opcode_table() {
     // ------------------
     // Shift Left
     // r/m64, imm8 
-    binary_opcode_table[LShift][bindex(Dest_Register, sz_64, Dest_Immediate, sz_8)][0] = 0xC1;
-    binary_opcode_table[LShift][bindex(Dest_Register, sz_64, Dest_Immediate, sz_8)][3] = 0x04;
-    binary_opcode_table[LShift][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_8)][0] = 0xC1;
-    binary_opcode_table[LShift][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_8)][3] = 0x04;
+    binary_opcode_table[SHL][bindex(Dest_Register, sz_64, Dest_Immediate, sz_8)][0] = 0xC1;
+    binary_opcode_table[SHL][bindex(Dest_Register, sz_64, Dest_Immediate, sz_8)][3] = 0x04;
+    binary_opcode_table[SHL][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_8)][0] = 0xC1;
+    binary_opcode_table[SHL][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_8)][3] = 0x04;
 
     // Shift Right
     // r/m64, imm8
-    binary_opcode_table[RShift][bindex(Dest_Register, sz_64, Dest_Immediate, sz_8)][0] = 0xD3;
-    binary_opcode_table[RShift][bindex(Dest_Register, sz_64, Dest_Immediate, sz_8)][3] = 0x05;
-    binary_opcode_table[RShift][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_8)][0] = 0xD3;
-    binary_opcode_table[RShift][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_8)][3] = 0x05;
+    binary_opcode_table[SHR][bindex(Dest_Register, sz_64, Dest_Immediate, sz_8)][0] = 0xC1;
+    binary_opcode_table[SHR][bindex(Dest_Register, sz_64, Dest_Immediate, sz_8)][3] = 0x05;
+    binary_opcode_table[SHR][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_8)][0] = 0xC1;
+    binary_opcode_table[SHR][bindex(Dest_Deref, sz_64, Dest_Immediate, sz_8)][3] = 0x05;
 
     // ------------------
     //  Memory
@@ -1497,7 +1497,7 @@ Document* pretty_location(Location loc, Allocator* a) {
 
 Document* pretty_binary_op(BinaryOp op, Allocator* a) {
     char* names[Binary_Op_Count] = {
-        "Add", "Sub", "Cmp", "And", "Or", "LShift", "RShift",
+        "Add", "Sub", "Cmp", "And", "Or", "SHL", "SHR",
         "Mov", "LEA", "CMovE", "CMovL", "CMovG",
     };
     // TODO BUG bounds check here.

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -392,7 +392,7 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
             // Get the tag gname of the variant
             RawTree* msym = (RawTree*)raw.nodes.data[1];
             if (msym->type != RawAtom && msym->atom.type != ASymbol) {
-                throw_error(point, mv_string("Second argument to projection term former should be symbol"));
+                throw_error(point, mv_string("First argument to projection term former should be symbol"));
             };
 
             //res.type = Ok;

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -471,6 +471,8 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
                     .abvar.index = 0,
                     .abvar.value = e->value,
                 };
+            } else {
+                throw_error(point, mv_string("Field not found in module!"));
             }
         } else {
             type_infer_i(untyped->projector.val, env, gen, a, point);

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -133,7 +133,7 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
         } else {
             String* sym = symbol_to_string(untyped->variable);
             String msg = string_cat(mv_string("Couldn't find type of variable: "), *sym, a);
-            throw_error(point, string_cat(msg, *sym, a));
+            throw_error(point, msg);
         }
         break;
     }

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -301,7 +301,10 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
         // Bind the vars in the all type to specific types!
         PiType* proc_type = pi_type_subst(all_type.binder.body, type_binds, a);
         if (proc_type->proc.args.len != untyped->all_application.args.len) {
-            throw_error(point, mk_string("To many args to procedure in all-application", a));
+            const char* msg = proc_type->proc.args.len < untyped->all_application.args.len
+                ? "Too many args to procedure in all-application"
+                : "Too few args to procedure in all-application";
+            throw_error(point, mk_string(msg, a));
         }
 
         for (size_t i = 0; i < proc_type->proc.args.len; i++) {

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -1320,7 +1320,7 @@ void instantiate_implicits(Syntax* syn, TypeEnv* env, Allocator* a, ErrorPoint* 
         if (syn->application.implicits.len != 0) {
             throw_error(point, mk_string("Implicit instantiation assumes no implicits are already present!", a));
         }
-        PiType fn_type = *syn->ptype;
+        PiType fn_type = *syn->application.function->ptype;
         for (size_t i = 0; i < fn_type.proc.implicits.len; i++) {
             PiType* arg_ty = fn_type.proc.implicits.data[i];
             if (arg_ty->sort != TTraitInstance) {

--- a/src/pico/binding/environment.c
+++ b/src/pico/binding/environment.c
@@ -92,8 +92,11 @@ Environment* env_from_module(Module* module, Allocator* a) {
     PtrArray instances = get_exported_instances(module, a);
     for (size_t i = 0; i < instances.len; i++ ) {
         InstanceSrc* instance = instances.data[i];
-        PtrArray* p = (PtrArray*)sym_ptr_lookup(instance->id, env->instances);
-        if (!p) {
+        PtrArray** res = (PtrArray**)sym_ptr_lookup(instance->id, env->instances);
+        PtrArray* p;
+        if (res) {
+            p = *res;
+        } else {
             p = mem_alloc(sizeof(PtrArray), a);
             *p = mk_ptr_array(8, a);
             // TODO: we know this isn't in the instances; could perhaps

--- a/src/pico/binding/environment.c
+++ b/src/pico/binding/environment.c
@@ -54,6 +54,7 @@ Environment* env_from_module(Module* module, Allocator* a) {
             PtrArray instances = get_exported_instances(importee, a);
             for (size_t i = 0; i < instances.len; i++ ) {
                 InstanceSrc* instance = instances.data[i];
+
                 PtrArray* p = (PtrArray*)sym_ptr_lookup(instance->id, env->instances);
                 if (!p) {
                     p = mem_alloc(sizeof(PtrArray), a);
@@ -119,8 +120,9 @@ EnvEntry env_lookup(Symbol sym, Environment* env) {
         ModuleEntry* mentry = get_def(sym, *module); 
         if (mentry != NULL) {
             result.success = Ok;
-            result.type = &mentry->type;
+            result.is_module = mentry->is_module;
             result.value = mentry->value;
+            result.type = mentry->is_module ? NULL : &mentry->type;
         } else {
             result.success = Err;
         }

--- a/src/pico/binding/type_env.c
+++ b/src/pico/binding/type_env.c
@@ -38,10 +38,12 @@ TypeEntry type_env_lookup(Symbol s, TypeEnv* env) {
     if (lresult != NULL) {
         out.type = TELocal;
         if (lresult->sort == LQVar) {
+            out.is_module = false;
             out.ptype = NULL;
             out.value = lresult->type;
             return out;
         } else if (lresult -> sort == LVar) {
+            out.is_module = false;
             out.ptype = lresult->type;
             out.value = NULL;
             return out;
@@ -54,8 +56,13 @@ TypeEntry type_env_lookup(Symbol s, TypeEnv* env) {
         out.type = TENotFound;
     } else {
         out.type = TEGlobal;
+        out.is_module = e.is_module;
         out.ptype = e.type;
-        out.value = (e.type->sort == TKind || e.type->sort == TConstraint) ? e.value : NULL;
+        if (!e.is_module) {
+            out.value = (e.type->sort == TKind || e.type->sort == TConstraint) ? e.value : NULL;
+        } else {
+            out.module = e.value;
+        }
     }
 
     return out;
@@ -83,6 +90,10 @@ InstanceEntry type_instance_lookup(uint64_t id, PtrArray args, TypeEnv* env) {
 
             ModuleEntry* m_entry = get_def(src->src_sym, src->src);
             if (!m_entry) panic(mv_string("Module entry is null!"));
+
+            if (m_entry->is_module) {
+                panic(mv_string("env_lookup cannot yet handle modules"));
+            }
 
             out = (InstanceEntry) {
                 .type = IEAbsSymbol,

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -565,7 +565,7 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
     }
     case SProjector: {
         // First, allocate space on the stack for the value
-        size_t out_sz = pi_size_of(*syn.ptype);
+        size_t out_sz = pi_stack_size_of(*syn.ptype);
         build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(out_sz), a, point);
         address_stack_grow(env, out_sz);
 

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -610,9 +610,9 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
             // Now, calculate offset for field 
             size_t offset = 0;
             for (size_t i = 0; i < syn.projector.val->ptype->instance.fields.len; i++) {
+                offset = pi_size_align(offset, pi_align_of(*(PiType*)syn.projector.val->ptype->instance.fields.data[i].val));
                 if (syn.projector.val->ptype->instance.fields.data[i].key == syn.projector.field)
                     break;
-                offset = pi_size_align(offset, pi_align_of(*(PiType*)syn.projector.val->ptype->instance.fields.data[i].val));
                 offset += pi_size_of(*(PiType*)syn.projector.val->ptype->instance.fields.data[i].val);
             }
             build_binary_op(ass, Add, reg(RSI, sz_64), imm32(offset), a, point);
@@ -637,7 +637,6 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         }
         build_binary_op(ass, Mov, reg(RSI, sz_64), imm32(immediate_sz), a, point);
         generate_tmp_malloc(reg(RAX, sz_64), reg(RSI, sz_64), ass, a, point);
-        // build_binary_op(ass, Add, reg(RAX), imm32(immediate_sz), a, point);
         build_binary_op(ass, Mov, reg(RCX, sz_64), reg(RAX, sz_64), a, point);
 
         // Grow by address size to account for the fact that the for loop
@@ -655,7 +654,7 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
             generate(*val, env, ass, links, a, point);
 
             // The offset tells us how far up the stack we look to find the instance ptr
-            size_t offset = pi_size_of(*val->ptype);
+            size_t offset = pi_stack_size_of(*val->ptype);
 
             // Retrieve index (ptr) 
             // TODO (BUG): Check offset is < int8_t max.

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -665,9 +665,9 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         build_binary_op(ass, Mov, reg(RSI, sz_64), reg(RSP, sz_64), a, point);
 #elif ABI == WIN_64 
         // arg1 = rcx, arg2 = rdx
-        build_binary_op(ass, Mov, reg(RCX), imm32(val_size), a, point);
-        build_binary_op(ass, Mov, reg(RDX), reg(RSP), a, point);
-        build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+        build_binary_op(ass, Mov, reg(RCX, sz_64), imm32(val_size), a, point);
+        build_binary_op(ass, Mov, reg(RDX, sz_64), reg(RSP, sz_64), a, point);
+        build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else
 #error "unknown ABI"
 #endif
@@ -677,7 +677,7 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64 
-        build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
         // Pop value off stack
         build_binary_op(ass, Add, reg(RSP, sz_64), imm32(val_size), a, point);
@@ -697,8 +697,8 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         build_unary_op(ass, Pop, reg(RDI, sz_64), a, point);
 #elif ABI == WIN_64 
         // arg1 = rcx
-        build_unary_op(ass, Pop, reg(RCX), a, point);
-        build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+        build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+        build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else
 #error "unknown ABI"
 #endif
@@ -708,7 +708,7 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64 
-        build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
         // Now, allocate space on stack
         size_t val_size = pi_size_of(*syn.ptype);

--- a/src/pico/codegen/internal.c
+++ b/src/pico/codegen/internal.c
@@ -90,8 +90,8 @@ void generate_tmp_malloc(Location dest, Location mem_size, Assembler* ass, Alloc
 #if ABI == SYSTEM_V_64
     build_binary_op(ass, Mov, reg(RDI, sz_64), mem_size, a, point);
 #elif ABI == WIN_64
-    build_binary_op(ass, Mov, reg(RCX), mem_size, a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), mem_size, a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -100,7 +100,7 @@ void generate_tmp_malloc(Location dest, Location mem_size, Assembler* ass, Alloc
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
 
     if (dest.type != Dest_Register && dest.reg != RAX) {
@@ -127,10 +127,10 @@ void gen_mk_family_app(size_t nfields, Assembler* ass, Allocator* a, ErrorPoint*
     build_binary_op(ass, Mov, reg(RSI, sz_64), reg(RSP, sz_64), a, point);
     build_binary_op(ass, Mov, reg(RDX, sz_64), imm32(nfields), a, point);
 #elif ABI == WIN_64
-    build_unary_op(ass, Pop, reg(RCX), a, point);
-    build_binary_op(ass, Mov, reg(RDX), reg(RSP), a, point);
-    build_binary_op(ass, Mov, reg(R8), imm32(nfields), a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), reg(RSP, sz_64), a, point);
+    build_binary_op(ass, Mov, reg(R8, sz_64), imm32(nfields), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -139,7 +139,7 @@ void gen_mk_family_app(size_t nfields, Assembler* ass, Allocator* a, ErrorPoint*
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
 
     build_binary_op(ass, Add, reg(RSP, sz_64), imm32(nfields * ADDRESS_SIZE), a, point);
@@ -165,9 +165,9 @@ void gen_mk_struct_ty(Location dest, Location nfields, Location data, Assembler*
     build_binary_op(ass, Mov, reg(RDI, sz_64), nfields, a, point);
     build_binary_op(ass, Mov, reg(RSI, sz_64), data, a, point);
 #elif ABI == WIN_64
-    build_binary_op(ass, Mov, reg(RCX), nfields, a, point);
-    build_binary_op(ass, Mov, reg(RDX), data, a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), nfields, a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), data, a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -176,7 +176,7 @@ void gen_mk_struct_ty(Location dest, Location nfields, Location data, Assembler*
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
 
     if (dest.type != Dest_Register && dest.reg != RAX) {
@@ -205,10 +205,10 @@ void gen_mk_proc_ty(Location dest, Location nfields, Location data, Location ret
     build_binary_op(ass, Mov, reg(RSI, sz_64), data, a, point);
     build_binary_op(ass, Mov, reg(RDX, sz_64), ret, a, point);
 #elif ABI == WIN_64
-    build_binary_op(ass, Mov, reg(RCX), nfields, a, point);
-    build_binary_op(ass, Mov, reg(RDX), data, a, point);
-    build_binary_op(ass, Mov, reg(R8), ret, a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), nfields, a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), data, a, point);
+    build_binary_op(ass, Mov, reg(R8, sz_64), ret, a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -217,7 +217,7 @@ void gen_mk_proc_ty(Location dest, Location nfields, Location data, Location ret
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
 
     if (dest.type != Dest_Register && dest.reg != RAX) {
@@ -265,11 +265,11 @@ void gen_mk_enum_ty(Location dest, SynEnumType shape, Location data, Assembler* 
     build_binary_op(ass, Mov, reg(RSI, sz_64), imm64((uint64_t)sml_shape), a, point);
     build_binary_op(ass, Mov, reg(RDX, sz_64), data, a, point);
 #elif ABI == WIN_64
-    build_binary_op(ass, Mov, reg(RCX), imm64(shape.variants.len), a, point);
-    build_binary_op(ass, Mov, reg(RDX), imm64((uint64_t)sml_shape), a, point);
-    build_binary_op(ass, Mov, reg(R8), data, a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), imm64(shape.variants.len), a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), imm64((uint64_t)sml_shape), a, point);
+    build_binary_op(ass, Mov, reg(R8, sz_64), data, a, point);
 
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -278,7 +278,7 @@ void gen_mk_enum_ty(Location dest, SynEnumType shape, Location data, Assembler* 
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
 
     if (dest.type != Dest_Register && dest.reg != RAX) {
@@ -304,10 +304,10 @@ void gen_mk_reset_ty(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Pop, reg(RSI, sz_64), a, point);
     build_unary_op(ass, Pop, reg(RDI, sz_64), a, point);
 #elif ABI == WIN_64
-    build_unary_op(ass, Pop, reg(RDX), a, point);
-    build_unary_op(ass, Pop, reg(RCX), a, point);
+    build_unary_op(ass, Pop, reg(RDX, sz_64), a, point);
+    build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
 
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -316,7 +316,7 @@ void gen_mk_reset_ty(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
     build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 }
@@ -338,9 +338,9 @@ void gen_mk_dynamic_ty(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #if ABI == SYSTEM_V_64
     build_unary_op(ass, Pop, reg(RDI, sz_64), a, point);
 #elif ABI == WIN_64
-    build_unary_op(ass, Pop, reg(RCX), a, point);
+    build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
 
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -349,7 +349,7 @@ void gen_mk_dynamic_ty(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
     build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 }
@@ -369,9 +369,9 @@ void gen_mk_type_var(Symbol var, Assembler* ass, Allocator* a, ErrorPoint* point
 #if ABI == SYSTEM_V_64
     build_binary_op(ass, Mov, reg(RDI, sz_64), imm64(var), a, point);
 #elif ABI == WIN_64
-    build_binary_op(ass, Mov, reg(RCX), imm64(var), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), imm64(var), a, point);
 
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -380,7 +380,7 @@ void gen_mk_type_var(Symbol var, Assembler* ass, Allocator* a, ErrorPoint* point
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
     build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 }
@@ -414,11 +414,11 @@ void gen_mk_forall_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint
     build_binary_op(ass, Mov, reg(RSI, sz_64), imm64((uint64_t)data),a, point);
     build_unary_op(ass, Pop, reg(RDX, sz_64), a, point);
 #elif ABI == WIN_64
-    build_binary_op(ass, Mov, reg(RCX), imm64(syms.len), a, point);
-    build_binary_op(ass, Mov, reg(RDX), imm64((uint64_t)data),a, point);
-    build_unary_op(ass, Pop, reg(R8), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), imm64(syms.len), a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), imm64((uint64_t)data),a, point);
+    build_unary_op(ass, Pop, reg(R8, sz_64), a, point);
 
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -427,7 +427,7 @@ void gen_mk_forall_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
     build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 }
@@ -459,11 +459,11 @@ void gen_mk_fam_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint* p
     build_binary_op(ass, Mov, reg(RSI, sz_64), imm64((uint64_t)data),a, point);
     build_unary_op(ass, Pop, reg(RDX, sz_64), a, point);
 #elif ABI == WIN_64
-    build_binary_op(ass, Mov, reg(RCX), imm64(syms.len), a, point);
-    build_binary_op(ass, Mov, reg(RDX), imm64((uint64_t)data),a, point);
-    build_unary_op(ass, Pop, reg(R8), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), imm64(syms.len), a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), imm64((uint64_t)data),a, point);
+    build_unary_op(ass, Pop, reg(R8, sz_64), a, point);
 
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -472,7 +472,7 @@ void gen_mk_fam_ty(SymbolArray syms, Assembler* ass, Allocator* a, ErrorPoint* p
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
     build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 }
@@ -495,8 +495,8 @@ void gen_mk_distinct_ty(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #if ABI == SYSTEM_V_64
     build_unary_op(ass, Pop, reg(RDI, sz_64), a, point);
 #elif ABI == WIN_64
-    build_unary_op(ass, Pop, reg(RCX), a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -505,7 +505,7 @@ void gen_mk_distinct_ty(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
     build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 }
@@ -528,8 +528,8 @@ void gen_mk_opaque_ty(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #if ABI == SYSTEM_V_64
     build_unary_op(ass, Pop, reg(RDI, sz_64), a, point);
 #elif ABI == WIN_64
-    build_unary_op(ass, Pop, reg(RCX), a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -538,7 +538,7 @@ void gen_mk_opaque_ty(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
     build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 }
@@ -578,12 +578,12 @@ void gen_mk_trait_ty(SymbolArray syms, Location dest, Location nfields, Location
     build_binary_op(ass, Mov, reg(RDX, sz_64), nfields, a, point);
     build_binary_op(ass, Mov, reg(RCX, sz_64), data, a, point);
 #elif ABI == WIN_64
-    build_binary_op(ass, Mov, reg(RCX), imm64(syms.len), a, point);
-    build_binary_op(ass, Mov, reg(RDX), imm64((uint64_t)sym_data), a, point);
-    build_binary_op(ass, Mov, reg(R8), nfields, a, point);
-    build_binary_op(ass, Mov, reg(R9), data, a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), imm64(syms.len), a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), imm64((uint64_t)sym_data), a, point);
+    build_binary_op(ass, Mov, reg(R8, sz_64), nfields, a, point);
+    build_binary_op(ass, Mov, reg(R9, sz_64), data, a, point);
 
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else 
     #error "Unknown calling convention"
 #endif
@@ -592,7 +592,7 @@ void gen_mk_trait_ty(SymbolArray syms, Location dest, Location nfields, Location
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif 
 
     if (dest.type != Dest_Register && dest.reg != RAX) {

--- a/src/pico/codegen/polymorphic.c
+++ b/src/pico/codegen/polymorphic.c
@@ -12,6 +12,9 @@
 // Implementation details
 void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allocator* a, ErrorPoint* point);
 void generate_size_of(Regname dest, PiType* type, AddressEnv* env, Assembler* ass, Allocator* a, ErrorPoint* point);
+void generate_align_of(Regname dest, PiType* type, AddressEnv* env, Assembler* ass, Allocator* a, ErrorPoint* point);
+void generate_align_to(Regname sz, Regname align, Assembler* ass, Allocator* a, ErrorPoint* point);
+void generate_stack_size_of(Regname dest, PiType* type, AddressEnv* env, Assembler* ass, Allocator* a, ErrorPoint* point);
 void generate_poly_move(Location dest, Location src, Location size, Assembler* ass, Allocator* a, ErrorPoint* point);
 
 void generate_polymorphic(SymbolArray types, Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allocator* a, ErrorPoint* point) {
@@ -70,7 +73,7 @@ void generate_polymorphic(SymbolArray types, Syntax syn, AddressEnv* env, Assemb
     // 2. Move output value to start of types. We do this via a poly stack move,
     // which needs three pieces of info: 
     // 2.1 : The size of the data to be copid: Relatively simple.
-    generate_size_of(RAX, body.ptype, env, ass, a, point);
+    generate_stack_size_of(RAX, body.ptype, env, ass, a, point);
 
     // 2.2 : The destination address. This is offset + RBP, with offset calculated as:
     //              OLD RBP+RET ADDR | accounts for types       | account for vars
@@ -130,22 +133,28 @@ void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, LinkDat
         AddressEntry e = address_env_lookup(syn.variable, env);
         switch (e.type) {
         case ALocalDirect:
+            // TODO (BUG): this won't work for values > 64 bits wide!
             build_unary_op(ass, Push, rref8(RBP, e.stack_offset, sz_64), a, point);
             break;
         case ALocalIndirect:
             // First, we need the size of the variable & allocate space for it on the stack
-            generate_size_of(RAX, syn.ptype, env, ass, a, point);
-            build_binary_op(ass, Sub, reg(RSP, sz_64), reg(RAX, sz_64), a, point);
+            // ------------------------------
+            // Store stack size in R8
+            generate_stack_size_of(R8, syn.ptype, env, ass, a, point);
+
+
+            // Subtract stack size
+            build_binary_op(ass, Sub, reg(RSP, sz_64), reg(R9, sz_64), a, point);
 
             // Then, find the location of the variable on the stack 
             // *(RBP + stack offset) = offset2
             // RBP + offset2 = dest (stored here in R9)
-            build_binary_op(ass, Mov, reg(R9, sz_64), rref8(RBP, e.stack_offset, sz_64), a, point);
-            build_binary_op(ass, Add, reg(R9, sz_64), reg(RBP, sz_64), a, point); // 
-            //build_binary_op(ass, Mov, reg(R9), rref8(R9, 0), a, point);
-            //build_binary_op(ass, Add, reg(R9), reg(RBP), a, point);
+            build_binary_op(ass, Mov, reg(R8, sz_64), rref8(RBP, e.stack_offset, sz_64), a, point);
+            // We need to stack-align the value!
 
-            generate_poly_move(reg(RSP, sz_64), reg(R9, sz_64), reg(RAX, sz_64), ass, a, point);
+            build_binary_op(ass, Add, reg(R8, sz_64), reg(RBP, sz_64), a, point); // 
+
+            generate_poly_move(reg(RSP, sz_64), reg(R8, sz_64), reg(R9, sz_64), ass, a, point);
             break;
         case ATypeVar:
             throw_error(point, mv_string("Codegen not implemented for ATypeVar"));
@@ -222,140 +231,23 @@ void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, LinkDat
     }
     case SAllApplication: {
         throw_error(point, mv_string("Internal error: cannot generate all application inside polymorphic code"));
-        // Generate the arguments
-        /*
-
-        for (size_t i = 0; i < syn.all_application.types.len; i++) {
-            src_offset += pi_runtime_size_of(*((Syntax*)syn.structure.fields.data[j].val)->ptype); 
-        }
-
-        for (size_t i = 0; i < syn.all_application.types.len; i++) {
-            PiType* type = *((Syntax*)syn.all_application.args.data[i])->ptype;
-            generate_polymorphic_type(*type, env, ass, links, a, point);
-        }
-
-        for (size_t i = 0; i < syn.all_application.args.len; i++) {
-            Syntax* arg = (Syntax*) syn.application.args.data[i];
-            generate_polymorphic_i(*arg, env, ass, links, a, point);
-        }
-
-        // This will push a function pointer onto the stack
-        generate_polymorphic_i(*syn.application.function, env, ass, links, a, point);
-        
-        // Regular Function Call
-        // Pop the function into RCX; call the function
-        build_unary_op(ass, Pop, reg(RCX), a, point);
-        build_unary_op(ass, Call, reg(RCX), a, point);
-        break;
-        */
     }
     case SStructure: {
         throw_error(point, mv_string("Not implemented: structure in forall."));
-        /*
-        // For structures, we have to be careful - this is because the order in
-        // which arguments are evaluated is not necessarily the order in which
-        // arguments are inserted into the structure.
-
-        // Step 1: Make room on the stack for our struct
-        size_t struct_size = pi_runtime_size_of(*syn.ptype);
-        out = build_binary_op(ass, Sub, reg(RSP), imm32(struct_size), a);
-        if (out.type == Err) return out;
-
-        // Step 2: evaluate each element/variable binding
-        for (size_t i = 0; i < syn.structure.fields.len; i++) {
-            out = generate_polymorphic(*(Syntax*)syn.structure.fields.data[i].val, env, ass, links, a);
-            if (out.type == Err) return out;
-        }
-        
-        // Step 3: copy each element of the array into it's place on the stack.
-        // Note: for, e.g. Struct [.x I64] [.y I64] we expect the stack to look 
-        // something like the below.
-        // ...  ..
-        // 144 y  } Destination - elements are ordered bottom-top
-        // 136 x  } 
-        // --- 
-        // 128 x   } Source - elements can be in any arbitrary order 
-        // 120 y   } <`top' of stack - grows down>
-        // ------------
-
-        // Copy from the bottom (of the destination) to the top (also of the destination) 
-        size_t dest_offset = 0;
-        for (size_t i = 0; i < syn.ptype->structure.fields.len; i++) {
-
-            // Find the field in the source & compute offset
-            size_t src_offset = 0;
-            for (size_t j = 0; j < syn.structure.fields.len; j++) {
-                PiType** t = (PiType**)sym_ptr_lookup(syn.structure.fields.data[j].key, syn.ptype->structure.fields);
-                if (t) {
-                    src_offset += pi_runtime_size_of(*((Syntax*)syn.structure.fields.data[j].val)->ptype); 
-                } else {
-                    out.type = Err;
-                    out.error_message = mv_string("Error code-generating for structure: field not found.");
-                    return out;
-                }
-
-                if (syn.structure.fields.data[j].key == syn.ptype->structure.fields.data[i].key) {
-                    break; // offset is correct, end the loop
-                }
-            }
-
-            // We now both the source_offset and dest_offset. These are both
-            // relative to the 'bottom' of their respective structures.
-            // Therefore, we now need to find their offsets relative to the `top'
-            // of the stack.
-            size_t src_stack_offset = struct_size - src_offset;
-            size_t dest_stack_offset = struct_size + dest_offset;
-            size_t field_size = pi_runtime_size_of(*(PiType*)syn.ptype->structure.fields.data[i].val);
-
-            // Now, move the data.
-            out = generate_runtime_stack_move(dest_stack_offset, src_stack_offset, field_size, ass, a);
-            if (out.type == Err) return out;
-
-            // Compute dest_offset for next loop
-            dest_offset += pi_runtime_size_of(*(PiType*)syn.ptype->structure.fields.data[i].val);
-        }
-        // Remove the space occupied by the temporary values 
-        out = build_binary_op(ass, Add, reg(RSP), imm32(struct_size), a);
-
-        address_stack_grow(env, pi_runtime_size_of(*syn.ptype));
-        break;
-        */
     }
     case SProjector: {
         if (syn.projector.val->ptype->sort == TStruct) {
             panic(mv_string("Projector not implemented for structures in polymorphic function"));
-            /*
-            // First, allocate space on the stack for the value
-            generate_size_of(RAX, syn.ptype, env, ass, a, point);
-            build_binary_op(ass, Sub, reg(RSP), reg(RAX), a, point);
-
-            // Second, generate the structure object
-            out = generate(*syn.projector.val, env, ass, links, a);
-
-            // Now, copy the structure to the destination
-            // for this, we need the struct size + offset of field in the struct
-            size_t struct_sz = pi_runtime_size_of(*syn.projector.val->ptype);
-            size_t offset = 0;
-            for (size_t i = 0; i < syn.projector.val->ptype->structure.fields.len; i++) {
-            if (syn.projector.val->ptype->structure.fields.data[i].key == syn.projector.field)
-            break;
-            offset += pi_runtime_size_of(*(PiType*)syn.projector.val->ptype->structure.fields.data[i].val);
-            }
-
-            out = generate_stack_move(struct_sz + out_sz - 0x8, offset, out_sz, ass, a);
-            if (out.type == Err) return out;
-            // now, remove the original struct from the stack
-            out = build_binary_op(ass, Add, reg(RSP), imm32(struct_sz), a);
-
-            address_stack_shrink(env, struct_sz);
-            address_stack_grow(env, out_sz);
-            */
         } else {
             generate_polymorphic_i(*syn.projector.val, env, ass, links, a, point);
 
             // Now, calculate offset for field 
             build_unary_op(ass, Push, imm8(0), a, point);
             for (size_t i = 0; i < syn.projector.val->ptype->instance.fields.len; i++) {
+                generate_align_of(R8, (PiType*)syn.projector.val->ptype->instance.fields.data[i].val, env, ass, a, point);
+                build_binary_op(ass, Mov, reg(R9, sz_64), rref8(RSP, 0, sz_64), a, point);
+                generate_align_to(R8, R9, ass, a, point);
+                build_binary_op(ass, Mov, rref8(RSP, 0, sz_64), reg(R8, sz_64), a, point);
                 if (syn.projector.val->ptype->instance.fields.data[i].key == syn.projector.field)
                     break;
                 // Push the size into RAX; this is then added to the top of the stack  
@@ -381,169 +273,12 @@ void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, LinkDat
     }
     case SConstructor: {
         throw_error(point, mv_string("Not implemented: constructor in forall."));
-        /*
-        PiType* enum_type = syn.constructor.enum_type->type_val;
-        size_t enum_size = pi_runtime_size_of(*enum_type);
-        size_t variant_size = calc_variant_size(enum_type->enumeration.variants.data[syn.variant.tag].val);
-
-        out = build_binary_op(ass, Sub, reg(RSP), imm32(enum_size - variant_size), a);
-        if (out.type == Err) return out;
-        out = build_unary_op(ass, Push, imm32(syn.constructor.tag), a);
-        if (out.type == Err) return out;
-
-        address_stack_grow(env, enum_size);
-        break;
-        */
     }
     case SVariant: {
         throw_error(point, mv_string("Not implemented: variant in forall."));
-        /*
-        const size_t tag_size = sizeof(uint64_t);
-        PiType* enum_type = syn.variant.enum_type->type_val;
-        size_t enum_size = pi_runtime_size_of(*enum_type);
-        size_t variant_size = calc_variant_size(enum_type->enumeration.variants.data[syn.variant.tag].val);
-
-        // Make space to fit the (final) variant
-        out = build_binary_op(ass, Sub, reg(RSP), imm32(enum_size), a);
-        if (out.type == Err) return out;
-
-        // Set the tag
-        out = build_binary_op(ass, Mov, rref8(RSP, 0), imm32(syn.constructor.tag), a);
-        if (out.type == Err) return out;
-
-        // Generate each argument
-        for (size_t i = 0; i < syn.variant.args.len; i++) {
-            out = generate(*(Syntax*)syn.variant.args.data[i], env, ass, links, a);
-            if (out.type == Err) return out;
-        }
-
-        // Now, move them into the space allocated in reverse order
-        PtrArray args = *(PtrArray*)syn.ptype->enumeration.variants.data[syn.variant.tag].val;
-        size_t src_stack_offset = variant_size - tag_size;
-        size_t dest_stack_offset = variant_size;
-        for (size_t i = 0; i < syn.variant.args.len; i++) {
-            // We now both the source_offset and dest_offset. These are both
-            // relative to the 'bottom' of their respective structures.
-            // Therefore, we now need to find their offsets relative to the `top'
-            // of the stack.
-            
-            size_t field_size = pi_runtime_size_of(*(PiType*)args.data[syn.variant.args.len - (i + 1)]);
-            src_stack_offset -= field_size;
-
-            // Now, move the data.
-            out = generate_stack_move(dest_stack_offset, src_stack_offset, field_size, ass, a);
-            if (out.type == Err) return out;
-
-            // Now, increase the amount of data we have used
-            dest_stack_offset += field_size;
-        }
-
-        // Remove the space occupied by the temporary values 
-        out = build_binary_op(ass, Add, reg(RSP), imm32(variant_size - tag_size), a);
-
-        // Grow the stack to account for the difference in enum & variant sizes
-        address_stack_grow(env, enum_size - variant_size);
-        break;
-        */
     }
     case SMatch: {
         throw_error(point, mv_string("Not implemented: match in forall."));
-        /*
-        // Generate code for the value
-        Syntax* match_value = syn.match.val;
-        size_t enum_size = pi_runtime_size_of(*match_value->ptype);
-        size_t out_size = pi_runtime_size_of(*syn.ptype);
-
-        out = generate(*match_value, env, ass, links, a);
-        if (out.type == Err) return out;
-
-        SizeArray back_positions = mk_size_array(syn.match.clauses.len, a);
-        PtrArray back_refs = mk_ptr_array(syn.match.clauses.len, a);
-
-        // For each pattern match, generate two things 
-        // 1. A comparison/check that the pattern has been matched
-        // 2. A jump to the relevant location
-        for (size_t i = 0; i < syn.match.clauses.len; i++) {
-            SynClause clause = *(SynClause*)syn.match.clauses.data[i];
-            out = build_binary_op(ass, Cmp, rref8(RSP, 0), imm32(clause.tag), a);
-            if (out.type == Err) return out;
-            out = build_unary_op(ass, JE, imm8(0), a);
-            if (out.type == Err) return out;
-            push_size(get_pos(ass), &back_positions);
-            push_ptr(get_instructions(ass).data + out.backlink, &back_refs);
-        }
-
-        // The 'body positions' and 'body_refs' store the inidices we need to
-        // use to calculate jumps (and the bytes we need to update with those jumps)
-        SizeArray body_positions = mk_size_array(syn.match.clauses.len, a);
-        PtrArray body_refs = mk_ptr_array(syn.match.clauses.len, a);
-
-        for (size_t i = 0; i < syn.match.clauses.len; i++) {
-            // 1. Backpatch the jump so that it jumps to here
-            size_t branch_pos = back_positions.data[i];
-            uint8_t* branch_ref = back_refs.data[i];
-
-            // calc backlink offset
-            size_t body_pos = get_pos(ass);
-            if (body_pos - branch_pos > INT8_MAX) {
-                out.type = Err;
-                out.error_message = mk_string("Jump in match too large", a);
-                return out;
-            } 
-
-            *branch_ref = (uint8_t)(body_pos - branch_pos);
-
-            SynClause clause = *(SynClause*)syn.match.clauses.data[i];
-            PtrArray variant_types = *(PtrArray*)match_value->ptype->enumeration.variants.data[clause.tag].val; 
-
-            // Bind Clause Vars 
-            SymSizeAssoc arg_sizes = mk_sym_size_assoc(variant_types.len, a);
-            for (size_t i = 0; i < variant_types.len; i++) {
-                sym_size_bind(clause.vars.data[i]
-                              , pi_mono_size_of(*(PiType*)variant_types.data[i])
-                              , &arg_sizes);
-            }
-            address_bind_enum_vars(arg_sizes, env, a);
-
-            out = generate(*clause.body, env, ass, links, a);
-            if (out.type == Err) return out;
-
-            // Generate jump to end of false branch to be backlinked later
-            out = build_unary_op(ass, JMP, imm8(0), a);
-            if (out.type == Err) return out;
-            push_size(get_pos(ass), &body_positions);
-            push_ptr(get_instructions(ass).data + out.backlink, &body_refs);
-
-            address_unbind_enum_vars(env);
-            address_stack_shrink(env, out_size);
-        }
-
-        // Finally, backlink all jumps from the bodies to the end.
-        size_t curr_pos = get_pos(ass);
-        for (size_t i = 0; i < body_positions.len; i++) {
-            size_t body_pos = body_positions.data[i];
-            uint8_t* body_ref = body_refs.data[i];
-
-            if (curr_pos - body_pos > INT8_MAX) {
-                out.type = Err;
-                out.error_message = mk_string("Jump in match too large", a);
-                return out;
-            } 
-
-            *body_ref = (uint8_t)(curr_pos - body_pos);
-        }
-
-
-        out = generate_stack_move(out_size + (enum_size - out_size), 0, out_size, ass, a);
-        if (out.type == Err) return out;
-
-        out = build_binary_op(ass, Add, reg(RSP), imm32(enum_size), a);
-
-        address_stack_shrink(env, enum_size);
-        address_stack_grow(env, out_size);
-        break;
-        */
-        
     }
     case SLet: {
         throw_error(point, mv_string("Not implemented: let in forall."));
@@ -551,64 +286,6 @@ void generate_polymorphic_i(Syntax syn, AddressEnv* env, Assembler* ass, LinkDat
     }
     case SIf: {
         throw_error(point, mv_string("Not implemented: if in forall."));
-        /*
-        // generate the condition
-        out = generate(*syn.if_expr.condition, env, ass, links, a);
-        if (out.type == Err) return out;
-
-        // Pop the bool into R9; compare with 0
-        out = build_unary_op(ass, Pop, reg(R9), a);
-        if (out.type == Err) return out;
-        out = build_binary_op(ass, Cmp, reg(R9), imm32(0), a);
-        if (out.type == Err) return out;
-
-        // ---------- CONDITIONAL JUMP ----------
-        // compare the value to 0
-        // jump to false branch if equal to 0 -- the immediate 8 is a placeholder
-        out = build_unary_op(ass, JE, imm8(0), a);
-        if (out.type == Err) return out;
-        size_t start_pos = get_pos(ass);
-
-        uint8_t* jmp_loc = get_instructions(ass).data + out.backlink;
-
-        // ---------- TRUE BRANCH ----------
-        // now, generate the code to run (if true)
-        out = generate(*syn.if_expr.true_branch, env, ass, links, a);
-        if (out.type == Err) return out;
-
-        // Generate jump to end of false branch to be backlinked later
-        out = build_unary_op(ass, JMP, imm8(0), a);
-        if (out.type == Err) return out;
-
-        // calc backlink offset
-        size_t end_pos = get_pos(ass);
-        if (end_pos - start_pos > INT8_MAX) {
-            out.type = Err;
-            out.error_message = mk_string("Jump in conditional too large", a);
-            return out;
-        } 
-
-        // backlink
-        *jmp_loc = (end_pos - start_pos);
-        jmp_loc = get_instructions(ass).data + out.backlink;
-        start_pos = get_pos(ass);
-
-
-        // ---------- FALSE BRANCH ----------
-        // Generate code for the false branch
-        out = generate(*syn.if_expr.false_branch, env, ass, links, a);
-        if (out.type == Err) return out;
-
-        // calc backlink offset
-        end_pos = get_pos(ass);
-        if (end_pos - start_pos > INT8_MAX) {
-            out.type = Err;
-            out.error_message = mk_string("Jump in conditional too large", a);
-            return out;
-        } 
-        *jmp_loc = (uint8_t)(end_pos - start_pos);
-        break;
-        */
     }
     case SCheckedType: {
         build_binary_op(ass, Mov, reg(R9, sz_64), imm64((uint64_t)syn.type_val), a, point);
@@ -633,6 +310,8 @@ void generate_size_of(Regname dest, PiType* type, AddressEnv* env, Assembler* as
         switch (e.type) {
         case ALocalDirect:
             build_binary_op(ass, Mov, reg(dest, sz_64), rref8(RBP, e.stack_offset, sz_64), a, point);
+            build_binary_op(ass, RShift, reg(dest, sz_64), imm32(28), a, point);
+            build_binary_op(ass, And, reg(dest, sz_64), imm32(0xFFFFFFF), a, point);
             break;
         case ALocalIndirect:
             panic(mv_string("cannot generate code for local indirect."));
@@ -664,6 +343,136 @@ void generate_size_of(Regname dest, PiType* type, AddressEnv* env, Assembler* as
     }
     }
 }
+
+void generate_align_of(Regname dest, PiType* type, AddressEnv* env, Assembler* ass, Allocator* a, ErrorPoint* point) {
+    switch (type->sort) {
+    case TPrim:
+    case TProc:
+    case TTraitInstance:
+        build_binary_op(ass, Mov, reg(dest, sz_64), imm32(pi_align_of(*type)), a, point);
+        break;
+    case TVar: {
+        // TODO (BUG UB VERY BAD) This is size - not alignment. Alignment
+        //   needs to be accounted for!
+        AddressEntry e = address_env_lookup(type->var, env);
+        switch (e.type) {
+        case ALocalDirect:
+            build_binary_op(ass, Mov, reg(dest, sz_64), rref8(RBP, e.stack_offset, sz_64), a, point);
+            build_binary_op(ass, RShift, reg(dest, sz_64), imm32(56), a, point);
+            build_binary_op(ass, And, reg(dest, sz_64), imm32(0xFF), a, point);
+            break;
+        case ALocalIndirect:
+            panic(mv_string("cannot generate code for local indirect."));
+            break;
+        case AGlobal:
+            panic(mv_string("Unexpected type variable sort: Global."));
+            break;
+        case ATypeVar:
+            panic(mv_string("Unexpected type variable sort: ATypeVar."));
+            break;
+        case ANotFound: {
+            panic(mv_string("Type Variable not found during codegen."));
+            break;
+        }
+        case ATooManyLocals: {
+            throw_error(point, mk_string("Too Many Local variables!", a));
+            break;
+        }
+        }
+        break;
+    }
+    default: {
+        // TODO BUG: This seems to cause crashes!
+        PtrArray nodes = mk_ptr_array(4, a);
+        push_ptr(mv_str_doc(mv_string("Unrecognized type provided to generate_align_of:"), a), &nodes);
+        push_ptr(pretty_type(type, a), &nodes);
+        Document* message = mk_sep_doc(nodes, a);
+        panic(doc_to_str(message, a));
+    }
+    }
+}
+
+void generate_stack_size_of(Regname dest, PiType* type, AddressEnv* env, Assembler* ass, Allocator* a, ErrorPoint* point) {
+    switch (type->sort) {
+    case TPrim:
+    case TProc:
+    case TTraitInstance:
+        build_binary_op(ass, Mov, reg(dest, sz_64), imm32(8), a, point);
+        break;
+    case TVar: {
+        AddressEntry e = address_env_lookup(type->var, env);
+        switch (e.type) {
+        case ALocalDirect:
+            build_binary_op(ass, Mov, reg(dest, sz_64), rref8(RBP, e.stack_offset, sz_64), a, point);
+            build_binary_op(ass, And, reg(dest, sz_64), imm32(0xFFFFFFF), a, point);
+            break;
+        case ALocalIndirect:
+            panic(mv_string("cannot generate code for local indirect."));
+            break;
+        case AGlobal:
+            panic(mv_string("Unexpected type variable sort: Global."));
+            break;
+        case ATypeVar:
+            panic(mv_string("Unexpected type variable sort: ATypeVar."));
+            break;
+        case ANotFound: {
+            panic(mv_string("Type Variable not found during codegen."));
+            break;
+        }
+        case ATooManyLocals: {
+            throw_error(point, mk_string("Too Many Local variables!", a));
+            break;
+        }
+        }
+        break;
+    }
+    default: {
+        // TODO BUG: This seems to cause crashes!
+        PtrArray nodes = mk_ptr_array(4, a);
+        push_ptr(mv_str_doc(mv_string("Unrecognized type provided to generate_stack_size_of:"), a), &nodes);
+        push_ptr(pretty_type(type, a), &nodes);
+        Document* message = mk_sep_doc(nodes, a);
+        panic(doc_to_str(message, a));
+    }
+    }
+}
+
+void generate_align_to(Regname sz_reg, Regname align, Assembler* ass, Allocator* a, ErrorPoint* point) {
+    // RDX, RAX, RCX
+    if (sz_reg == RAX || sz_reg == RCX || sz_reg == RDX ||
+        align == RAX  || align == RCX  || align == RDX) {
+        throw_error(point, mv_string("Error in generate_align_to: sz or align registers were either RAX, RCX or RDX!"));
+    }
+
+    /* size_t rem = size % 8; */
+    /* size_t pad = rem == 0 ? 0 : align - rem; */
+    /* return size + pad; */
+
+    // We accomplish modulo with IDiv, which stores the remainder (modulo) in RDX 
+    build_binary_op(ass, Mov, reg(RAX, sz_64), reg(sz_reg, sz_64), a, point); 
+    build_binary_op(ass, Mov, reg(RDX, sz_64), imm32(0), a, point); 
+    build_binary_op(ass, Mov, reg(RCX, sz_64), imm32(align), a, point); 
+    build_unary_op(ass, IDiv, reg(RCX, sz_64), a, point); 
+
+    // Now, rem is in RDX
+
+    // Store align - rem in RAX and 0 in RCX
+    build_binary_op(ass, Mov, reg(RAX, sz_64), reg(align, sz_64), a, point); 
+    build_binary_op(ass, Sub, reg(RAX, sz_64), reg(RDX, sz_64), a, point); 
+    build_binary_op(ass, Mov, reg(RCX, sz_64), imm32(0), a, point); 
+
+    // Nowd to the compare (rem == 0) and CMove (asignment base on compare), so
+    // the result (pad) is in RDX
+    build_binary_op(ass, Cmp, reg(RDX, sz_64), imm32(0), a, point); 
+    build_binary_op(ass, CMovE, reg(RDX, sz_64), reg(RCX, sz_64), a, point); 
+
+    // Finally, add size (sz_reg) to padding (RDX)
+    build_binary_op(ass, Add, reg(sz_reg, sz_64), reg(RDX, sz_64), a, point); 
+
+    //build_binary_op(ass, Mov, reg(sz_reg, sz_64), reg(R9, sz_64), a, point); 
+}
+
+
 
 void generate_poly_move(Location dest, Location src, Location size, Assembler* ass, Allocator* a, ErrorPoint* point) {
 

--- a/src/pico/codegen/polymorphic.c
+++ b/src/pico/codegen/polymorphic.c
@@ -676,10 +676,10 @@ void generate_poly_move(Location dest, Location src, Location size, Assembler* a
 
 #elif ABI == WIN_64
     // memcpy (dest = rcx, src = rdx, size = r8)
-    build_binary_op(ass, Mov, reg(RCX), dest, a, point);
-    build_binary_op(ass, Mov, reg(RDX), src, a, point);
-    build_binary_op(ass, Mov, reg(R8), size, a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), dest, a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), src, a, point);
+    build_binary_op(ass, Mov, reg(R8, sz_64), size, a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else
 #error "Unknown calling convention"
 #endif
@@ -689,6 +689,6 @@ void generate_poly_move(Location dest, Location src, Location size, Assembler* a
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 }

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -97,15 +97,15 @@ void* pico_run_expr(Assembler* ass, size_t rsize, Allocator* a, ErrorPoint* poin
     // memcpy (dest = rcx, src = rdx, size = r8)
     // retval = rax
     if (rsize != 0) {
-        build_binary_op(ass, Mov, reg(RCX), imm64((int64_t)value), a, point);
-        build_binary_op(ass, Mov, reg(RDX), reg(RSP), a, point);
-        build_binary_op(ass, Mov, reg(R8), imm64((int64_t)rsize), a, point);
-        build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+        build_binary_op(ass, Mov, reg(RCX, sz_64), imm64((int64_t)value), a, point);
+        build_binary_op(ass, Mov, reg(RDX, sz_64), reg(RSP, sz_64), a, point);
+        build_binary_op(ass, Mov, reg(R8, sz_64), imm64((int64_t)rsize), a, point);
+        build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 
-        build_binary_op(ass, Mov, reg(RAX), imm64((int64_t)&memcpy), a, point);
-        build_unary_op(ass, Call, reg(RAX), a, point);
+        build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((int64_t)&memcpy), a, point);
+        build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
         // pop value from stack
-        build_binary_op(ass, Add, reg(RSP), imm32(rsize + 32), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(rsize + 32), a, point);
     }
     build_nullary_op(ass, Ret, a, point);
 #else

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -89,7 +89,7 @@ void* pico_run_expr(Assembler* ass, size_t rsize, Allocator* a, ErrorPoint* poin
         build_binary_op(ass, Mov, reg(RCX, sz_64), imm64((int64_t)&memcpy), a, point);
         build_unary_op(ass, Call, reg(RCX, sz_64), a, point);
         // pop value from stack
-        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(rsize), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(pi_stack_round(rsize)), a, point);
     }
     build_nullary_op(ass, Ret, a, point);
 
@@ -105,7 +105,7 @@ void* pico_run_expr(Assembler* ass, size_t rsize, Allocator* a, ErrorPoint* poin
         build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((int64_t)&memcpy), a, point);
         build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
         // pop value from stack
-        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(rsize + 32), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(pi_stack_round(rsize) + 32), a, point);
     }
     build_nullary_op(ass, Ret, a, point);
 #else

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -2,7 +2,6 @@
 #include <string.h> // for memcpy
 
 #include "platform/machine_info.h"
-#include "platform/memory/arena.h"
 
 #include "pico/eval/call.h"
 #include "pico/values/types.h"
@@ -56,7 +55,6 @@ EvalResult pico_run_toplevel(TopLevel top, Assembler* ass, SymSArrAMap* backlink
             break;
         }
         case TTraitInstance: {
-            // TODO: instances need to be copied (handlein add_def?)
             void* val = pico_run_expr(ass, pi_size_of(*top.def.value->ptype), a, point);
             add_def(module, top.def.bind, *top.def.value->ptype, val);
             break;
@@ -84,14 +82,14 @@ void* pico_run_expr(Assembler* ass, size_t rsize, Allocator* a, ErrorPoint* poin
     // memcpy (dest = rdi, src = rsi, size = rdx)
     // retval = rax
     if (rsize != 0) {
-        build_binary_op(ass, Mov, reg(RDI), imm64((int64_t)value), a, point);
-        build_binary_op(ass, Mov, reg(RSI), reg(RSP), a, point);
-        build_binary_op(ass, Mov, reg(RDX), imm64((int64_t)rsize), a, point);
+        build_binary_op(ass, Mov, reg(RDI, sz_64), imm64((int64_t)value), a, point);
+        build_binary_op(ass, Mov, reg(RSI, sz_64), reg(RSP, sz_64), a, point);
+        build_binary_op(ass, Mov, reg(RDX, sz_64), imm64((int64_t)rsize), a, point);
 
-        build_binary_op(ass, Mov, reg(RCX), imm64((int64_t)&memcpy), a, point);
-        build_unary_op(ass, Call, reg(RCX), a, point);
+        build_binary_op(ass, Mov, reg(RCX, sz_64), imm64((int64_t)&memcpy), a, point);
+        build_unary_op(ass, Call, reg(RCX, sz_64), a, point);
         // pop value from stack
-        build_binary_op(ass, Add, reg(RSP), imm32(rsize), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(rsize), a, point);
     }
     build_nullary_op(ass, Ret, a, point);
 

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -89,7 +89,7 @@ void* pico_run_expr(Assembler* ass, size_t rsize, Allocator* a, ErrorPoint* poin
         build_binary_op(ass, Mov, reg(RCX, sz_64), imm64((int64_t)&memcpy), a, point);
         build_unary_op(ass, Call, reg(RCX, sz_64), a, point);
         // pop value from stack
-        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(pi_stack_round(rsize)), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(pi_stack_align(rsize)), a, point);
     }
     build_nullary_op(ass, Ret, a, point);
 

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -108,6 +108,8 @@ Module* mk_module(ModuleHeader header, Package* pkg_parent, Module* parent, Allo
 // Helper
 void delete_module_entry(ModuleEntryInternal entry, Module* module) {
     if (entry.is_module) {
+        delete_module(entry.value);
+    } else {
         if (entry.type.sort == TProc || entry.type.sort == TAll) {
             mem_free(entry.value, &module->executable_allocator);
         } else if (entry.type.sort == TKind || entry.type.sort == TConstraint) {
@@ -119,10 +121,7 @@ void delete_module_entry(ModuleEntryInternal entry, Module* module) {
             mem_free(entry.value, module->allocator);
         }
         delete_pi_type(entry.type, module->allocator);
-    } else {
-        delete_module(entry.value);
     }
-    
 
     if (entry.backlinks) {
         delete_sym_sarr_amap(*entry.backlinks,
@@ -147,6 +146,7 @@ void delete_module(Module* module) {
 
 Result add_def (Module* module, Symbol name, PiType type, void* data) {
     ModuleEntryInternal entry;
+    entry.is_module = false;
     size_t size = pi_size_of(type);
 
     if (type.sort == TKind || type.sort == TConstraint) {
@@ -218,10 +218,8 @@ Result add_module_def(Module* module, Symbol name, Module* child) {
     ModuleEntryInternal entry = (ModuleEntryInternal) {
         .value = child,
         .is_module = true,
+        .backlinks = NULL,
     };
-
-    //entry.type = copy_pi_type(type, module->allocator);
-    entry.backlinks = NULL;
 
     // Free a previous definition (if it exists!)
     // TODO BUG UB: possibly throw here?
@@ -231,10 +229,6 @@ Result add_module_def(Module* module, Symbol name, Module* child) {
     entry_insert(name, entry, &module->entries);
 
     return (Result) {.type = Ok};
-
-    Result out;
-    out.type = Ok;
-    return out;
 }
 
 ModuleEntry* get_def(Symbol sym, Module* module) {

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -155,6 +155,7 @@ Result add_def (Module* module, Symbol name, PiType type, void* data) {
     } else if (type.sort == TTraitInstance){
         size_t total = 0;
         for (size_t i = 0; i < type.instance.fields.len; i++) {
+            total = pi_size_align(total, pi_align_of(*(PiType*)type.instance.fields.data[i].val));
             total += pi_size_of(*(PiType*)type.instance.fields.data[i].val);
         }
         void* new_memory = mem_alloc(total, module->allocator);

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -72,9 +72,9 @@ PiType mk_unary_op_type(Allocator* a, PiType arg, PrimType ret) {
 
 void build_binary_fun(Assembler* ass, BinaryOp op, LocationSize sz, Allocator* a, ErrorPoint* point) {
     build_unary_op (ass, Pop, reg(RCX, sz_64), a, point);
-    build_unary_op (ass, Pop, reg(R9, sz_64), a, point);
+    build_unary_op (ass, Pop, reg(RDX, sz_64), a, point);
     build_unary_op (ass, Pop, reg(RAX, sz_64), a, point);
-    build_binary_op (ass, op, reg(RAX, sz), reg(R9, sz), a, point);
+    build_binary_op (ass, op, reg(RAX, sz), reg(RDX, sz), a, point);
     build_unary_op (ass, Push, reg(RAX, sz_64), a, point);
     build_unary_op (ass, Push, reg(RCX, sz_64), a, point);
     build_nullary_op (ass, Ret, a, point);

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -115,9 +115,9 @@ void build_print_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
 
 #elif ABI == WIN_64
     // puts (bytes = rcx)
-    build_binary_op (ass, Mov, reg(RCX), rref8(RSP, 16), a, point);
+    build_binary_op (ass, Mov, reg(RCX, sz_64), rref8(RSP, 16, sz_64), a, point);
 
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else
 #error "Unknown calling convention"
 #endif
@@ -126,7 +126,7 @@ void build_print_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     // Store RSI, pop args & return
@@ -162,13 +162,13 @@ void build_load_module_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // load_module_c_fun: push struct
     // pass in platform/memory/on stack(?)
     build_unary_op (ass, Push, imm32(0), a, point);
-    build_unary_op (ass, Push, rref8(RSP, 24), a, point);
+    build_unary_op (ass, Push, rref8(RSP, 24, sz_64), a, point);
     // note: use 24 twice as RSP grows with push! 
-    build_unary_op (ass, Push, rref8(RSP, 24), a, point);
+    build_unary_op (ass, Push, rref8(RSP, 24, sz_64), a, point);
 
     // store ptr to struct in rcx
-    build_binary_op(ass, Mov, reg(RCX), reg(RSP), a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), reg(RSP, sz_64), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else
 #error "Unknown calling convention"
 #endif
@@ -177,7 +177,7 @@ void build_load_module_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     // To return:
@@ -217,13 +217,13 @@ void build_run_script_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // load_module_c_fun: push struct
     // pass in platform/memory/on stack(?)
     build_unary_op (ass, Push, imm32(0), a, point);
-    build_unary_op (ass, Push, rref8(RSP, 24), a, point);
+    build_unary_op (ass, Push, rref8(RSP, 24, sz_64), a, point);
     // note: use 24 twice as RSP grows with push! 
-    build_unary_op (ass, Push, rref8(RSP, 24), a, point);
+    build_unary_op (ass, Push, rref8(RSP, 24, sz_64), a, point);
 
     // store ptr to struct in rcx
-    build_binary_op(ass, Mov, reg(RCX), reg(RSP), a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), reg(RSP, sz_64), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else
 #error "Unknown calling convention"
 #endif
@@ -232,7 +232,7 @@ void build_run_script_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     // To return:
@@ -340,11 +340,11 @@ void build_store_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 
 #elif ABI == WIN_64
     // memcpy (dest = rcx, src = rdx, size = r8)
-    build_binary_op(ass, Mov, reg(RCX), reg(RDI), a, point);
-    build_binary_op(ass, Mov, reg(RDX), reg(RSP), a, point);
-    build_binary_op(ass, Mov, reg(R8), reg(R9), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), reg(RDI, sz_64), a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), reg(RSP, sz_64), a, point);
+    build_binary_op(ass, Mov, reg(R8, sz_64), reg(R9, sz_64), a, point);
 
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else
 #error "Unknown calling convention"
 #endif
@@ -354,7 +354,7 @@ void build_store_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     // Store return address in R9
@@ -443,12 +443,12 @@ void build_load_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 
 #elif ABI == WIN_64
     // memcpy (dest = rcx, src = rdx, size = r8)
-    build_binary_op(ass, Mov, reg(RCX), reg(RSP), a, point);
-    build_binary_op(ass, Add, reg(RCX), imm8(ADDRESS_SIZE), a, point);
+    build_binary_op(ass, Mov, reg(RCX, sz_64), reg(RSP, sz_64), a, point);
+    build_binary_op(ass, Add, reg(RCX, sz_64), imm8(ADDRESS_SIZE), a, point);
 
-    build_binary_op(ass, Mov, reg(RDX), reg(RSI), a, point);
-    build_binary_op(ass, Mov, reg(R8), reg(R9), a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), reg(RSI, sz_64), a, point);
+    build_binary_op(ass, Mov, reg(R8, sz_64), reg(R9, sz_64), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #else
 #error "Unknown calling convention"
 #endif
@@ -458,7 +458,7 @@ void build_load_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     // Return
@@ -478,10 +478,10 @@ void build_realloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 
 #elif ABI == WIN_64
     // realloc (ptr = RCX, size = RDX)
-    build_unary_op(ass, Pop, reg(RDX), a, point);
-    build_unary_op(ass, Pop, reg(RCX), a, point);
-    build_unary_op(ass, Push, reg(RAX), a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_unary_op(ass, Pop, reg(RDX, sz_64), a, point);
+    build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
 
@@ -489,7 +489,7 @@ void build_realloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     build_unary_op(ass, Pop, reg(R9, sz_64), a, point);
@@ -511,9 +511,9 @@ void build_malloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 
 #elif ABI == WIN_64
-    build_unary_op(ass, Pop, reg(RCX), a, point);
-    build_unary_op(ass, Push, reg(RAX), a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     // Get the malloc dynamic variable
@@ -524,7 +524,7 @@ void build_malloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     build_unary_op(ass, Pop, reg(R9, sz_64), a, point);
@@ -547,16 +547,16 @@ void build_free_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #elif ABI == WIN_64
     // free (addr = rcx)
     // copy address into RCX
-    build_unary_op(ass, Pop, reg(RCX), a, point);
-    build_unary_op(ass, Push, reg(RAX), a, point);
-    build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
+    build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&free),  a, point);
     build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
-    build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(32), a, point);
 #endif
 
     build_nullary_op(ass, Ret, a, point);

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -71,34 +71,34 @@ PiType mk_unary_op_type(Allocator* a, PiType arg, PrimType ret) {
 }
 
 void build_binary_fun(Assembler* ass, BinaryOp op, Allocator* a, ErrorPoint* point) {
-    build_unary_op (ass, Pop, reg(RCX), a, point);
-    build_unary_op (ass, Pop, reg(R9), a, point);
-    build_unary_op (ass, Pop, reg(RAX), a, point);
-    build_binary_op (ass, op, reg(RAX), reg(R9), a, point);
-    build_unary_op (ass, Push, reg(RAX), a, point);
-    build_unary_op (ass, Push, reg(RCX), a, point);
+    build_unary_op (ass, Pop, reg(RCX, sz_64), a, point);
+    build_unary_op (ass, Pop, reg(R9, sz_64), a, point);
+    build_unary_op (ass, Pop, reg(RAX, sz_64), a, point);
+    build_binary_op (ass, op, reg(RAX, sz_64), reg(R9, sz_64), a, point);
+    build_unary_op (ass, Push, reg(RAX, sz_64), a, point);
+    build_unary_op (ass, Push, reg(RCX, sz_64), a, point);
     build_nullary_op (ass, Ret, a, point);
 }
 
 void build_special_binary_fun(Assembler* ass, UnaryOp op, Allocator* a, ErrorPoint* point) {
-    build_unary_op (ass, Pop, reg(RCX), a, point);
-    build_unary_op (ass, Pop, reg(R9), a, point);
-    build_unary_op (ass, Pop, reg(RAX), a, point);
-    build_binary_op (ass, Mov, reg(RDX), imm32(0), a, point);
-    build_unary_op (ass, op, reg(R9), a, point);
-    build_unary_op (ass, Push, reg(RAX), a, point);
-    build_unary_op (ass, Push, reg(RCX), a, point);
+    build_unary_op (ass, Pop, reg(RCX, sz_64), a, point);
+    build_unary_op (ass, Pop, reg(R9, sz_64), a, point);
+    build_unary_op (ass, Pop, reg(RAX, sz_64), a, point);
+    build_binary_op (ass, Mov, reg(RDX, sz_64), imm32(0), a, point);
+    build_unary_op (ass, op, reg(R9, sz_64), a, point);
+    build_unary_op (ass, Push, reg(RAX, sz_64), a, point);
+    build_unary_op (ass, Push, reg(RCX, sz_64), a, point);
     build_nullary_op (ass, Ret, a, point);
 }
 
 void build_comp_fun(Assembler* ass, UnaryOp op, Allocator* a, ErrorPoint* point) {
-    build_unary_op (ass, Pop, reg(RCX), a, point);
-    build_unary_op (ass, Pop, reg(R9), a, point);
-    build_unary_op (ass, Pop, reg(RAX), a, point);
-    build_binary_op (ass, Cmp, reg(RAX), reg(R9), a, point);
-    build_unary_op (ass, op, reg(RAX), a, point);
-    build_unary_op (ass, Push, reg(RAX), a, point);
-    build_unary_op (ass, Push, reg(RCX), a, point);
+    build_unary_op (ass, Pop, reg(RCX, sz_64), a, point);
+    build_unary_op (ass, Pop, reg(R9, sz_64), a, point);
+    build_unary_op (ass, Pop, reg(RAX, sz_64), a, point);
+    build_binary_op (ass, Cmp, reg(RAX, sz_64), reg(R9, sz_64), a, point);
+    build_unary_op (ass, op, reg(RAX, sz_64), a, point);
+    build_unary_op (ass, Push, reg(RAX, sz_64), a, point);
+    build_unary_op (ass, Push, reg(RCX, sz_64), a, point);
     build_nullary_op (ass, Ret, a, point);
 }
 
@@ -111,7 +111,7 @@ void build_print_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
 
 #if ABI == SYSTEM_V_64
     // puts (bytes = rdi)
-    build_binary_op (ass, Mov, reg(RDI), rref8(RSP, 16), a, point);
+    build_binary_op (ass, Mov, reg(RDI, sz_64), rref8(RSP, sz_64, 16), a, point);
 
 #elif ABI == WIN_64
     // puts (bytes = rcx)
@@ -122,17 +122,17 @@ void build_print_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #error "Unknown calling convention"
 #endif
 
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&puts), a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&puts), a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
 #endif
 
     // Store RSI, pop args & return
-    build_unary_op(ass, Pop, reg(RSI), a, point);
-    build_binary_op(ass, Add, reg(RSP), imm32(16), a, point);
-    build_unary_op(ass, Push, reg(RSI), a, point);
+    build_unary_op(ass, Pop, reg(RSI, sz_64), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(16), a, point);
+    build_unary_op(ass, Push, reg(RSI, sz_64), a, point);
     build_nullary_op (ass, Ret, a, point);
 }
 
@@ -154,9 +154,9 @@ void build_load_module_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // load_module_c_fun (struct on stack)
     // pass in platform/memory/on stack(?)
     build_unary_op (ass, Push, imm32(0), a, point);
-    build_unary_op (ass, Push, rref8(RSP, 24), a, point);
+    build_unary_op (ass, Push, rref8(RSP, sz_64, 24), a, point);
     // note: use 24 twice as RSP grows with push! 
-    build_unary_op (ass, Push, rref8(RSP, 24), a, point);
+    build_unary_op (ass, Push, rref8(RSP, sz_64, 24), a, point);
 
 #elif ABI == WIN_64
     // load_module_c_fun: push struct
@@ -173,8 +173,8 @@ void build_load_module_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #error "Unknown calling convention"
 #endif
 
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&load_module_c_fun), a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&load_module_c_fun), a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
@@ -185,10 +185,10 @@ void build_load_module_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // + stash ret addr
     // + pop argument we were called with
     // + push ret addr & return
-    build_binary_op(ass, Add, reg(RSP), imm32(24), a, point);
-    build_unary_op (ass, Pop, reg(RAX), a, point);
-    build_binary_op(ass, Add, reg(RSP), imm32(16), a, point);
-    build_unary_op (ass, Push, reg(RAX), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(24), a, point);
+    build_unary_op (ass, Pop, reg(RAX, sz_64), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(16), a, point);
+    build_unary_op (ass, Push, reg(RAX, sz_64), a, point);
     build_nullary_op (ass, Ret, a, point);
 }
 
@@ -209,9 +209,9 @@ void build_run_script_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // load_module_c_fun ({.memsize = rcx, .bytes = rdi, .allocator = rcx = NULL})
     // pass in platform/memory/on stack(?)
     build_unary_op (ass, Push, imm32(0), a, point);
-    build_unary_op (ass, Push, rref8(RSP, 24), a, point);
+    build_unary_op (ass, Push, rref8(RSP, sz_64, 24), a, point);
     // note: use 24 twice as RSP grows with push! 
-    build_unary_op (ass, Push, rref8(RSP, 24), a, point);
+    build_unary_op (ass, Push, rref8(RSP, sz_64, 24), a, point);
 
 #elif ABI == WIN_64
     // load_module_c_fun: push struct
@@ -228,8 +228,8 @@ void build_run_script_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #error "Unknown calling convention"
 #endif
 
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&run_script_c_fun), a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&run_script_c_fun), a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
@@ -240,10 +240,10 @@ void build_run_script_fun(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // + stash ret addr
     // + pop argument we were called with
     // + push ret addr & return
-    build_binary_op(ass, Add, reg(RSP), imm32(24), a, point);
-    build_unary_op (ass, Pop, reg(RAX), a, point);
-    build_binary_op(ass, Add, reg(RSP), imm32(16), a, point);
-    build_unary_op (ass, Push, reg(RAX), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(24), a, point);
+    build_unary_op (ass, Pop, reg(RAX, sz_64), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(16), a, point);
+    build_unary_op (ass, Push, reg(RAX, sz_64), a, point);
     build_nullary_op (ass, Ret, a, point);
 }
 
@@ -252,8 +252,8 @@ void exit_callback() {
 }
 
 void build_exit_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)exit_callback), a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)exit_callback), a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 }
 
 
@@ -268,7 +268,7 @@ uint64_t stdlib_size_of(PiType* t) {
 void build_size_of_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // size-of: PiType* -> uint64_t
 #if OS_FAMILY == UNIX
-    build_binary_op(ass, Mov, reg(RDI), rref8(RSP, 8), a, point);
+    build_binary_op(ass, Mov, reg(RDI, sz_64), rref8(RSP, sz_64, 8), a, point);
 #elif OS_FAMILY == WINDOWS
     build_binary_op(ass, Mov, reg(RCX), rref8(RSP, 8), a, point);
     build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
@@ -277,17 +277,17 @@ void build_size_of_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #endif
 
     // call pi_size_of
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&stdlib_size_of), a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&stdlib_size_of), a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if OS_FAMILY == WINDOWS
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
 #endif 
 
-    build_unary_op(ass, Pop, reg(RCX), a, point);
-    build_binary_op(ass, Add, reg(RSP), imm32(8), a, point);
-    build_unary_op(ass, Push, reg(RAX), a, point);
-    build_unary_op(ass, Push, reg(RCX), a, point);
+    build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm32(8), a, point);
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
+    build_unary_op(ass, Push, reg(RCX, sz_64), a, point);
     build_nullary_op(ass, Ret, a, point);
 }
 
@@ -321,22 +321,22 @@ void build_store_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // Note: as there is only two args, we can guarantee that RSP = pointer to SRC
     // also note that size = RBP + 0x10
     // Store the return address in RBP + 8
-    build_unary_op(ass, Pop, reg(R9), a, point);
-    build_binary_op(ass, Mov, rref8(RBP, 8), reg(R9), a, point);
+    build_unary_op(ass, Pop, reg(R9, sz_64), a, point);
+    build_binary_op(ass, Mov, rref8(RBP, sz_64, 8), reg(R9, sz_64), a, point);
 
     // Store Dest address (located @ RBP - 8)
-    build_binary_op(ass, Mov, reg(RDI), rref8(RBP, -8), a, point);
+    build_binary_op(ass, Mov, reg(RDI, sz_64), rref8(RBP, sz_64, -8), a, point);
 
     // SRC address = RSP 
 
     // Store size in R9
-    build_binary_op(ass, Mov, reg(R9), rref8(RBP, 4*ADDRESS_SIZE), a, point); 
+    build_binary_op(ass, Mov, reg(R9, sz_64), rref8(RBP, sz_64, 4*ADDRESS_SIZE), a, point); 
 
 #if ABI == SYSTEM_V_64
     // memcpy (dest = rdi, src = rsi, size = rdx)
     // copy size into RDX
-    build_binary_op(ass, Mov, reg(RSI), reg(RSP), a, point);
-    build_binary_op(ass, Mov, reg(RDX), reg(R9), a, point);
+    build_binary_op(ass, Mov, reg(RSI, sz_64), reg(RSP, sz_64), a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), reg(R9, sz_64), a, point);
 
 #elif ABI == WIN_64
     // memcpy (dest = rcx, src = rdx, size = r8)
@@ -350,25 +350,25 @@ void build_store_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #endif
 
     // call memcpy
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&memcpy), a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&memcpy), a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
 #endif
 
     // Store return address in R9
-    build_binary_op(ass, Mov, reg(R9), rref8(RBP, 8), a, point);
+    build_binary_op(ass, Mov, reg(R9, sz_64), rref8(RBP, sz_64, 8), a, point);
 
     // set RSP = current RBP + 5*ADDRESS
-    build_binary_op(ass, Mov, reg(RSP), reg(RBP), a, point);
-    build_binary_op(ass, Add, reg(RSP), imm8(5*ADDRESS_SIZE), a, point);
+    build_binary_op(ass, Mov, reg(RSP, sz_64), reg(RBP, sz_64), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm8(5*ADDRESS_SIZE), a, point);
 
     // Restore the old RBP
-    build_binary_op(ass, Mov, reg(RBP), rref8(RBP, 0), a, point);
+    build_binary_op(ass, Mov, reg(RBP, sz_64), rref8(RBP, sz_64, 0), a, point);
 
     // push return address
-    build_unary_op(ass, Push, reg(R9), a, point);
+    build_unary_op(ass, Push, reg(R9, sz_64), a, point);
 
     build_nullary_op(ass, Ret, a, point);
 }
@@ -415,31 +415,31 @@ void build_load_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // 5. Push return address
 
     // Store size in R9
-    build_binary_op(ass, Mov, reg(R9), rref8(RBP, 3*ADDRESS_SIZE), a, point); 
+    build_binary_op(ass, Mov, reg(R9, sz_64), rref8(RBP, sz_64, 3*ADDRESS_SIZE), a, point); 
 
     // Stash return address in RAX
-    build_unary_op(ass, Pop, reg(RAX), a, point); 
+    build_unary_op(ass, Pop, reg(RAX, sz_64), a, point); 
 
     // Stash load src address
-    build_unary_op(ass, Pop, reg(RSI), a, point);
+    build_unary_op(ass, Pop, reg(RSI, sz_64), a, point);
 
     // Set RSP = RBP + 4 Addresses - Size (note that at this point, RSP = RBP
-    build_binary_op(ass, Add, reg(RSP), imm8(4*ADDRESS_SIZE), a, point);
-    build_binary_op(ass, Sub, reg(RSP), reg(R9), a, point);
+    build_binary_op(ass, Add, reg(RSP, sz_64), imm8(4*ADDRESS_SIZE), a, point);
+    build_binary_op(ass, Sub, reg(RSP, sz_64), reg(R9, sz_64), a, point);
 
     // Set RBP = [RBP]
-    build_binary_op(ass, Mov, reg(RBP), rref8(RBP, 0), a, point);
+    build_binary_op(ass, Mov, reg(RBP, sz_64), rref8(RBP, sz_64, 0), a, point);
 
     // Make sure return address is available when we Ret
-    build_unary_op(ass, Push, reg(RAX), a, point); 
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point); 
 
 #if ABI == SYSTEM_V_64
     // memcpy (dest = rdi, src = rsi, size = rdx)
-    build_binary_op(ass, Mov, reg(RDI), reg(RSP), a, point);
-    build_binary_op(ass, Add, reg(RDI), imm8(ADDRESS_SIZE), a, point);
+    build_binary_op(ass, Mov, reg(RDI, sz_64), reg(RSP, sz_64), a, point);
+    build_binary_op(ass, Add, reg(RDI, sz_64), imm8(ADDRESS_SIZE), a, point);
 
     //build_binary_op(ass, Mov, reg(RSI), reg(RSP), a, point);
-    build_binary_op(ass, Mov, reg(RDX), reg(R9), a, point);
+    build_binary_op(ass, Mov, reg(RDX, sz_64), reg(R9, sz_64), a, point);
 
 #elif ABI == WIN_64
     // memcpy (dest = rcx, src = rdx, size = r8)
@@ -454,8 +454,8 @@ void build_load_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #endif
 
     // copy memcpy into RCX & call
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&memcpy), a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&memcpy), a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
@@ -467,14 +467,14 @@ void build_load_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 
 void build_realloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // realloc : Proc (Address U64) Unit
-    build_unary_op(ass, Pop, reg(RAX), a, point);
+    build_unary_op(ass, Pop, reg(RAX, sz_64), a, point);
 
 #if ABI == SYSTEM_V_64
     // realloc (ptr = rdi, size = rsi)
     // copy size into RDX
-    build_unary_op(ass, Pop, reg(RSI), a, point);
-    build_unary_op(ass, Pop, reg(RDI), a, point);
-    build_unary_op(ass, Push, reg(RAX), a, point);
+    build_unary_op(ass, Pop, reg(RSI, sz_64), a, point);
+    build_unary_op(ass, Pop, reg(RDI, sz_64), a, point);
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 
 #elif ABI == WIN_64
     // realloc (ptr = RCX, size = RDX)
@@ -485,16 +485,16 @@ void build_realloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 #endif
 
 
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&realloc),  a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&realloc),  a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
 #endif
 
-    build_unary_op(ass, Pop, reg(R9), a, point);
-    build_unary_op(ass, Push, reg(RAX), a, point);
-    build_unary_op(ass, Push, reg(R9), a, point);
+    build_unary_op(ass, Pop, reg(R9, sz_64), a, point);
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
+    build_unary_op(ass, Push, reg(R9, sz_64), a, point);
 
     build_nullary_op(ass, Ret, a, point);
     
@@ -502,13 +502,13 @@ void build_realloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
 
 void build_malloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // malloc : Proc (U64) Unit
-    build_unary_op(ass, Pop, reg(RAX), a, point);
+    build_unary_op(ass, Pop, reg(RAX, sz_64), a, point);
 
 #if ABI == SYSTEM_V_64
     // memcpy (dest = rdi, src = rsi, size = rdx)
     // copy size into RDX
-    build_unary_op(ass, Pop, reg(RDI), a, point);
-    build_unary_op(ass, Push, reg(RAX), a, point);
+    build_unary_op(ass, Pop, reg(RDI, sz_64), a, point);
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 
 #elif ABI == WIN_64
     build_unary_op(ass, Pop, reg(RCX), a, point);
@@ -520,29 +520,29 @@ void build_malloc_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     /* build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&malloc_dyn_var),  a, point); */
     /* build_unary_op(ass, Call, reg(RAX), a, point); */
 
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&malloc),  a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&malloc),  a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);
 #endif
 
-    build_unary_op(ass, Pop, reg(R9), a, point);
-    build_unary_op(ass, Push, reg(RAX), a, point);
-    build_unary_op(ass, Push, reg(R9), a, point);
+    build_unary_op(ass, Pop, reg(R9, sz_64), a, point);
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
+    build_unary_op(ass, Push, reg(R9, sz_64), a, point);
 
     build_nullary_op(ass, Ret, a, point);
 }
 
 void build_free_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     // free : Proc (Address) Unit
-    build_unary_op(ass, Pop, reg(RAX), a, point);
+    build_unary_op(ass, Pop, reg(RAX, sz_64), a, point);
 
 #if ABI == SYSTEM_V_64
     // free (dest = rdi)
     // copy address into RDI
-    build_unary_op(ass, Pop, reg(RDI), a, point);
-    build_unary_op(ass, Push, reg(RAX), a, point);
+    build_unary_op(ass, Pop, reg(RDI, sz_64), a, point);
+    build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 
 #elif ABI == WIN_64
     // free (addr = rcx)
@@ -552,8 +552,8 @@ void build_free_fn(Assembler* ass, Allocator* a, ErrorPoint* point) {
     build_binary_op(ass, Sub, reg(RSP), imm32(32), a, point);
 #endif
 
-    build_binary_op(ass, Mov, reg(RAX), imm64((uint64_t)&free),  a, point);
-    build_unary_op(ass, Call, reg(RAX), a, point);
+    build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)&free),  a, point);
+    build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
 
 #if ABI == WIN_64
     build_binary_op(ass, Add, reg(RSP), imm32(32), a, point);

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -661,7 +661,7 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
     // TODO: we use int64_t as it has the requisite size (8 bytes)
     // for pico values: currently don't support non-64 bit values 
-    int64_t former;
+    TermFormer former;
     //TermFormer former;
     type.sort = TPrim;
     type.prim = TFormer;

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -825,12 +825,16 @@ size_t pi_align_of(PiType type) {
             return sizeof(uint8_t);
         case Address:
         case Int_64:
+        case UInt_64:
             return sizeof(int64_t);
         case Int_32:
+        case UInt_32:
             return sizeof(int32_t);
         case Int_16:
+        case UInt_16:
             return sizeof(int16_t);
         case Int_8:
+        case UInt_8:
             return sizeof(int8_t);
         case TFormer:
             return sizeof(TermFormer);

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -302,12 +302,12 @@ Document* pretty_pi_value(void* val, PiType* type, Allocator* a) {
         }
         case UInt_16: {
             uint16_t* uival = (uint16_t*) val;
-            out =  pretty_i16(*uival, a);
+            out =  pretty_u16(*uival, a);
             break;
         }
         case UInt_8: {
             uint8_t* uival = (uint8_t*) val;
-            out =  pretty_i8(*uival, a);
+            out =  pretty_u8(*uival, a);
             break;
         }
         case TFormer:  {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -257,7 +257,7 @@ Document* pretty_pi_value(void* val, PiType* type, Allocator* a) {
             break;
         }
         case Bool:  {
-            uint64_t* uival = (uint64_t*) val;
+            uint8_t* uival = (uint8_t*) val;
             if (*uival == 0) {
                 out = mk_str_doc(mv_string(":false"), a);
             } else {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -708,6 +708,20 @@ Document* pretty_type(PiType* type, Allocator* a) {
     return out;
 }
 
+size_t pi_size_align(size_t size, size_t align) {
+    size_t rem = size % align;
+    size_t pad = rem == 0 ? 0 : align - rem;
+    return size + pad;
+}
+
+size_t pi_stack_round(size_t in) {
+    return pi_size_align(in, 8);
+}
+
+size_t pi_stack_size_of(PiType type) {
+    return pi_stack_round(pi_size_of(type));
+}
+
 size_t pi_size_of(PiType type) {
     switch (type.sort) {
     case TPrim:
@@ -718,12 +732,16 @@ size_t pi_size_of(PiType type) {
             return sizeof(uint8_t);
         case Address:
         case Int_64:
+        case UInt_64:
             return sizeof(int64_t);
         case Int_32:
+        case UInt_32:
             return sizeof(int32_t);
         case Int_16:
+        case UInt_16:
             return sizeof(int16_t);
         case Int_8:
+        case UInt_8:
             return sizeof(int8_t);
         case TFormer:
             return sizeof(TermFormer);

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -714,12 +714,12 @@ size_t pi_size_align(size_t size, size_t align) {
     return size + pad;
 }
 
-size_t pi_stack_round(size_t in) {
+size_t pi_stack_align(size_t in) {
     return pi_size_align(in, 8);
 }
 
 size_t pi_stack_size_of(PiType type) {
-    return pi_stack_round(pi_size_of(type));
+    return pi_stack_align(pi_size_of(type));
 }
 
 size_t pi_size_of(PiType type) {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -708,18 +708,12 @@ Document* pretty_type(PiType* type, Allocator* a) {
     return out;
 }
 
-
-size_t pi_mono_size_of(PiType type) {
-    return pi_size_of(type);
-}
-
 size_t pi_size_of(PiType type) {
     switch (type.sort) {
     case TPrim:
         switch (type.prim) {
         case Unit:
             return 0;
-        /*
         case Bool:
             return sizeof(uint8_t);
         case Address:
@@ -732,12 +726,11 @@ size_t pi_size_of(PiType type) {
         case Int_8:
             return sizeof(int8_t);
         case TFormer:
-            return sizeof(TermFormer); // sizeof(pi_term_former_t);
-        */
+            return sizeof(TermFormer);
         default:
-            return sizeof(uint64_t);
+            panic(mv_string("pi-size-of: unrecognized primitive."));
         }
-        return sizeof(uint64_t);
+        break;
     case TProc:
         return sizeof(uint64_t);
     case TStruct: {
@@ -803,6 +796,90 @@ size_t pi_size_of(PiType type) {
         panic(mv_string("pi_size_of received invalid type."));
     }
 }
+
+size_t pi_align_of(PiType type) {
+    switch (type.sort) {
+    case TPrim:
+        switch (type.prim) {
+        case Unit:
+            return 0;
+        case Bool:
+            return sizeof(uint8_t);
+        case Address:
+        case Int_64:
+            return sizeof(int64_t);
+        case Int_32:
+            return sizeof(int32_t);
+        case Int_16:
+            return sizeof(int16_t);
+        case Int_8:
+            return sizeof(int8_t);
+        case TFormer:
+            return sizeof(TermFormer);
+        default:
+            panic(mv_string("pi_align_of received invalid primitive"));
+        }
+        return sizeof(uint64_t);
+    case TProc:
+        return sizeof(uint64_t);
+    case TStruct: {
+        size_t align = 0; 
+        for (size_t i = 0; i < type.structure.fields.len; i++) {
+            size_t field_align = pi_align_of(*(PiType*)type.structure.fields.data[i].val);
+            // align = max(align, field_align)
+            align = align > field_align ? align : field_align;
+        }
+        return align;
+    }
+    case TEnum: {
+        size_t align = 0; 
+        for (size_t i = 0; i < type.enumeration.variants.len; i++) {
+            PtrArray types = *(PtrArray*)type.enumeration.variants.data[i].val;
+            for (size_t i = 0; i < types.len; i++) {
+                // Note: Data is padded to be 8-byte aligned!
+                // TODO (FEAT): Make generic on padding size?
+                size_t field_align = pi_align_of(*(PiType*)types.data[i]);
+                // accumulate max
+                // size_t padding = field_size % 8 == 0 ? 0 : 8 - (field_size % 8);
+                align += field_align > align ? field_align : align;
+            }
+        }
+        // Note: this will set it to max, we should shrink the tag size (maybe 16 bits? variable bits?)
+        return 8 > align ? 8 : align;
+    }
+
+    case TReset: {
+    case TResumeMark: 
+    case TDynamic:
+        return ADDRESS_ALIGN;
+    }
+    case TDistinct: {
+        return pi_align_of(*type.distinct.type);
+    }
+    case TTrait:
+        panic(mv_string("pi_align_of received invalid type: Trait."));
+        break;
+    case TTraitInstance:
+        return ADDRESS_ALIGN;
+        break;
+    case TAll: {
+        return sizeof(void*);
+    }
+    case TFam: {
+        panic(mv_string("pi_align_of received invalid type: Family."));
+    }
+    case TKind: 
+    case TConstraint: 
+        return sizeof(void*);
+    case TUVar:
+        panic(mv_string("pi_align_of received invalid type: UVar."));
+    case TUVarDefaulted:
+        panic(mv_string("pi_align_of received invalid type: UVar with Default."));
+    default:
+        panic(mv_string("pi_align_of received invalid type."));
+    }
+}
+
 PiType* mk_uvar(UVarGenerator* gen, Allocator* a) {
     PiType* uvar = mem_alloc(sizeof(PiType), a);
     uvar->sort = TUVar; 

--- a/src/platform/memory/executable.c
+++ b/src/platform/memory/executable.c
@@ -136,13 +136,17 @@ void* alloc_medium(size_t size, exec_context* ctx) {
 }
 
 void* alloc_large(size_t size, exec_context* ctx) {
-    LargeBlock* new = mem_alloc(sizeof(MediumBlock), ctx->metadata_allocator);
+    LargeBlock* new = mem_alloc(sizeof(LargeBlock), ctx->metadata_allocator);
     new->block_memory = alloc_ex_mem(size);
     new->next = NULL;
-    ctx->large_blocks_end = new;
 
     LargeBlock* blk = ctx->large_blocks_end;
     if (blk) blk->next = new;
+    ctx->large_blocks_end = new;
+
+    if (!ctx->large_blocks) {
+        ctx->large_blocks = new;
+    }
 
     return new->block_memory.data;
 }

--- a/src/platform/memory/executable.c
+++ b/src/platform/memory/executable.c
@@ -60,32 +60,32 @@ void free_ex_mem(ex_mem mem) {
 // -----------------------------------------------------------------------------
 
 // Medium blocks
-typedef struct small_block {
+typedef struct SmallBlock {
     ex_mem block_memory;
     size_t num_chunks;
     U8Array free_slots;
-} small_block;
+} SmallBlock;
 static const size_t small_chunk_size = 8;
 
-typedef struct medium_block {
+typedef struct MediumBlock {
     ex_mem block_memory;
-    struct medium_block* next;
-} medium_block;
+    struct MediumBlock* next;
+} MediumBlock;
 
-typedef struct large_block {
+typedef struct LargeBlock {
     ex_mem block_memory;
-    struct large_block* next;
-} large_block;
+    struct LargeBlock* next;
+} LargeBlock;
 
 typedef struct exec_context {
     // Blocks
     PtrArray small_blocks;
 
-    medium_block* medium_blocks;
-    medium_block* medium_blocks_end;
+    MediumBlock* medium_blocks;
+    MediumBlock* medium_blocks_end;
 
-    large_block* large_blocks;
-    large_block* large_blocks_end;
+    LargeBlock* large_blocks;
+    LargeBlock* large_blocks_end;
 
     size_t blocksize;
     
@@ -97,7 +97,7 @@ typedef struct exec_context {
 
 void* alloc_small(exec_context* ctx) {
     for (size_t block_idx = 0; block_idx < ctx->small_blocks.len; block_idx++) {
-        small_block b = *(small_block*)ctx->small_blocks.data[block_idx];
+        SmallBlock b = *(SmallBlock*)ctx->small_blocks.data[block_idx];
         for (size_t i = 0; i < b.num_chunks; i++) {
             if (b.free_slots.data[i]) {
                 b.free_slots.data[i] = false;
@@ -106,9 +106,10 @@ void* alloc_small(exec_context* ctx) {
         }
     }
     // there was no free slot
-    small_block* sb = (small_block*)mem_alloc(sizeof(small_block), ctx->metadata_allocator);
+    SmallBlock* sb = (SmallBlock*)mem_alloc(sizeof(SmallBlock), ctx->metadata_allocator);
     sb->block_memory = alloc_ex_mem(ctx->blocksize);
-    sb->block_memory.size = ctx->blocksize / 8;
+    sb->block_memory.size = ctx->blocksize;
+    sb->num_chunks = ctx->blocksize / 8;
     sb->free_slots = mk_u8_array(sb->num_chunks, ctx->metadata_allocator);
     for (size_t i = 0; i < sb->num_chunks; i++) {
         push_u8(0, &sb->free_slots);
@@ -119,11 +120,11 @@ void* alloc_small(exec_context* ctx) {
 }
 
 void* alloc_medium(size_t size, exec_context* ctx) {
-    medium_block* new = mem_alloc(sizeof(medium_block), ctx->metadata_allocator);
+    MediumBlock* new = mem_alloc(sizeof(MediumBlock), ctx->metadata_allocator);
     new->block_memory = alloc_ex_mem(size);
     new->next = NULL;
 
-    medium_block* blk = ctx->medium_blocks_end;
+    MediumBlock* blk = ctx->medium_blocks_end;
     if (blk) blk->next = new;
     ctx->medium_blocks_end = new;
 
@@ -135,12 +136,12 @@ void* alloc_medium(size_t size, exec_context* ctx) {
 }
 
 void* alloc_large(size_t size, exec_context* ctx) {
-    large_block* new = mem_alloc(sizeof(medium_block), ctx->metadata_allocator);
+    LargeBlock* new = mem_alloc(sizeof(MediumBlock), ctx->metadata_allocator);
     new->block_memory = alloc_ex_mem(size);
     new->next = NULL;
     ctx->large_blocks_end = new;
 
-    large_block* blk = ctx->large_blocks_end;
+    LargeBlock* blk = ctx->large_blocks_end;
     if (blk) blk->next = new;
 
     return new->block_memory.data;
@@ -165,7 +166,7 @@ void* exec_realloc(void* ptr, size_t new_size, void* ctx) {
 
 bool free_small(void* ptr, exec_context* ctx) {
     for (size_t i = 0; i < ctx->small_blocks.len; i++) {
-        small_block block = *(small_block*)(ctx->small_blocks.data[i]);
+        SmallBlock block = *(SmallBlock*)(ctx->small_blocks.data[i]);
         const void* data = block.block_memory.data;
         size_t offset = 0;
         // check for each element of to_free
@@ -180,9 +181,9 @@ bool free_small(void* ptr, exec_context* ctx) {
     return false;
 }
 bool free_medium(void* ptr, exec_context* ctx) {
-    medium_block* blk_prev = NULL;
-    medium_block** blk_ptr = &ctx->medium_blocks;
-    medium_block* blk = ctx->medium_blocks;
+    MediumBlock* blk_prev = NULL;
+    MediumBlock** blk_ptr = &ctx->medium_blocks;
+    MediumBlock* blk = ctx->medium_blocks;
     while (blk != NULL) {
         if (ptr == blk) {
             *blk_ptr = blk->next;
@@ -202,9 +203,9 @@ bool free_medium(void* ptr, exec_context* ctx) {
 }
 
 bool free_large(void* ptr, exec_context* ctx) {
-    large_block* blk_prev = NULL;
-    large_block** blk_ptr = &ctx->large_blocks;
-    large_block* blk = ctx->large_blocks;
+    LargeBlock* blk_prev = NULL;
+    LargeBlock** blk_ptr = &ctx->large_blocks;
+    LargeBlock* blk = ctx->large_blocks;
     while (blk != NULL) {
         if (ptr == blk) {
             *blk_ptr = blk->next;
@@ -256,22 +257,23 @@ void release_executable_allocator(Allocator a) {
     Allocator* mda = ctx->metadata_allocator;
 
     for (size_t i = 0; i < ctx->small_blocks.len; i++) {
-        small_block* b = (small_block*) ctx->small_blocks.data[i];
+        SmallBlock* b = (SmallBlock*) ctx->small_blocks.data[i];
         free_ex_mem(b->block_memory);
+        sdelete_u8_array(b->free_slots);
         mem_free(b, mda);
     }
     sdelete_ptr_array(ctx->small_blocks);
 
-    medium_block* mb = ctx->medium_blocks;
+    MediumBlock* mb = ctx->medium_blocks;
     while (mb) {
-        medium_block* next = mb->next;
+        MediumBlock* next = mb->next;
         mem_free(mb, mda);
         mb = next;
     }
 
-    large_block* lb = ctx->large_blocks;
+    LargeBlock* lb = ctx->large_blocks;
     while (lb) {
-        large_block* next = lb->next;
+        LargeBlock* next = lb->next;
         mem_free(lb, mda);
         lb = next;
     }


### PR DESCRIPTION
Major changes
+ Add primitive numeric operations for 8, 16, 32 and 64-bit signed and unsigned integers.
+ Greatly extended polymorphic codegen to accommodate alternate sizes and alignments
+ Modules can now nest inside each other (although there is not yet syntax for this)
+ Assembler now supports non 64-bit registers and memory locations

Multiple bugfixes and improvements
+ Instances now work with `def` and correctly accommodate alignment
+ Fixed operand encoding for SHL/SHR
+ Can accommodate multi-byte opcodes when assembling binary instructions
+ Added support for CMov instructions
+ Added support for unsigned comparison