### PR TITLE
Add macros

### DIFF
--- a/include/data/array.h
+++ b/include/data/array.h
@@ -8,6 +8,7 @@
 ARRAY_HEADER(void*, ptr, Ptr)
 
 ARRAY_HEADER(uint8_t, u8, U8)
+void add_u8_chunk(uint8_t* chunk, size_t memsize, U8Array* array);
 
 ARRAY_HEADER(uint32_t, u32, U32)
 

--- a/include/data/meta/array_header.h
+++ b/include/data/meta/array_header.h
@@ -6,9 +6,9 @@
 
 #define ARRAY_HEADER(type, fprefix, tprefix)                            \
     typedef struct tprefix##Array {                                     \
-        size_t size;                                                    \
-        size_t len;                                                     \
         type* data;                                                     \
+        size_t len;                                                     \
+        size_t size;                                                    \
         Allocator* gpa;                                                 \
     } tprefix##Array;                                                   \
                                                                         \

--- a/include/data/string.h
+++ b/include/data/string.h
@@ -18,6 +18,7 @@ void delete_string(String str, Allocator* a);
 String copy_string(const String str, Allocator* a);
 
 String string_from_UTF_32(U32Array arr, Allocator* a);
+String string_from_ASCII(U8Array arr, Allocator* a);
 
 int string_cmp(const String lhs, const String rhs);
 String string_cat(const String lhs, const String rhs, Allocator* a);

--- a/include/pico/codegen/codegen.h
+++ b/include/pico/codegen/codegen.h
@@ -1,39 +1,17 @@
 #ifndef __PICO_CODEGEN_CODEGEN_H
 #define __PICO_CODEGEN_CODEGEN_H
 
-#include "data/meta/array_header.h"
-
-#include "assembler/assembler.h"
-
 #include "pico/binding/environment.h"
 #include "pico/syntax/syntax.h"
-#include "pico/data/sym_sarr_amap.h"
-
-/* Brainstorm for side-allocations
- * Two extra bits: 
- *  + Data storage for string/array literals
- *  + Data storage for procedures/functions
- * We also need to relate these "Side allocations" for definitions/storage
- * Thus, for each, of data/code store an array of:
- *  (origin: bool, origin_offset: size_t, array_index: size_t)
- */
 
 typedef struct {
-    size_t origin_offset;
-    size_t data_index;
-} LinkMetaData;
+    U8Array* data_aux;
+    Assembler* code_aux;
+    Assembler* target;
+} Target;
 
-ARRAY_HEADER(LinkMetaData, link_meta, LinkMeta)
+LinkData generate_toplevel(TopLevel top, Environment* env, Target target, Allocator* a, ErrorPoint* point);
 
-typedef struct {
-    SymSArrAMap backlinks;
-
-    LinkMetaArray code_metadata;
-    LinkMetaArray data_metadata;
-} GenResult;
-
-GenResult generate_toplevel(TopLevel top, Environment* env, Assembler* ass, Allocator* a, ErrorPoint* point);
-
-GenResult generate_expr(Syntax* syn, Environment* env, Assembler* ass, Allocator* a, ErrorPoint* point);
+LinkData generate_expr(Syntax* syn, Environment* env, Target target, Allocator* a, ErrorPoint* point);
 
 #endif

--- a/include/pico/codegen/internal.h
+++ b/include/pico/codegen/internal.h
@@ -2,13 +2,11 @@
 #define __PICO_CODEGEN_INTERNAL_H
 
 #include "data/meta/array_header.h"
-#include "data/array.h"
 #include "assembler/assembler.h"
 
 #include "pico/data/sym_sarr_amap.h"
 #include "pico/syntax/syntax.h"
 #include "pico/values/values.h"
-
 #include "pico/codegen/codegen.h"
 
 /* Utility functions shared across code generation */
@@ -21,17 +19,13 @@ typedef struct {
 ARRAY_HEADER(ToGenerate, to_gen, ToGen);
 
 typedef struct {
-    //SymSArrAMap backlinks;
     SymSArrAMap gotolinks;
     LinkData links;
-    //ToGenArray to_generate;
-    
-    /* U8Array bytes; */
-    /* LinkMetaArray data_meta; */
-    /* LinkMetaArray code_meta; */
 } InternalLinkData;
 
 void backlink_global(Symbol sym, size_t offset, InternalLinkData* links, Allocator* a);
+void backlink_code(Target target, size_t offset, InternalLinkData* links);
+void backlink_data(Target target, size_t offset, InternalLinkData* links);
 void backlink_goto(Symbol sym, size_t offset, InternalLinkData* links, Allocator* a);
 
 void generate_monomorphic_copy(Regname dest, Regname src, size_t size, Assembler* ass, Allocator* a, ErrorPoint* point);

--- a/include/pico/codegen/internal.h
+++ b/include/pico/codegen/internal.h
@@ -21,17 +21,18 @@ typedef struct {
 ARRAY_HEADER(ToGenerate, to_gen, ToGen);
 
 typedef struct {
-    SymSArrAMap backlinks;
+    //SymSArrAMap backlinks;
     SymSArrAMap gotolinks;
-    ToGenArray to_generate;
+    LinkData links;
+    //ToGenArray to_generate;
     
-    U8Array bytes;
-    LinkMetaArray data_meta;
-    LinkMetaArray code_meta;
-} LinkData;
+    /* U8Array bytes; */
+    /* LinkMetaArray data_meta; */
+    /* LinkMetaArray code_meta; */
+} InternalLinkData;
 
-void backlink_global(Symbol sym, size_t offset, LinkData* links, Allocator* a);
-void backlink_goto(Symbol sym, size_t offset, LinkData* links, Allocator* a);
+void backlink_global(Symbol sym, size_t offset, InternalLinkData* links, Allocator* a);
+void backlink_goto(Symbol sym, size_t offset, InternalLinkData* links, Allocator* a);
 
 void generate_monomorphic_copy(Regname dest, Regname src, size_t size, Assembler* ass, Allocator* a, ErrorPoint* point);
 void generate_monomorphic_swap(Regname loc1, Regname loc2, size_t size, Assembler* ass, Allocator* a, ErrorPoint* point);

--- a/include/pico/codegen/polymorphic.h
+++ b/include/pico/codegen/polymorphic.h
@@ -1,12 +1,9 @@
 #ifndef __PICO_CODEGEN_POLYMORPHIC_H
 #define __PICO_CODEGEN_POLYMORPHIC_H
 
-#include "data/result.h"
-
-#include "assembler/assembler.h"
-
 #include "pico/binding/address_env.h"
 #include "pico/syntax/syntax.h"
+#include "pico/codegen/codegen.h"
 #include "pico/codegen/internal.h"
 
 void generate_polymorphic(SymbolArray arr, Syntax syn, AddressEnv* env, Target target, InternalLinkData* links, Allocator* a, ErrorPoint* point);

--- a/include/pico/codegen/polymorphic.h
+++ b/include/pico/codegen/polymorphic.h
@@ -7,9 +7,8 @@
 
 #include "pico/binding/address_env.h"
 #include "pico/syntax/syntax.h"
-#include "pico/data/sym_sarr_amap.h"
 #include "pico/codegen/internal.h"
 
-void generate_polymorphic(SymbolArray arr, Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allocator* a, ErrorPoint* point);
+void generate_polymorphic(SymbolArray arr, Syntax syn, AddressEnv* env, Target target, InternalLinkData* links, Allocator* a, ErrorPoint* point);
 
 #endif

--- a/include/pico/eval/call.h
+++ b/include/pico/eval/call.h
@@ -35,8 +35,6 @@ typedef struct EvalResult {
     };
 } EvalResult;
 
-Target prep_target(Target target);
-
 EvalResult pico_run_toplevel(TopLevel top, Target target, LinkData links, Module* module, Allocator* a, ErrorPoint* point);
 
 void* pico_run_expr(Target target, size_t size, Allocator* a, ErrorPoint* point);

--- a/include/pico/eval/call.h
+++ b/include/pico/eval/call.h
@@ -7,6 +7,7 @@
 #include "pretty/document.h"
 #include "pico/syntax/syntax.h"
 #include "pico/values/modular.h"
+#include "pico/codegen/codegen.h" // TOOD (ORGANISATION): Move link data out of codegen.h  
 
 
 // Utilities for calling Pico functions from C (adapt to the different calling convention)
@@ -34,9 +35,11 @@ typedef struct EvalResult {
     };
 } EvalResult;
 
-EvalResult pico_run_toplevel(TopLevel top, Assembler* ass, SymSArrAMap* backlinks, Module* module, Allocator* a, ErrorPoint* point);
+Target prep_target(Target target);
 
-void* pico_run_expr(Assembler* ass, size_t size, Allocator* a, ErrorPoint* point);
+EvalResult pico_run_toplevel(TopLevel top, Target target, LinkData links, Module* module, Allocator* a, ErrorPoint* point);
+
+void* pico_run_expr(Target target, size_t size, Allocator* a, ErrorPoint* point);
 
 Document* pretty_res(EvalResult res, Allocator* a);
 

--- a/include/pico/syntax/concrete.h
+++ b/include/pico/syntax/concrete.h
@@ -10,7 +10,7 @@
 /* This file describes the concrete syntax tree of pico. It is manipulated directly by L1 macros.
  */
 
-typedef enum {
+typedef enum : uint64_t {
     ABool,
     AIntegral,
     ASymbol,
@@ -27,14 +27,7 @@ typedef struct {
     };
 } Atom;
 
-AMAP_HEADER(Symbol, Atom, sym_atom, SymAtom)
-
-typedef enum {
-    RawList,
-    RawAtom,
-} RawTree_t;
-
-typedef enum {
+typedef enum : uint64_t {
     HNone,
     HExpression,
     HSpecial,
@@ -42,11 +35,23 @@ typedef enum {
 } SyntaxHint;
 
 typedef struct {
-    RawTree_t type;
     SyntaxHint hint;
+    PtrArray nodes;
+} Branch;
+
+AMAP_HEADER(Symbol, Atom, sym_atom, SymAtom)
+
+typedef enum : uint64_t {
+    RawAtom,
+    RawBranch,
+} RawTree_t;
+
+
+typedef struct {
+    RawTree_t type;
     union {
         Atom atom;
-        PtrArray nodes;
+        Branch branch;
     };
 } RawTree;
 

--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -36,7 +36,7 @@ typedef enum {
     // Terms & term formers
     SProcedure,
     SAll,
-    STransformer,
+    SMacro,
     SApplication,
     SAllApplication,
     SConstructor,

--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -63,6 +63,8 @@ typedef enum {
     SInTo,
     SOutOf,
     SDynAlloc,
+    SSizeOf,
+    SAlignOf,
     SModule,
 
     // Types & Type formers

--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -36,6 +36,7 @@ typedef enum {
     // Terms & term formers
     SProcedure,
     SAll,
+    STransformer,
     SApplication,
     SAllApplication,
     SConstructor,
@@ -284,6 +285,7 @@ struct Syntax {
 
         SynProcedure procedure;
         SynAll all;
+        Syntax* transformer;
         SynApp application;
         SynAllApp all_application;
         SynConstructor constructor;

--- a/include/pico/values/modular.h
+++ b/include/pico/values/modular.h
@@ -22,7 +22,6 @@ typedef struct {
     void* value;
     bool is_module;
     PiType type;
-    SymSArrAMap* backlinks;
 } ModuleEntry;
 
 typedef struct {
@@ -31,6 +30,66 @@ typedef struct {
     Symbol src_sym;
     Module* src;
 } InstanceSrc;
+
+/* Definitions and codegen. 
+ * Codegen is relatively simple: given an expression e.g. (+ 2 3) and an
+ * assembler, generate use the assembler to generate the code that corresponds
+ * to the expression, e.g. "mov 2, rax; add rax, 3; push rax". Complexity is introduced because:
+ * • Expressions may contain data such as strings. If the result is defined,
+ *   these may need to be copied into the defining module. 
+ * • Expressions may contain (or be) procedures, again, meaning that if defined
+ *   then the procedure code needs to be copied by the defining module.
+ * 
+ * To accommodate this, code generation has two copyable targets as follows: 
+ * • There is a 'eval segment' assembler, which is the entry-point to the experssion.
+ * • There is a 'code-segment' assembler, where output of procedure code within the
+ *   expression is put.
+ * 
+ * In order to facilitate copying of both code and data to new addresses,
+ * internal (absolute) pointers must be updated, and so link information has to
+ * be maintained.
+ * 
+ * As both the code and data are effectively byte-arrays, there are 4 pieces of
+ * link data: 
+ * | Matches chunks (addresses) in the | To indices in the | Name     |
+ * |-----------------------------------|-------------------|----------|
+ * | Eval Segment                      | Code Segment      | ec_links |
+ * | Eval Segment                      | Data Segment      | ed_links |
+ * | Code Segment                      | Code Segment      | cc_links |
+ * | Code Segment                      | Data Segment      | cd_links |
+ * | Data Segment                      | Code Segment      | N/A      |
+ * | Data Segment                      | Data Segment      | N/A      |
+ * 
+ * Note that the data segment is only for strings, so cannot have any links to
+ * other segments.
+ * 
+ * Finally, there are the 'external links', which are used to indicate locations
+ * in the code segment which are addresses of specific symbols (values). These
+ * locations need updating if the symbol is redefined.
+ * 
+ */
+
+typedef struct {
+    size_t origin_offset;
+    size_t data_index;
+} LinkMetaData;
+
+ARRAY_HEADER(LinkMetaData, link_meta, LinkMeta)
+
+typedef struct {
+    SymSArrAMap external_links;
+
+    LinkMetaArray ec_links;
+    LinkMetaArray ed_links;
+
+    LinkMetaArray cc_links;
+    LinkMetaArray cd_links;
+} LinkData;
+
+typedef struct {
+    U8Array data;
+    U8Array code;
+} Segments;
 
 // Package Interface
 Package* mk_package(Symbol name, Allocator* a);
@@ -42,8 +101,15 @@ Module* get_module(Symbol name, Package* package);
 Module* mk_module(ModuleHeader header, Package* pkg_parent, Module* parent, Allocator* a);
 void delete_module(Module* module);
 
-Result add_def(Module* module, Symbol name, PiType type, void* data); 
-Result add_fn_def(Module* module, Symbol name, PiType type, Assembler* fn, SymSArrAMap* backlinks); 
+// If we are going to define the result of evaluating (target), then it must be prepped
+// so that the code and data segments are owned by the module
+// This needs to be done BEFORE evaluation
+Segments prep_target(Module* module, Segments in_segments, Assembler* target, LinkData* links);
+
+// Add a value definition in to the module's namespace. Must be prepped (see above)
+Result add_def(Module* module, Symbol name, PiType type, void* data, Segments segments, LinkData* links); 
+
+// Add a module definition in to the module's namespace. 
 Result add_module_def(Module* module, Symbol name, Module* child); 
 
 ModuleEntry* get_def(Symbol sym, Module* module);

--- a/include/pico/values/modular.h
+++ b/include/pico/values/modular.h
@@ -70,8 +70,8 @@ typedef struct {
  */
 
 typedef struct {
-    size_t origin_offset;
-    size_t data_index;
+    size_t source_offset;
+    size_t dest_offset;
 } LinkMetaData;
 
 ARRAY_HEADER(LinkMetaData, link_meta, LinkMeta)

--- a/include/pico/values/stdlib.h
+++ b/include/pico/values/stdlib.h
@@ -18,6 +18,9 @@ void set_current_package(Package* current);
 void set_std_istream(IStream* current);
 void set_std_ostream(OStream* current);
 
+PiType* get_atom_type();
+PiType* get_syntax_type();
+
 Allocator* get_std_tmp_allocator();
 Allocator* set_std_tmp_allocator(Allocator* al);
 

--- a/include/pico/values/stdlib.h
+++ b/include/pico/values/stdlib.h
@@ -18,8 +18,8 @@ void set_current_package(Package* current);
 void set_std_istream(IStream* current);
 void set_std_ostream(OStream* current);
 
-PiType* get_atom_type();
 PiType* get_syntax_type();
+PiType* get_array_type();
 
 Allocator* get_std_tmp_allocator();
 Allocator* set_std_tmp_allocator(Allocator* al);

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -12,20 +12,21 @@ typedef struct PiType PiType;
 typedef struct UVarGenerator UVarGenerator;
 
 typedef enum {
-    Unit = 0b0000,
-    Bool = 0b0001,
-    Address = 0b0010,
-    TFormer = 0b0011,
+    Int_8  = 0b000,
+    Int_16 = 0b001,
+    Int_32 = 0b010,
+    Int_64 = 0b011,
 
-    Int_8  = 0b0100,
-    Int_16 = 0b0101,
-    Int_32 = 0b0110,
-    Int_64 = 0b0111,
+    UInt_8  = 0b100,
+    UInt_16 = 0b101,
+    UInt_32 = 0b110,
+    UInt_64 = 0b111,
 
-    UInt_8  = 0b1100,
-    UInt_16 = 0b1101,
-    UInt_32 = 0b1110,
-    UInt_64 = 0b1111,
+    Unit,
+    Bool,
+    Address,
+    TFormer,
+    TTransformer,
 } PrimType;
 
 typedef enum {
@@ -193,6 +194,13 @@ PiType mk_prim_type(PrimType t);
 PiType mk_dynamic_type(Allocator* a, PiType t);
 PiType mk_proc_type(Allocator* a, size_t nargs, ...);
 PiType mk_struct_type(Allocator* a, size_t nfields, ...);
+
+// Sample usage: mk_enum_type(a, 3,
+//   "Pair", 2, mk_prim_type(Int_64), mk_prim_type(Int_64),
+//   "Singleton", 1, mk_prim_type(Int_64),
+//   "None", 0)
+PiType mk_enum_type(Allocator* a, size_t nfields, ...);
+
 
 // Types from the standard library
 // Struct [.len U64] [.capacity U64] [.bytes Address]

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -115,13 +115,6 @@ typedef struct {
 } DistinctType;
 
 typedef struct {
-    PiType* body;
-    uint64_t id;
-    PtrArray* args;
-    void* source_module;
-} DistinctTypeApp;
-
-typedef struct {
     size_t nargs;
 } PiKind;
 
@@ -143,7 +136,6 @@ struct PiType {
         TraitInstance instance;
 
         DistinctType distinct;
-        DistinctTypeApp distinct_app;
 
         // From System Fω: variables, application, abstraction (exists, forall, lambda)
         uint64_t var;

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -26,7 +26,7 @@ typedef enum {
     Bool,
     Address,
     TFormer,
-    TTransformer,
+    TMacro,
 } PrimType;
 
 typedef enum {

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -184,7 +184,11 @@ PiType* type_app (PiType family, PtrArray args, Allocator* a);
 
 PiType mk_prim_type(PrimType t);
 PiType mk_dynamic_type(Allocator* a, PiType t);
+
+// Sample usage: mk_proc_type(a, 2, arg_1_ty, arg_2_ty, ret_ty)
 PiType mk_proc_type(Allocator* a, size_t nargs, ...);
+
+// Sample usage: mk_proc_type(a, 2, "field-1", field_1_ty, "field-2", arg_2_ty)
 PiType mk_struct_type(Allocator* a, size_t nfields, ...);
 
 // Sample usage: mk_enum_type(a, 3,
@@ -193,6 +197,11 @@ PiType mk_struct_type(Allocator* a, size_t nfields, ...);
 //   "None", 0)
 PiType mk_enum_type(Allocator* a, size_t nfields, ...);
 
+// Sample usage: mk_distinct_type(a, mk_prim_type(Address))
+PiType mk_distinct_type(Allocator* a, PiType inner);
+
+// Sample usage: mk_distinct_type(a, vars, mk_prim_type(Address))
+PiType mk_type_family(Allocator* a, SymbolArray vars, PiType body);
 
 // Types from the standard library
 // Struct [.len U64] [.capacity U64] [.bytes Address]

--- a/include/pico/values/values.h
+++ b/include/pico/values/values.h
@@ -69,6 +69,8 @@ typedef enum TermFormer {
     FInTo,
     FOutOf,
     FDynAlloc,
+    FSizeOf,
+    FAlignOf,
 
     // Type formers
     FProcType,

--- a/include/pico/values/values.h
+++ b/include/pico/values/values.h
@@ -43,6 +43,7 @@ typedef enum TermFormer {
     // Term Formers: value construction/destruction
     FProcedure,
     FAll,
+    FTransformer,
     FApplication,
     FVariant,
     FMatch,

--- a/include/pico/values/values.h
+++ b/include/pico/values/values.h
@@ -43,7 +43,7 @@ typedef enum TermFormer {
     // Term Formers: value construction/destruction
     FProcedure,
     FAll,
-    FTransformer,
+    FMacro,
     FApplication,
     FVariant,
     FMatch,

--- a/include/platform/machine_info.h
+++ b/include/platform/machine_info.h
@@ -36,7 +36,7 @@
    * ------------------
    * Argument Registers: RDI, RSI, RDX, RCX, R8, R9
    * 
-   * Nonvolatile: RBX, RSP, RBP, R12, R13, R14, R16
+   * Nonvolatile: RBX, RSP, RBP, R12, R13, R14, R15
    * Volatile: RAX, RCX, RDX, RSI, RDI, R8, R9, R10, R11
    */
 #define ABI SYSTEM_V_64

--- a/src/app/module_load.c
+++ b/src/app/module_load.c
@@ -185,21 +185,23 @@ void run_script_from_istream(IStream* in, OStream* serr, Module* current, Alloca
         pico_run_toplevel(abs, target, links, current, &arena, &point);
     }
 
-    return;
-
  on_exit:
-    clear_assembler(target.target);
-    clear_assembler(target.code_aux);
+    delete_assembler(target.target);
+    delete_assembler(target.code_aux);
     sdelete_u8_array(*target.data_aux);
+    mem_free(target.data_aux, a);
     release_arena_allocator(arena);
+    release_executable_allocator(exec);
     return;
 
  on_error:
     write_string(point.error_message, serr);
     write_string(mv_string("\n"), serr);
-    clear_assembler(target.target);
-    clear_assembler(target.code_aux);
+    delete_assembler(target.target);
+    delete_assembler(target.code_aux);
     sdelete_u8_array(*target.data_aux);
+    mem_free(target.data_aux, a);
     release_arena_allocator(arena);
+    release_executable_allocator(exec);
     return;
 }

--- a/src/app/module_load.c
+++ b/src/app/module_load.c
@@ -23,11 +23,11 @@ void load_module_from_istream(IStream* in, OStream* serr, Package* package, Modu
     };
     *target.data_aux = mk_u8_array(256, a);
 
-    ErrorPoint point;
-    if (catch_error(point)) goto on_error;
-
     ModuleHeader* volatile header = NULL;
     Module* volatile module = NULL;
+
+    ErrorPoint point;
+    if (catch_error(point)) goto on_error;
 
     // Step 1: Parse Module header, get the result (ph_res)
     // TODO (BUG) header & module (below) will be uninitialized if parse fails.

--- a/src/data/array.c
+++ b/src/data/array.c
@@ -7,6 +7,19 @@ ARRAY_IMPL(void*, ptr, Ptr)
 
 ARRAY_IMPL(uint8_t, u8, U8)
 
+void add_u8_chunk(uint8_t* chunk, size_t memsize, U8Array* array) {
+    // TODO (BUG) assumes sizeof(uint_t) == 1.
+    if (array->len + memsize < array->size) {
+        memcpy(array->data + array->len, chunk, memsize);
+        array->len += memsize;
+    } else {
+        // TODO (BUG): realloc - must account for failure (return NULL)
+        array->data = mem_realloc(array->data, memsize + array->size, array->gpa);
+        memcpy(array->data + array->len, chunk, memsize);
+        array->len += memsize;
+    }
+}
+
 ARRAY_IMPL(uint32_t, u32, U32)
 
 ARRAY_IMPL(uint64_t, u64, U64)

--- a/src/data/string.c
+++ b/src/data/string.c
@@ -54,6 +54,18 @@ String string_from_UTF_32(U32Array arr, Allocator* a) {
     return out;
 }
 
+String string_from_ASCII(U8Array arr, Allocator* a) {
+    // Step1: calcluate byte length (initialize to 1 for NULL-terminator)
+    size_t numbytes = 1 + arr.len;
+    String out;
+    out.memsize = numbytes * sizeof(uint8_t);
+    out.bytes = mem_alloc(out.memsize, a);
+
+    memcpy(out.bytes, arr.data, out.memsize - sizeof(uint8_t));
+    out.bytes[out.memsize - 1] = 0;
+    return out;
+}
+
 int string_cmp(const String lhs, const String rhs) {
     // TODO: this assumed char == uint8_t. Implement thine own
     //       method, instead of relying on strcmp!

--- a/src/main.c
+++ b/src/main.c
@@ -120,13 +120,11 @@ bool repl_iter(IStream* cin, OStream* cout, Allocator* a, Allocator* exec, Modul
         write_string(mv_string("Execute Assembly:\n"), cout);
         doc = pretty_assembler(gen_target.target, &arena);
         write_doc(doc, cout);
-        write_string(mv_string("Code Segment:\n"), cout);
-        doc = pretty_assembler(gen_target.target, &arena);
+        write_string(mv_string("\nCode Segment:\n"), cout);
+        doc = pretty_assembler(gen_target.code_aux, &arena);
         write_doc(doc, cout);
-        write_string(mv_string("Data Segment not yet printed!\n"), cout);
-        /* doc = pretty_assembler(gen_target.target, &arena); */
-        /* write_doc(doc, cout); */
-        write_string(mv_string("\n"), cout);
+        write_string(mv_string("\nData Segment:\n"), cout);
+        write_string(string_from_ASCII(*gen_target.data_aux, &arena), cout);
     }
 
     // -------------------------------------------------------------------------

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -356,6 +356,19 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         };
         break;
     }
+    case FTransformer: {
+        if (raw.nodes.len <= 2) {
+            throw_error(point, mv_string("Malformed transformer expression: expects at least 1 arg."));
+        }
+        RawTree* body = raw.nodes.len == 2 ? raw.nodes.data[1] : raw_slice(&raw, 1, a);
+        Syntax* transformer = abstract_expr_i(*body, env, a, point);
+
+        *res = (Syntax) {
+            .type = STransformer,
+            .transformer = transformer,
+        };
+        break;
+    }
     case FApplication: {
         res = mk_application(raw, env, a, point);
         break;

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -359,8 +359,8 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         break;
     }
     case FMacro: {
-        if (raw.nodes.len <= 2) {
-            throw_error(point, mv_string("Malformed transformer expression: expects at least 1 arg."));
+        if (raw.nodes.len < 2) {
+            throw_error(point, mv_string("Malformed macro expression: expects at least 1 arg."));
         }
         RawTree* body = raw.nodes.len == 2 ? raw.nodes.data[1] : raw_slice(&raw, 1, a);
         Syntax* transformer = abstract_expr_i(*body, env, a, point);

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -922,6 +922,32 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         };
         break;
     }
+    case FSizeOf: {
+        if (raw.nodes.len != 2) {
+            throw_error(point, mv_string("Term former 'size-of' expects precisely 1 argument!"));
+        }
+
+        Syntax* term = abstract_expr_i(*(RawTree*)raw.nodes.data[1], env, a, point);
+        
+        *res = (Syntax) {
+            .type = SSizeOf,
+            .size = term,
+        };
+        break;
+    }
+    case FAlignOf: {
+        if (raw.nodes.len != 2) {
+            throw_error(point, mv_string("Term former 'align-of' expects precisely 1 argument!"));
+        }
+
+        Syntax* term = abstract_expr_i(*(RawTree*)raw.nodes.data[1], env, a, point);
+        
+        *res = (Syntax) {
+            .type = SAlignOf,
+            .size = term,
+        };
+        break;
+    }
     case FProcType: {
         if (raw.nodes.len != 3) {
             throw_error(point, mv_string("Wrong number of terms to proc type former."));

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -356,7 +356,7 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         };
         break;
     }
-    case FTransformer: {
+    case FMacro: {
         if (raw.nodes.len <= 2) {
             throw_error(point, mv_string("Malformed transformer expression: expects at least 1 arg."));
         }
@@ -364,7 +364,7 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         Syntax* transformer = abstract_expr_i(*body, env, a, point);
 
         *res = (Syntax) {
-            .type = STransformer,
+            .type = SMacro,
             .transformer = transformer,
         };
         break;

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -206,8 +206,8 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
         all_ty->binder.body = untyped->all.body->ptype;
         break;
     }
-    case STransformer: {
-        // Transformer inner type: 
+    case SMacro: {
+        // Macro inner type: 
         // proc [Array Syntax] Syntax
         // where syntax = ...
         // 
@@ -220,7 +220,7 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
         PiType* t = mem_alloc(sizeof(PiType), a);
         *t = (PiType) {
             .sort = TPrim,
-            .prim = TTransformer,
+            .prim = TMacro,
         };
         untyped->ptype = t;
         break;
@@ -961,7 +961,7 @@ void instantiate_implicits(Syntax* syn, TypeEnv* env, Allocator* a, ErrorPoint* 
         pop_types(env, syn->all.args.len);
         break;
     }
-    case STransformer: {
+    case SMacro: {
         instantiate_implicits(syn->transformer, env, a, point);
         break;
     }
@@ -1215,7 +1215,7 @@ void squash_types(Syntax* typed, Allocator* a, ErrorPoint* point) {
         squash_types(typed->all.body, a, point);
         break;
     }
-    case STransformer: { 
+    case SMacro: { 
         squash_types(typed->transformer, a, point);
         break;
     }

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -1428,16 +1428,14 @@ void squash_types(Syntax* typed, Allocator* a, ErrorPoint* point) {
     }
     else {
         squash_type(typed->ptype);
-        Document* doc = pretty_type(typed->ptype, a);
-        String str = doc_to_str(doc, a);
-        throw_error(point,
-            string_cat(
-                       string_cat(mv_string("Typechecking error: not all unification vars were instantiated. Term:\n"), 
-                                  str, a),
-                       string_cat(mv_string("\nType:\n"),
-                                  doc_to_str(pretty_type(typed->ptype, a), a),
-                                  a),
-                       a));
+
+        PtrArray nodes = mk_ptr_array(4, a);
+        push_ptr(mk_str_doc(mv_string("Typechecking error: not all unification vars were instantiated. Term:"), a), &nodes);
+        push_ptr(pretty_syntax(typed, a), &nodes);
+        push_ptr(mk_str_doc(mv_string("Type:"), a), &nodes);
+        push_ptr(pretty_type(typed->ptype, a), &nodes);
+
+        throw_error(point, doc_to_str(mv_vsep_doc(nodes, a), a));
     }
 }
 

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -212,9 +212,13 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
         // where syntax = ...
         // 
         PiType* syntax = get_syntax_type();
+        PiType* array = get_array_type();
+        PtrArray syn_arr = mk_ptr_array(1, a);
+        push_ptr(syntax, &syn_arr);
+        PiType* syntax_array = type_app(*array, syn_arr, a);
 
         PiType* transformer_proc = mem_alloc(sizeof(PiType), a);
-        *transformer_proc = mk_proc_type(a, 1, *syntax, *syntax);
+        *transformer_proc = mk_proc_type(a, 1, *syntax_array, *syntax);
 
         type_check_i(untyped->transformer, transformer_proc, env, gen, a, point);
         PiType* t = mem_alloc(sizeof(PiType), a);

--- a/src/pico/analysis/unify.c
+++ b/src/pico/analysis/unify.c
@@ -249,7 +249,7 @@ Result assert_maybe_integral(PiType* type) {
     // Use a while loop to trace through uvars
     while (type) {
         // If it is a primtive, check it is integral type
-        if (type->sort == TPrim && (type->prim & 0b0100)) {
+        if (type->sort == TPrim && (type->prim < 0b1000)) {
             return (Result) {.type = Ok};
         } else if (type->sort == TUVar || type->sort == TUVarDefaulted) {
             // continue on to next iteration

--- a/src/pico/binding/type_env.c
+++ b/src/pico/binding/type_env.c
@@ -32,6 +32,7 @@ TypeEnv* mk_type_env(Environment* env, Allocator* a) {
 }
 
 TypeEntry type_env_lookup(Symbol s, TypeEnv* env) {
+    static PiType kind = {.sort = TKind, .kind.nargs = 0};
     // Search locally
     TypeEntry out;
     Local* lresult = sym_local_alookup(s, env->locals);
@@ -39,7 +40,7 @@ TypeEntry type_env_lookup(Symbol s, TypeEnv* env) {
         out.type = TELocal;
         if (lresult->sort == LQVar) {
             out.is_module = false;
-            out.ptype = NULL;
+            out.ptype = &kind;
             out.value = lresult->type;
             return out;
         } else if (lresult -> sort == LVar) {

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -195,7 +195,8 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
         proc_address += get_instructions(target.code_aux).len;
 
         // Generate procedure value (push the address onto the stack)
-        build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)proc_address), a, point);
+        AsmResult out = build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)proc_address), a, point);
+        backlink_code(target, out.backlink, links);
         build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 
         // Now, change the target and the assembler, such that code is now
@@ -257,7 +258,8 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
         all_address += get_instructions(target.code_aux).len;
 
         // Generate procedure value (push the address onto the stack)
-        build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)all_address), a, point);
+        AsmResult out = build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)all_address), a, point);
+        backlink_code(target, out.backlink, links);
         build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
 
         // Now, change the target and the assembler, such that code is now

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -36,10 +36,10 @@ LinkData generate_toplevel(TopLevel top, Environment* env, Target target, Alloca
     InternalLinkData links = (InternalLinkData) {
         .links = (LinkData) {
             .external_links = mk_sym_sarr_amap(8, a),
+            .ec_links = mk_link_meta_array(32, a),
+            .ed_links = mk_link_meta_array(8, a),
             .cc_links = mk_link_meta_array(32, a),
             .cd_links = mk_link_meta_array(8, a),
-            .dc_links = mk_link_meta_array(0, a),
-            .dd_links = mk_link_meta_array(0, a),
         },
         .gotolinks = mk_sym_sarr_amap(8, a),
     };
@@ -67,10 +67,10 @@ LinkData generate_expr(Syntax* syn, Environment* env, Target target, Allocator* 
     InternalLinkData links = (InternalLinkData) {
         .links = (LinkData) {
             .external_links = mk_sym_sarr_amap(8, a),
+            .ec_links = mk_link_meta_array(0, a),
+            .ed_links = mk_link_meta_array(0, a),
             .cc_links = mk_link_meta_array(32, a),
             .cd_links = mk_link_meta_array(8, a),
-            .dc_links = mk_link_meta_array(0, a),
-            .dd_links = mk_link_meta_array(0, a),
         },
         .gotolinks = mk_sym_sarr_amap(8, a),
     };

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -362,8 +362,10 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
             offset += pi_stack_size_of(*((Syntax*)syn.all_application.args.data[i])->ptype);
             build_unary_op(ass, Push, imm32(-offset), a, point);
         }
-        //size_t args_size = offset - ADDRESS_SIZE;
+
+        // Reserve for return address
         build_binary_op(ass, Sub, reg(RSP, sz_64), imm8(ADDRESS_SIZE), a, point);
+        // Store "Old" RBP (RBP to restore)
         build_unary_op(ass, Push, reg(RBP, sz_64), a, point);
 
         address_stack_grow(env, ADDRESS_SIZE * (syn.all_application.types.len

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -168,8 +168,7 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
                             string_ncat(a, 3,
                                         mv_string("Codegen: Global var '"),
                                         *symbol_to_string(syn.variable),
-                                        mv_string("' has unsupported sort")
-                                        ));
+                                        mv_string("' has unsupported sort")));
             }
             break;
         }
@@ -1206,6 +1205,16 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
         build_binary_op(ass, Add, reg(R14, sz_64), reg(RAX, sz_64), a, point);
 
         break;
+    case SSizeOf: {
+        size_t sz = pi_size_of(*syn.size->type_val);
+        build_unary_op(ass, Push, imm32(sz), a, point);
+        break;
+    }
+    case SAlignOf: {
+        size_t sz = pi_align_of(*syn.size->type_val);
+        build_unary_op(ass, Push, imm32(sz), a, point);
+        break;
+    }
     case SCheckedType: {
         build_binary_op(ass, Mov, reg(R9, sz_64), imm64((uint64_t)syn.type_val), a, point);
         build_unary_op(ass, Push, reg(R9, sz_64), a, point);

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -187,10 +187,6 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         address_stack_grow(env, pi_size_of(*syn.ptype));
         break;
     }
-    case SAll: {
-        generate_polymorphic(syn.all.args, *syn.all.body, env, ass, links, a, point);
-        break;
-    }
     case SProcedure: {
         // Codegen function setup
         build_unary_op(ass, Push, reg(R14, sz_64), a, point);
@@ -239,6 +235,14 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         // push return address 
         build_unary_op(ass, Push, reg(R9, sz_64), a, point);
         build_nullary_op(ass, Ret, a, point);
+        break;
+    }
+    case SAll: {
+        generate_polymorphic(syn.all.args, *syn.all.body, env, ass, links, a, point);
+        break;
+    }
+    case STransformer: {
+        generate(*syn.transformer, env, ass, links, a, point);
         break;
     }
     case SApplication: {

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -241,7 +241,7 @@ void generate(Syntax syn, AddressEnv* env, Assembler* ass, LinkData* links, Allo
         generate_polymorphic(syn.all.args, *syn.all.body, env, ass, links, a, point);
         break;
     }
-    case STransformer: {
+    case SMacro: {
         generate(*syn.transformer, env, ass, links, a, point);
         break;
     }

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -254,6 +254,18 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
         break;
     }
     case SAll: {
+        void* all_address = get_instructions(target.code_aux).data;
+        all_address += get_instructions(target.code_aux).len;
+
+        // Generate procedure value (push the address onto the stack)
+        build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((uint64_t)all_address), a, point);
+        build_unary_op(ass, Push, reg(RAX, sz_64), a, point);
+
+        // Now, change the target and the assembler, such that code is now
+        // generated in the 'code segment'. Then, generate the function body
+        ass = target.code_aux;
+        target.target = target.code_aux;
+
         generate_polymorphic(syn.all.args, *syn.all.body, env, target, links, a, point);
         break;
     }

--- a/src/pico/codegen/internal.c
+++ b/src/pico/codegen/internal.c
@@ -1,3 +1,4 @@
+#include "pico/codegen/codegen.h"
 #include "pico/codegen/internal.h"
 
 #include "platform/machine_info.h"
@@ -24,6 +25,34 @@ void backlink_global(Symbol sym, size_t offset, InternalLinkData* links, Allocat
 
     // Step 2: insert offset into array
     push_size(offset, sarr);
+}
+
+void backlink_code(Target target, size_t offset, InternalLinkData* links) {
+    U8Array assembly = get_instructions(target.code_aux);
+    
+    LinkMetaData link = (LinkMetaData) {
+        .source_offset = offset,
+        .dest_offset = assembly.len,
+    };
+
+    if (target.target == target.code_aux) {
+        push_link_meta(link, &links->links.cc_links);
+    } else {
+        push_link_meta(link, &links->links.ec_links);
+    }
+}
+
+void backlink_data(Target target, size_t offset, InternalLinkData* links) {
+    LinkMetaData link = (LinkMetaData) {
+        .source_offset = offset,
+        .dest_offset = target.data_aux->len,
+    };
+
+    if (target.target == target.code_aux) {
+        push_link_meta(link, &links->links.cd_links);
+    } else {
+        push_link_meta(link, &links->links.ed_links);
+    }
 }
 
 void backlink_goto(Symbol sym, size_t offset, InternalLinkData* links, Allocator* a) {

--- a/src/pico/codegen/internal.c
+++ b/src/pico/codegen/internal.c
@@ -562,6 +562,7 @@ void* mk_opaque_ty(PiType* body) {
         .distinct.type = body,
         .distinct.id = distinct_id(),
         .distinct.source_module = current,
+        .distinct.args = NULL,
     };
     return ty;
 }

--- a/src/pico/codegen/internal.c
+++ b/src/pico/codegen/internal.c
@@ -12,21 +12,21 @@ int compare_to_generate(ToGenerate lhs, ToGenerate rhs) {
 
 ARRAY_CMP_IMPL(ToGenerate, compare_to_generate, to_gen, ToGen);
 
-void backlink_global(Symbol sym, size_t offset, LinkData* links, Allocator* a) {
+void backlink_global(Symbol sym, size_t offset, InternalLinkData* links, Allocator* a) {
     // Step 1: Try lookup or else create & insert 
-    SizeArray* sarr = sym_sarr_lookup(sym, links->backlinks);
+    SizeArray* sarr = sym_sarr_lookup(sym, links->links.external_links);
 
     if (!sarr) {
         // Create & Insert
-        sym_sarr_insert(sym, mk_size_array(4, a), &links->backlinks);
-        sarr = sym_sarr_lookup(sym, links->backlinks);
+        sym_sarr_insert(sym, mk_size_array(4, a), &links->links.external_links);
+        sarr = sym_sarr_lookup(sym, links->links.external_links);
     }
 
     // Step 2: insert offset into array
     push_size(offset, sarr);
 }
 
-void backlink_goto(Symbol sym, size_t offset, LinkData* links, Allocator* a) {
+void backlink_goto(Symbol sym, size_t offset, InternalLinkData* links, Allocator* a) {
     // Step 1: Try lookup or else create & insert 
     SizeArray* sarr = sym_sarr_lookup(sym, links->gotolinks);
 

--- a/src/pico/codegen/polymorphic.c
+++ b/src/pico/codegen/polymorphic.c
@@ -88,7 +88,7 @@ void generate_polymorphic(SymbolArray types, Syntax syn, AddressEnv* env, Target
     build_binary_op(ass, Mov, reg(RDX, sz_64), reg(RSP, sz_64), a, point);
     build_binary_op(ass, Add, reg(RDX, sz_64), imm8(2 * ADDRESS_SIZE), a, point);
 
-    // Note: we push R9 (the new head of stack) so it can be used
+    // Note: We push R9 (the new head of stack) so it can be used
     build_unary_op(ass, Push, reg(R9, sz_64), a, point); 
     
     generate_poly_move(reg(R9, sz_64), reg(RDX, sz_64), reg(RAX, sz_64), ass, a, point);

--- a/src/pico/codegen/polymorphic.c
+++ b/src/pico/codegen/polymorphic.c
@@ -263,9 +263,11 @@ void generate_polymorphic_i(Syntax syn, AddressEnv* env, Target target, Internal
             build_binary_op(ass, Sub, reg(RCX, sz_64), reg(RDX, sz_64), a, point);
             build_binary_op(ass, Cmp, reg(RDX, sz_64), imm8(0), a, point);
             
-            build_binary_op(ass, CMovE, reg(RCX, sz_64), reg(RCX, sz_64), a, point);
+            build_binary_op(ass, CMovE, reg(RCX, sz_64), reg(RDX, sz_64), a, point);
 
-            build_binary_op(ass, Or, rref8(RSP, 0, sz_64), reg(RCX, sz_64), a, point);
+            // Add this to the original size and binary-or it into the type.
+            build_binary_op(ass, Add, reg(R8, sz_64), reg(RCX, sz_64), a, point);
+            build_binary_op(ass, Or, rref8(RSP, 0, sz_64), reg(R8, sz_64), a, point);
         }
 
         // Calculation of offsets:

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -91,6 +91,7 @@ void* pico_run_expr(Target target, size_t rsize, Allocator* a, ErrorPoint* point
 
     void* dvars = get_dynamic_memory();
     void* dynamic_memory_space = mem_alloc(4096, a);
+    void* offset_memory_space = mem_alloc(1024, a);
 
     Allocator* old_tmp_alloc = set_std_tmp_allocator(a);
 
@@ -99,11 +100,15 @@ void* pico_run_expr(Target target, size_t rsize, Allocator* a, ErrorPoint* point
         "push %%rbp       \n"
         "push %%r15       \n"
         "push %%r14       \n"
-        "mov %3, %%r14    \n"
+        "push %%r13       \n"
         "mov %2, %%r15    \n"
+        "mov %3, %%r14    \n"
+        "mov %4, %%r13    \n"
         "mov %%rsp, %%rbp \n"
-        "sub $0x8, %%rbp  \n" // Do this to align RSP & RBP?
+        "sub $0x8, %%rbp  \n" // Do this to align RSP & RBP? Possibly to account
+                              // for value on stack?
         "call *%1         \n"
+        "pop %%r13        \n"
         "pop %%r14        \n"
         "pop %%r15        \n"
         "pop %%rbp        \n"
@@ -111,7 +116,8 @@ void* pico_run_expr(Target target, size_t rsize, Allocator* a, ErrorPoint* point
 
         : "r" (instructions.data)
         , "r" (dvars)
-        , "r"(dynamic_memory_space)) ;
+        , "r" (dynamic_memory_space)
+        , "r" (offset_memory_space)) ;
 
     set_std_tmp_allocator(old_tmp_alloc);
     mem_free(dynamic_memory_space, a);

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -97,6 +97,8 @@ void* pico_run_expr(Target target, size_t rsize, Allocator* a, ErrorPoint* point
 
     int64_t out;
     __asm__ __volatile__(
+        // NOTE: When updating to push more registers, make sure to also update assembly
+        //       in abstraction.c
         "push %%rbp       \n"
         "push %%r15       \n"
         "push %%r14       \n"

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -22,8 +22,6 @@ EvalResult pico_run_toplevel(TopLevel top, Target target, LinkData links, Module
         break;
     }
     case TLDef: {
-        PiType indistinct_type = *top.def.value->ptype;
-        while (indistinct_type.sort == TDistinct) { indistinct_type = *indistinct_type.distinct.type; }
         // copy into module
         res = (EvalResult) {
             .type = ERDef,
@@ -31,12 +29,13 @@ EvalResult pico_run_toplevel(TopLevel top, Target target, LinkData links, Module
             .def.type = top.def.value->ptype,
         };
 
-        void* val = pico_run_expr(target, pi_size_of(*top.def.value->ptype), a, point);
-
         Segments def_segments = (Segments) {
             .code = get_instructions(target.code_aux),
             .data = *target.data_aux,
         };
+
+        def_segments = prep_target(module, def_segments, target.target, &links);
+        void* val = pico_run_expr(target, pi_size_of(*top.def.value->ptype), a, point);
         add_def(module, top.def.bind, *top.def.value->ptype, val, def_segments, &links);
     }
     }

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -105,7 +105,7 @@ void* pico_run_expr(Assembler* ass, size_t rsize, Allocator* a, ErrorPoint* poin
         build_binary_op(ass, Mov, reg(RAX, sz_64), imm64((int64_t)&memcpy), a, point);
         build_unary_op(ass, Call, reg(RAX, sz_64), a, point);
         // pop value from stack
-        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(pi_stack_round(rsize) + 32), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(pi_stack_align(rsize) + 32), a, point);
     }
     build_nullary_op(ass, Ret, a, point);
 #else

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -15,7 +15,14 @@ EvalResult pico_run_toplevel(TopLevel top, Assembler* ass, SymSArrAMap* backlink
         while (indistinct_type.sort == TDistinct) { indistinct_type = *indistinct_type.distinct.type; }
         size_t sz = pi_size_of(indistinct_type);
 
-        if (indistinct_type.sort == TPrim
+        if (indistinct_type.sort == TProc ||
+            (indistinct_type.sort == TPrim && indistinct_type.prim == TMacro)) {
+            res.type = ERValue;
+            res.val.type = top.expr->ptype;
+            res.val.val = get_instructions(ass).data;
+        }
+        else if (indistinct_type.sort == TPrim
+            || indistinct_type.sort == TProc
             || indistinct_type.sort == TStruct
             || indistinct_type.sort == TEnum
             || indistinct_type.sort == TDynamic

--- a/src/pico/parse/parse.c
+++ b/src/pico/parse/parse.c
@@ -68,7 +68,6 @@ ParseResult parse_main(IStream* is, SourcePos* parse_state, Allocator* a) {
                         .type = ParseSuccess,
                         .data.result = (RawTree) {
                             .type = RawAtom,
-                            .hint = HNone,
                             .atom.type = ASymbol,
                             .atom.symbol = string_to_symbol(mv_string(":")),
                         }
@@ -85,7 +84,6 @@ ParseResult parse_main(IStream* is, SourcePos* parse_state, Allocator* a) {
                         .type = ParseSuccess,
                         .data.result = (RawTree) {
                             .type = RawAtom,
-                            .hint = HNone,
                             .atom.type = ASymbol,
                             .atom.symbol = string_to_symbol(mv_string(".")),
                         }
@@ -155,9 +153,9 @@ ParseResult parse_main(IStream* is, SourcePos* parse_state, Allocator* a) {
 
             current = mem_alloc(sizeof(RawTree), a);
             *current = (RawTree) {
-                .type = RawList,
-                .hint = HNone,
-                .nodes = children,
+                .type = RawBranch,
+                .branch.hint = HNone,
+                .branch.nodes = children,
             };
         };
 
@@ -205,9 +203,9 @@ ParseResult parse_list(IStream* is, SourcePos* parse_state, uint32_t terminator,
     } else {
         out.type = ParseSuccess;
         out.data.result = (RawTree) {
-            .type = RawList,
-            .hint = hint,
-            .nodes = nodes,
+            .type = RawBranch,
+            .branch.hint = hint,
+            .branch.nodes = nodes,
         };
         // consume closing ')'
         next(is, &codepoint);
@@ -245,7 +243,6 @@ ParseResult parse_atom(IStream* is, SourcePos* parse_state, Allocator* a) {
             String str = string_from_UTF_32(arr, a);
             *val = (RawTree) {
                 .type = RawAtom,
-                .hint = HNone,
                 .atom.type = ASymbol,
                 .atom.symbol = string_to_symbol(str),
             };
@@ -255,7 +252,6 @@ ParseResult parse_atom(IStream* is, SourcePos* parse_state, Allocator* a) {
             RawTree* op = mem_alloc(sizeof(RawTree), a);
             *op = (RawTree) {
                 .type = RawAtom,
-                .hint = HNone,
                 .atom.type = ASymbol,
                 .atom.symbol = codepoint == '.'
                   ? string_to_symbol(mv_string("."))
@@ -267,7 +263,6 @@ ParseResult parse_atom(IStream* is, SourcePos* parse_state, Allocator* a) {
             String str = string_from_UTF_32(arr, a);
             *val = (RawTree) {
                 .type = RawAtom,
-                .hint = HNone,
                 .atom.type = ASymbol,
                 .atom.symbol = string_to_symbol(str),
             };
@@ -296,9 +291,9 @@ ParseResult parse_atom(IStream* is, SourcePos* parse_state, Allocator* a) {
 
             current = mem_alloc(sizeof(RawTree), a);
             *current = (RawTree) {
-                .type = RawList,
-                .hint = HNone,
-                .nodes = children,
+                .type = RawBranch,
+                .branch.hint = HNone,
+                .branch.nodes = children,
             };
         };
 
@@ -414,9 +409,9 @@ ParseResult parse_prefix(char prefix, IStream* is, SourcePos* parse_state, Alloc
 
         out.type = ParseSuccess;
         out.data.result = (RawTree) {
-            .type = RawList,
-            .hint = HNone,
-            .nodes = nodes,
+            .type = RawBranch,
+            .branch.hint = HNone,
+            .branch.nodes = nodes,
         };
     }
     
@@ -446,7 +441,6 @@ ParseResult parse_string(IStream* is, SourcePos* parse_state, Allocator* a) {
     return (ParseResult) {
         .type = ParseSuccess,
         .data.result.type = RawAtom,
-        .data.result.hint = HNone,
         .data.result.atom.type = AString,
         .data.result.atom.string = string_from_UTF_32(arr, a),
     };
@@ -470,7 +464,6 @@ ParseResult parse_char(IStream* is, SourcePos* parse_state) {
     return (ParseResult) {
         .type = ParseSuccess,
         .data.result.type = RawAtom,
-        .data.result.hint = HNone,
         .data.result.atom.type = AIntegral,
         .data.result.atom.int_64 = codepoint,
     };

--- a/src/pico/parse/parse.c
+++ b/src/pico/parse/parse.c
@@ -1,5 +1,13 @@
 #include "pico/parse/parse.h"
 
+/* High Level overview of the grammar:
+ *
+ * 
+ *
+ *
+ *
+ */
+
 
 // The 'actual' parser funciton
 ParseResult parse_main(IStream* is, SourcePos* parse_state, Allocator* a);
@@ -34,48 +42,129 @@ ParseResult parse_main(IStream* is, SourcePos* parse_state, Allocator* a) {
     uint32_t point;
 
     consume_whitespace(is, parse_state);
+    StreamResult result;
+    PtrArray terms = mk_ptr_array(8, a);
+    bool running = true;
 
-    switch (peek(is, &point)) {
-    case StreamSuccess:
-        if (point == '(') {
-            out = parse_list(is, parse_state, ')', HExpression, a);
-        }
-        else if (point == '[') {
-            out = parse_list(is, parse_state, ']', HSpecial, a);
-        }
-        else if (point == '{') {
-            out = parse_list(is, parse_state, '}', HImplicit, a);
-        }
-        else if (point == ':') {
-            out = parse_prefix(':', is, parse_state, a);
-        }
-        else if (point == '.') {
-            out = parse_prefix('.', is, parse_state, a);
-        }
-        else if (point == '"') {
-            out = parse_string(is, parse_state, a);
-        }
-        else if (point == '#') {
-            out = parse_char(is, parse_state);
-        }
-        else if (is_numchar(point) || point == '-') {
-            out = parse_number(is, parse_state, a);
-        }
-        else {
-            out = parse_atom(is, parse_state, a);
-        }
-        break;
+    while (running && ((result = peek(is, &point)) == StreamSuccess)) {
+        switch (peek(is, &point)) {
+        case StreamSuccess:
+            if (point == '(') {
+                out = parse_list(is, parse_state, ')', HExpression, a);
+            }
+            else if (point == '[') {
+                out = parse_list(is, parse_state, ']', HSpecial, a);
+            }
+            else if (point == '{') {
+                out = parse_list(is, parse_state, '}', HImplicit, a);
+            }
+            else if (point == ':') {
+                if (terms.len == 0) {
+                    out = parse_prefix(':', is, parse_state, a);
+                } else {
+                    next(is, &point);
 
-    case StreamEnd: {
-        out.type = ParseNone;
-        break;
-    }
+                    out = (ParseResult) {
+                        .type = ParseSuccess,
+                        .data.result = (RawTree) {
+                            .type = RawAtom,
+                            .hint = HNone,
+                            .atom.type = ASymbol,
+                            .atom.symbol = string_to_symbol(mv_string(":")),
+                        }
+                    };
+                }
+            }
+            else if (point == '.') {
+                if (terms.len == 0) {
+                    out = parse_prefix('.', is, parse_state, a);
+                } else {
+                    next(is, &point);
+
+                    out = (ParseResult) {
+                        .type = ParseSuccess,
+                        .data.result = (RawTree) {
+                            .type = RawAtom,
+                            .hint = HNone,
+                            .atom.type = ASymbol,
+                            .atom.symbol = string_to_symbol(mv_string(".")),
+                        }
+                    };
+                }
+            }
+            else if (point == '"') {
+                out = parse_string(is, parse_state, a);
+            }
+            else if (point == '#') {
+                out = parse_char(is, parse_state);
+            }
+            else if (is_numchar(point) || point == '-') {
+                out = parse_number(is, parse_state, a);
+            }
+            else if (is_whitespace(point)) {
+                out.type = ParseNone;
+                running = false;
+                break;
+            }
+            else if (is_symchar(point)){
+                out = parse_atom(is, parse_state, a);
+            } else {
+                out.type = ParseNone;
+                running = false;
+                break;
+            }
+            break;
+
+        case StreamEnd: {
+            out.type = ParseNone;
+            running = false;
+            break;
+        }
         
-    default: {
-        out.type = ParseFail;
-        out.data.range.start = *parse_state;
-        out.data.range.end = *parse_state;
-    } break;
+        default: {
+            out = (ParseResult) {
+                .type = ParseFail,
+                .data.range.start = *parse_state,
+                .data.range.end = *parse_state,
+            };
+            running = false;
+        } break;
+        }
+
+        if (out.type == ParseSuccess) {
+            RawTree* term = mem_alloc(sizeof(RawTree), a);
+            *term = out.data.result;
+            push_ptr(term, &terms);
+        }
+    }
+
+    if (out.type == ParseSuccess && terms.len == 0) {
+        out.type = ParseNone;
+    } else if (out.type == ParseNone && terms.len == 1) {
+        out.type = ParseSuccess;
+        out.data.result = *(RawTree*)terms.data[0];
+    } else if ((out.type == ParseSuccess || out.type == ParseNone) && terms.len > 1) {
+        // Now that the list has been accumulated, 'unroll' the list appropriately, 
+        // meaning that (num : i64 . +) becomes (. + (: num i64))
+        RawTree* current = terms.data[0];
+        for (size_t i = 1; terms.len - i != 0; i += 2) {
+            PtrArray children = mk_ptr_array(3, a);
+            push_ptr(terms.data[i], &children);
+            push_ptr(terms.data[i+1], &children);
+            push_ptr(current, &children);
+
+            current = mem_alloc(sizeof(RawTree), a);
+            *current = (RawTree) {
+                .type = RawList,
+                .hint = HNone,
+                .nodes = children,
+            };
+        };
+
+        out = (ParseResult) {
+            .type = ParseSuccess,
+            .data.result = *current,
+        };
     }
     return out;
 }
@@ -92,6 +181,7 @@ ParseResult parse_list(IStream* is, SourcePos* parse_state, uint32_t terminator,
     next(is, &codepoint);
     consume_whitespace(is, parse_state);
     StreamResult sres;
+
     while ((sres = peek(is, &codepoint)) == StreamSuccess && (codepoint != terminator)) {
         res = parse_main(is, parse_state, a);
 

--- a/src/pico/syntax/concrete.c
+++ b/src/pico/syntax/concrete.c
@@ -11,22 +11,22 @@ Document* pretty_rawtree(RawTree tree, Allocator* a) {
         out = pretty_atom(tree.atom, a);
         break;
     }
-    case RawList: {
-        char* open; switch (tree.hint) {
+    case RawBranch: {
+        char* open; switch (tree.branch.hint) {
           case HSpecial: open = "["; break;
           case HImplicit: open = "{"; break;
           default: open = "("; break;
         };
-        char* close; switch (tree.hint) {
+        char* close; switch (tree.branch.hint) {
           case HSpecial: close = "]"; break;
           case HImplicit: close = "}"; break;
           default: close = ")"; break;
         };
 
-        PtrArray doc_arr = mk_ptr_array(tree.nodes.len + 2, a);
+        PtrArray doc_arr = mk_ptr_array(tree.branch.nodes.len + 2, a);
         push_ptr(mv_str_doc(mk_string(open, a), a), &doc_arr);
-        for (size_t i = 0; i < tree.nodes.len; i++) {
-            RawTree node = *((RawTree*)tree.nodes.data[i]);
+        for (size_t i = 0; i < tree.branch.nodes.len; i++) {
+            RawTree node = *((RawTree*)tree.branch.nodes.data[i]);
             Document* doc = pretty_rawtree(node, a);
             push_ptr(doc, &doc_arr);
         }
@@ -47,10 +47,10 @@ void delete_rawtree(RawTree tree, Allocator* a) {
     switch (tree.type) {
     case RawAtom:
         break;
-    case RawList:
-        for (size_t i = 0; i < tree.nodes.len; i++)
-            delete_rawtree_ptr(tree.nodes.data[i], a);
-        sdelete_ptr_array(tree.nodes);
+    case RawBranch:
+        for (size_t i = 0; i < tree.branch.nodes.len; i++)
+            delete_rawtree_ptr(tree.branch.nodes.data[i], a);
+        sdelete_ptr_array(tree.branch.nodes);
         break;
     }
 }

--- a/src/pico/syntax/syntax.c
+++ b/src/pico/syntax/syntax.c
@@ -108,9 +108,8 @@ Document* pretty_syntax(Syntax* syntax, Allocator* a) {
     }
     case SAllApplication: {
         Document* head = pretty_syntax(syntax->all_application.function, a);
-        bool print_types = syntax->all_application.types.len == 0;
-        PtrArray nodes = mk_ptr_array((print_types ? 5 : 3) + syntax->all_application.types.len + syntax->all_application.args.len, a);
-        push_ptr(mk_str_doc(mv_string("("), a), &nodes);
+        bool print_types = syntax->all_application.types.len != 0;
+        PtrArray nodes = mk_ptr_array((print_types ? 3 : 1) + syntax->all_application.types.len + syntax->all_application.args.len, a);
         push_ptr(head, &nodes);
 
         if (print_types) push_ptr(mk_str_doc(mv_string("{"), a), &nodes);
@@ -124,8 +123,7 @@ Document* pretty_syntax(Syntax* syntax, Allocator* a) {
             Document* node = pretty_syntax(syntax->all_application.args.data[i], a);
             push_ptr(node, &nodes);
         }
-        push_ptr(mk_str_doc(mv_string(")"), a), &nodes);
-        out = mv_sep_doc(nodes, a);
+        out = mk_paren_doc("(", ")", mv_sep_doc(nodes, a), a);
         break;
     }
     case SConstructor: {
@@ -323,49 +321,37 @@ Document* pretty_syntax(Syntax* syntax, Allocator* a) {
         break;
     }
     case SIf: {
-        PtrArray nodes = mk_ptr_array(6, a);
-        push_ptr(mk_str_doc(mv_string("(if"), a), &nodes);
+        PtrArray nodes = mk_ptr_array(3, a);
         push_ptr(pretty_syntax(syntax->if_expr.condition, a), &nodes);
         push_ptr(pretty_syntax(syntax->if_expr.true_branch, a), &nodes);
         push_ptr(pretty_syntax(syntax->if_expr.false_branch, a), &nodes);
-        push_ptr(mv_str_doc(mk_string(")", a), a), &nodes);
-        out = mv_sep_doc(nodes, a);
+        out = mk_paren_doc("(if ", ")", mv_sep_doc(nodes, a), a);
         break;
     }
 
     case SIs: {
-        PtrArray nodes = mk_ptr_array(4, a);
-        push_ptr(mk_str_doc(mv_string("(is "), a), &nodes);
+        PtrArray nodes = mk_ptr_array(2, a);
         push_ptr(pretty_syntax(syntax->is.val, a), &nodes);
         push_ptr(pretty_syntax(syntax->is.type, a), &nodes);
-        push_ptr(mv_str_doc(mk_string(")", a), a), &nodes);
-        out = mv_cat_doc(nodes, a);
+        out = mk_paren_doc("(is ", ")", mv_sep_doc(nodes, a), a);
         break;
     }
     case SInTo: {
-        PtrArray nodes = mk_ptr_array(4, a);
-        push_ptr(mk_str_doc(mv_string("(into "), a), &nodes);
-        push_ptr(pretty_syntax(syntax->is.val, a), &nodes);
+        PtrArray nodes = mk_ptr_array(2, a);
         push_ptr(pretty_syntax(syntax->is.type, a), &nodes);
-        push_ptr(mv_str_doc(mk_string(")", a), a), &nodes);
-        out = mv_cat_doc(nodes, a);
+        push_ptr(pretty_syntax(syntax->is.val, a), &nodes);
+        out = mk_paren_doc("(into ", ")", mv_sep_doc(nodes, a), a);
         break;
     }
     case SOutOf: {
-        PtrArray nodes = mk_ptr_array(4, a);
-        push_ptr(mk_str_doc(mv_string("(out-of "), a), &nodes);
-        push_ptr(pretty_syntax(syntax->is.val, a), &nodes);
+        PtrArray nodes = mk_ptr_array(2, a);
         push_ptr(pretty_syntax(syntax->is.type, a), &nodes);
-        push_ptr(mv_str_doc(mk_string(")", a), a), &nodes);
-        out = mv_cat_doc(nodes, a);
+        push_ptr(pretty_syntax(syntax->is.val, a), &nodes);
+        out = mk_paren_doc("(out-of ", ")", mv_sep_doc(nodes, a), a);
         break;
     }
     case SDynAlloc: {
-        PtrArray nodes = mk_ptr_array(4, a);
-        push_ptr(mk_str_doc(mv_string("(dyn-alloc "), a), &nodes);
-        push_ptr(pretty_syntax(syntax->size, a), &nodes);
-        push_ptr(mv_str_doc(mk_string(")", a), a), &nodes);
-        out = mv_cat_doc(nodes, a);
+        out = mk_paren_doc("(dyn-alloc ", ")", pretty_syntax(syntax->size, a), a);
         break;
     }
     case SModule: {

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -207,6 +207,8 @@ Segments prep_target(Module* module, Segments in_segments, Assembler* target, Li
 Result add_def (Module* module, Symbol name, PiType type, void* data, Segments segments, LinkData* links) {
     ModuleEntryInternal entry;
     entry.is_module = false;
+    entry.data_segment = NULL;
+    entry.code_segment = NULL;
     size_t size = pi_size_of(type);
 
     if (type.sort == TKind || type.sort == TConstraint) {
@@ -230,14 +232,10 @@ Result add_def (Module* module, Symbol name, PiType type, void* data, Segments s
         if (segments.code.len != 0) {
             entry.code_segment = mem_alloc(sizeof(U8Array), module->allocator);
             *entry.code_segment = segments.code;
-        } else {
-            entry.code_segment = NULL;
         }
         if (segments.data.len != 0) {
             entry.data_segment = mem_alloc(sizeof(U8Array), module->allocator);
             *entry.data_segment = segments.data;
-        } else {
-            entry.data_segment = NULL;
         }
     }
 
@@ -275,6 +273,8 @@ Result add_module_def(Module* module, Symbol name, Module* child) {
         .value = child,
         .is_module = true,
         .backlinks = NULL,
+        .code_segment = NULL,
+        .data_segment = NULL,
     };
 
     // Free a previous definition (if it exists!)

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -214,20 +214,22 @@ Result add_def (Module* module, Symbol name, PiType type, void* data, Segments s
     if (type.sort == TKind || type.sort == TConstraint) {
         PiType* t_val = *(PiType**)data; 
         entry.value = copy_pi_type_p(t_val, module->allocator);
-    } else if (type.sort == TTraitInstance) {
-        size_t total = 0;
-        for (size_t i = 0; i < type.instance.fields.len; i++) {
-            total = pi_size_align(total, pi_align_of(*(PiType*)type.instance.fields.data[i].val));
-            total += pi_size_of(*(PiType*)type.instance.fields.data[i].val);
-        }
-        void* new_memory = mem_alloc(total, module->allocator);
-        memcpy(new_memory, *(void**)data, total);
-
-        entry.value = mem_alloc(size, module->allocator);
-        memcpy(entry.value, &new_memory, ADDRESS_SIZE);
     } else {
-        entry.value = mem_alloc(size, module->allocator);
-        memcpy(entry.value, data, size);
+        if (type.sort == TTraitInstance) {
+            size_t total = 0;
+            for (size_t i = 0; i < type.instance.fields.len; i++) {
+                total = pi_size_align(total, pi_align_of(*(PiType*)type.instance.fields.data[i].val));
+                total += pi_size_of(*(PiType*)type.instance.fields.data[i].val);
+            }
+            void* new_memory = mem_alloc(total, module->allocator);
+            memcpy(new_memory, *(void**)data, total);
+
+            entry.value = mem_alloc(size, module->allocator);
+            memcpy(entry.value, &new_memory, ADDRESS_SIZE);
+        } else {
+            entry.value = mem_alloc(size, module->allocator);
+            memcpy(entry.value, data, size);
+        }
 
         if (segments.code.len != 0) {
             entry.code_segment = mem_alloc(sizeof(U8Array), module->allocator);

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -183,6 +183,7 @@ Result add_def (Module* module, Symbol name, PiType type, void* data) {
 
 Result add_fn_def (Module* module, Symbol name, PiType type, Assembler* fn, SymSArrAMap* backlinks) {
     ModuleEntryInternal entry;
+    entry.is_module = false;
     U8Array instrs = get_instructions(fn);
     size_t size = instrs.len;
 

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -674,8 +674,8 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
     sym = string_to_symbol(mv_string("all"));
     add_def(module, sym, type, &former);
 
-    former = FTransformer;
-    sym = string_to_symbol(mv_string("transformer"));
+    former = FMacro;
+    sym = string_to_symbol(mv_string("macro"));
     add_def(module, sym, type, &former);
 
     former = FApplication;

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -903,7 +903,8 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
     build_store_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("store"));
     fn_segments.code = get_instructions(ass);
-    add_def(module, sym, type, &prepped.code.data, fn_segments, NULL);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -939,7 +939,8 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
     sdelete_u8_array(null_segments.code);
     sdelete_u8_array(null_segments.data);
-    sdelete_u8_array(fn_segments.code);
+    // Note: we do NOT delete the 'fn_segments.code' because it is the
+    // assembler, and needs to be used later!
     sdelete_u8_array(fn_segments.data);
 }
 

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -763,6 +763,14 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
     sym = string_to_symbol(mv_string("dyn-alloc"));
     add_def(module, sym, type, &former, null_segments, NULL);
 
+    former = FSizeOf;
+    sym = string_to_symbol(mv_string("size-of"));
+    add_def(module, sym, type, &former, null_segments, NULL);
+
+    former = FAlignOf;
+    sym = string_to_symbol(mv_string("align-of"));
+    add_def(module, sym, type, &former, null_segments, NULL);
+
     former = FProcType;
     sym = string_to_symbol(mv_string("Proc"));
     add_def(module, sym, type, &former, null_segments, NULL);
@@ -890,24 +898,6 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
     Segments fn_segments = (Segments) {.data = mk_u8_array(0, a),};
     Segments prepped;
-
-    type = mk_unary_op_type(a, (PiType){.sort = TKind, .kind = {.nargs = 0}}, UInt_64);
-    build_size_of_fn(ass, a, &point);
-    sym = string_to_symbol(mv_string("size-of"));
-    fn_segments.code = get_instructions(ass);
-    prepped = prep_target(module, fn_segments, ass, NULL);
-    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
-    clear_assembler(ass);
-    delete_pi_type(type, a);
-
-    type = mk_unary_op_type(a, (PiType){.sort = TKind, .kind = {.nargs = 0}}, UInt_64);
-    build_align_of_fn(ass, a, &point);
-    sym = string_to_symbol(mv_string("align-of"));
-    fn_segments.code = get_instructions(ass);
-    prepped = prep_target(module, fn_segments, ass, NULL);
-    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
-    clear_assembler(ass);
-    delete_pi_type(type, a);
 
     type = build_store_fn_ty(a);
     build_store_fn(ass, a, &point);

--- a/src/pico/values/stdlib.c
+++ b/src/pico/values/stdlib.c
@@ -655,148 +655,153 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
     type.sort = TPrim;
     type.prim = TFormer;
 
+    Segments null_segments = (Segments) {
+        .code = mk_u8_array(0, a),
+        .data = mk_u8_array(0, a),
+    };
+
     // ------------------------------------------------------------------------
     // Term Formers
     // ------------------------------------------------------------------------
     former = FDefine;
     sym = string_to_symbol(mv_string("def"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FDefine;
     sym = string_to_symbol(mv_string("declare"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FProcedure;
     sym = string_to_symbol(mv_string("proc"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FAll;
     sym = string_to_symbol(mv_string("all"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FMacro;
     sym = string_to_symbol(mv_string("macro"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FApplication;
     sym = string_to_symbol(mv_string("$"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FProjector;
     sym = string_to_symbol(mv_string("."));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FDynamic;
     sym = string_to_symbol(mv_string("dynamic"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FDynamicUse;
     sym = string_to_symbol(mv_string("use"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FInstance;
     sym = string_to_symbol(mv_string("instance"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FStructure;
     sym = string_to_symbol(mv_string("struct"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FVariant;
     sym = string_to_symbol(mv_string(":"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FMatch;
     sym = string_to_symbol(mv_string("match"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FIf;
     sym = string_to_symbol(mv_string("if"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FLabels;
     sym = string_to_symbol(mv_string("labels"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FGoTo;
     sym = string_to_symbol(mv_string("go-to"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FWithReset;
     sym = string_to_symbol(mv_string("with-reset"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FResetTo;
     sym = string_to_symbol(mv_string("reset-to"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FSequence;
     sym = string_to_symbol(mv_string("seq"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FLet;
     sym = string_to_symbol(mv_string("let"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FDynamicLet;
     sym = string_to_symbol(mv_string("bind"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FIs;
     sym = string_to_symbol(mv_string("is"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FInTo;
     sym = string_to_symbol(mv_string("into"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FOutOf;
     sym = string_to_symbol(mv_string("out-of"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FDynAlloc;
     sym = string_to_symbol(mv_string("dyn-alloc"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FProcType;
     sym = string_to_symbol(mv_string("Proc"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FStructType;
     sym = string_to_symbol(mv_string("Struct"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FEnumType;
     sym = string_to_symbol(mv_string("Enum"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FResetType;
     sym = string_to_symbol(mv_string("Reset"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FDynamicType;
     sym = string_to_symbol(mv_string("Dynamic"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FDistinctType;
     sym = string_to_symbol(mv_string("Distinct"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FOpaqueType;
     sym = string_to_symbol(mv_string("Opaque"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FTraitType;
     sym = string_to_symbol(mv_string("Trait"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FAllType;
     sym = string_to_symbol(mv_string("All"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     former = FFamily;
     sym = string_to_symbol(mv_string("Family"));
-    add_def(module, sym, type, &former);
+    add_def(module, sym, type, &former, null_segments, NULL);
 
     // ------------------------------------------------------------------------
     // Types 
@@ -809,51 +814,51 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
     type_val = type;
     sym = string_to_symbol(mv_string("Type"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(Unit);
     sym = string_to_symbol(mv_string("Unit"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(Bool);
     sym = string_to_symbol(mv_string("Bool"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(Address);
     sym = string_to_symbol(mv_string("Address"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(Int_64);
     sym = string_to_symbol(mv_string("I64"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(Int_32);
     sym = string_to_symbol(mv_string("I32"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(Int_16);
     sym = string_to_symbol(mv_string("I16"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(Int_8);
     sym = string_to_symbol(mv_string("I8"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(UInt_64);
     sym = string_to_symbol(mv_string("U64"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(UInt_32);
     sym = string_to_symbol(mv_string("U32"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(UInt_16);
     sym = string_to_symbol(mv_string("U16"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     type_val = mk_prim_type(UInt_8);
     sym = string_to_symbol(mv_string("U8"));
-    add_def(module, sym, type, &type_data);
+    add_def(module, sym, type, &type_data, null_segments, NULL);
 
     // Syntax Type : components and definition 
     {
@@ -864,12 +869,12 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
                                         "string", 1, mk_string_type(a));
         type_data = &atom_type;
         sym = string_to_symbol(mv_string("Atom"));
-        add_def(module, sym, type, &type_data);
+        add_def(module, sym, type, &type_data, null_segments, NULL);
 
         PiType hint_type = mk_enum_type(a, 4, "none", 0, "expr", 0, "special", 0, "implicit", 0);
         type_data = &hint_type;
         sym = string_to_symbol(mv_string("Hint"));
-        add_def(module, sym, type, &type_data);
+        add_def(module, sym, type, &type_data, null_segments, NULL);
 
         type_val = mk_enum_type(a, 2,
                                 "atom", 1, atom_type,
@@ -877,55 +882,74 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
         type_data = &type_val;
         sym = string_to_symbol(mv_string("Syntax"));
-        add_def(module, sym, type, &type_data);
+        add_def(module, sym, type, &type_data, null_segments, NULL);
         delete_pi_type(type_val, a);
         ModuleEntry* e = get_def(sym, module);
         syntax_type = e->value;
     }
 
+    Segments fn_segments = (Segments) {.data = mk_u8_array(0, a),};
+    Segments prepped;
+
     type = mk_unary_op_type(a, (PiType){.sort = TKind, .kind = {.nargs = 0}}, UInt_64);
     build_size_of_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("size-of"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
     type = mk_unary_op_type(a, (PiType){.sort = TKind, .kind = {.nargs = 0}}, UInt_64);
     build_align_of_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("align-of"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
     type = build_store_fn_ty(a);
     build_store_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("store"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    add_def(module, sym, type, &prepped.code.data, fn_segments, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
     type = build_load_fn_ty(a);
     build_load_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("load"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
     type = mk_proc_type(a, 1, mk_prim_type(Address), mk_prim_type(UInt_64));
     build_nop_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("address-to-num"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
     type = mk_proc_type(a, 1, mk_prim_type(UInt_64), mk_prim_type(Address));
     build_nop_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("num-to-address"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
     add_module(string_to_symbol(mv_string("core")), module, base);
+
+    sdelete_u8_array(null_segments.code);
+    sdelete_u8_array(null_segments.data);
+    sdelete_u8_array(fn_segments.code);
+    sdelete_u8_array(fn_segments.data);
 }
 
 void add_primitive_module(String name, LocationSize sz, bool is_signed, Assembler* ass, Module* num, Allocator* a) {
@@ -959,47 +983,67 @@ void add_primitive_module(String name, LocationSize sz, bool is_signed, Assemble
     };
     PrimType prim = prims[is_signed][sz];
 
+    Segments fn_segments = (Segments) {.data = mk_u8_array(0, a)};
+    Segments prepped;
+
     build_binary_fn(ass, Add, sz, a, &point);
     type = mk_binop_type(a, prim, prim, prim);
     sym = string_to_symbol(mv_string("+"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
 
     build_binary_fn(ass, Sub, sz, a, &point);
     sym = string_to_symbol(mv_string("-"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
 
     build_special_binary_fn(ass, is_signed ? IMul : Mul, sz, a, &point);
     sym = string_to_symbol(mv_string("*"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
 
     build_special_binary_fn(ass, is_signed ? IDiv : Div, sz, a, &point);
     sym = string_to_symbol(mv_string("/"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
     build_comp_fn(ass, is_signed ? SetL : SetB, sz, a, &point);
     type = mk_binop_type(a, prim, prim, Bool);
     sym = string_to_symbol(mv_string("<"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
 
     build_comp_fn(ass, is_signed ? SetG : SetA, sz, a, &point);
     sym = string_to_symbol(mv_string(">"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
 
     build_comp_fn(ass, SetE, sz, a, &point);
     sym = string_to_symbol(mv_string("="));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
+
     delete_pi_type(type, a);
+    sdelete_u8_array(fn_segments.data);
 
     Result r = add_module_def(num, string_to_symbol(name), module);
     if (r.type == Err) panic(r.error_message);
+
 }
 
 void add_num_module(Assembler* ass, Package* base, Allocator* a) {
@@ -1053,8 +1097,13 @@ void add_extra_module(Assembler* ass, Package* base, Allocator* default_allocato
     if (catch_error(point)) {
         panic(point.error_message);
     }
+
+    Segments null_segments = (Segments) {
+        .code = mk_u8_array(0, a),
+        .data = mk_u8_array(0, a),
+    };
     
-    //uint64_t dyn_curr_package = mk_dynamic_var(sizeof(void*), &base); 
+    // uint64_t dyn_curr_package = mk_dynamic_var(sizeof(void*), &base); 
     std_allocator = mk_dynamic_var(sizeof(Allocator), default_allocator); 
     type = mk_dynamic_type(a, mk_struct_type(a, 4,
                                              "malloc", mk_prim_type(Address),
@@ -1062,7 +1111,7 @@ void add_extra_module(Assembler* ass, Package* base, Allocator* default_allocato
                                              "free", mk_prim_type(Address),
                                              "ctx", mk_prim_type(Address)));
     sym = string_to_symbol(mv_string("allocator"));
-    add_def(module, sym, type, &std_allocator);
+    add_def(module, sym, type, &std_allocator, null_segments, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
@@ -1072,16 +1121,21 @@ void add_extra_module(Assembler* ass, Package* base, Allocator* default_allocato
 
     type = mk_dynamic_type(a, mk_prim_type(Address));
     sym = string_to_symbol(mv_string("temp-allocator"));
-    add_def(module, sym, type, &std_tmp_allocator);
+    add_def(module, sym, type, &std_tmp_allocator, null_segments, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
     // C Wrappers!
+    Segments fn_segments = {.data = mk_u8_array(0, a),};
+    Segments prepped;
+
     // exit : Proc [] Unit
     type = mk_proc_type(a, 0, mk_prim_type(Unit));
     build_exit_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("exit"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
@@ -1089,7 +1143,9 @@ void add_extra_module(Assembler* ass, Package* base, Allocator* default_allocato
     type = mk_proc_type(a, 1, mk_prim_type(UInt_64), mk_prim_type(Address));
     build_malloc_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("malloc"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
@@ -1099,7 +1155,9 @@ void add_extra_module(Assembler* ass, Package* base, Allocator* default_allocato
                         mk_prim_type(Address));
     build_realloc_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("realloc"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
@@ -1107,7 +1165,9 @@ void add_extra_module(Assembler* ass, Package* base, Allocator* default_allocato
     type = mk_proc_type(a, 1, mk_prim_type(Address), mk_prim_type(Unit));
     build_free_fn(ass, a, &point);
     sym = string_to_symbol(mv_string("free"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
@@ -1115,7 +1175,9 @@ void add_extra_module(Assembler* ass, Package* base, Allocator* default_allocato
     type = mk_proc_type(a, 1, mk_string_type(a), mk_prim_type(Unit));
     build_print_fun(ass, a, &point);
     sym = string_to_symbol(mv_string("print"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
@@ -1123,7 +1185,9 @@ void add_extra_module(Assembler* ass, Package* base, Allocator* default_allocato
     type = mk_proc_type(a, 1, mk_string_type(a), mk_prim_type(Unit));
     build_load_module_fun(ass, a, &point);
     sym = string_to_symbol(mv_string("load-module"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
@@ -1131,11 +1195,17 @@ void add_extra_module(Assembler* ass, Package* base, Allocator* default_allocato
     type = mk_proc_type(a, 1, mk_string_type(a), mk_prim_type(Unit));
     build_run_script_fun(ass, a, &point);
     sym = string_to_symbol(mv_string("run-script"));
-    add_fn_def(module, sym, type, ass, NULL);
+    fn_segments.code = get_instructions(ass);
+    prepped = prep_target(module, fn_segments, ass, NULL);
+    add_def(module, sym, type, &prepped.code.data, prepped, NULL);
     clear_assembler(ass);
     delete_pi_type(type, a);
 
     add_module(string_to_symbol(mv_string("extra")), module, base);
+
+    sdelete_u8_array(null_segments.code);
+    sdelete_u8_array(null_segments.data);
+    sdelete_u8_array(fn_segments.data);
 }
 
 void add_user_module(Package* base, Allocator* a) {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -1083,7 +1083,9 @@ PiType* type_app (PiType family, PtrArray args, Allocator* a) {
         new_type->distinct.id = family.distinct.id;
         new_type->distinct.source_module = family.distinct.source_module;
         new_type->distinct.args = mem_alloc(sizeof(PtrArray), a);
-        *new_type->distinct.args = args;
+
+        typedef void* (*TyCopier)(void*, Allocator*);
+        *new_type->distinct.args = copy_ptr_array(args,  (TyCopier)copy_pi_type_p, a);
         return new_type;
     } else {
         if (family.sort != TFam || family.binder.vars.len != args.len) {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -69,6 +69,7 @@ void delete_pi_type(PiType t, Allocator* a) {
             for (size_t i = 0; i < t.distinct.args->len; i++)
                 delete_pi_type_p(t.distinct.args->data[i], a);
             sdelete_ptr_array(*t.distinct.args);
+            mem_free(t.distinct.args, a);
         }
         break;
     }
@@ -1075,9 +1076,14 @@ PiType* type_app (PiType family, PtrArray args, Allocator* a) {
         };
         return out_ty;
     } else if (family.sort == TDistinct) {
+        // TODO (BUG LOGIC): check kind of family?
         PiType* new_type = mem_alloc(sizeof(PiType), a);
         *new_type = family;
         new_type->distinct.type = type_app(*family.distinct.type, args, a);
+        new_type->distinct.id = family.distinct.id;
+        new_type->distinct.source_module = family.distinct.source_module;
+        new_type->distinct.args = mem_alloc(sizeof(PtrArray), a);
+        *new_type->distinct.args = args;
         return new_type;
     } else {
         if (family.sort != TFam || family.binder.vars.len != args.len) {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -605,6 +605,7 @@ Document* pretty_type(PiType* type, Allocator* a) {
         } else {
             push_ptr(mk_str_doc(mv_string("Distinct #" ), a), &nodes);
         }
+        push_ptr(pretty_u64(type->distinct.id, a), &nodes);
         if (type->distinct.args) {
             PtrArray args = mk_ptr_array(type->distinct.args->len, a);
             for (size_t i = 0; i < type->distinct.args->len; i++) {
@@ -612,7 +613,6 @@ Document* pretty_type(PiType* type, Allocator* a) {
             }
             push_ptr(mk_paren_doc("(", ")", mv_sep_doc(args, a), a), &nodes);
         }
-        push_ptr(pretty_u64(type->distinct.id, a), &nodes);
         push_ptr(mk_str_doc(mv_string(" " ), a), &nodes);
         push_ptr(pretty_type(type->distinct.type, a), &nodes);
         out = mk_paren_doc("(", ")", mv_cat_doc(nodes, a), a);
@@ -1251,6 +1251,28 @@ PiType mk_enum_type(Allocator* a, size_t nfields, ...) {
     va_end(args);
 
     return (PiType) {.sort = TEnum, .structure.fields = fields,};
+}
+
+PiType mk_distinct_type(Allocator* a, PiType inner) {
+    PiType out = (PiType) {
+        .sort = TDistinct,
+        .distinct.type = mem_alloc(sizeof(PiType), a),
+        .distinct.id = distinct_id(),
+        .distinct.source_module = NULL,
+        .distinct.args = NULL,
+    };
+    *out.distinct.type = inner;
+    return out;
+}
+
+PiType mk_type_family(Allocator* a, SymbolArray vars, PiType body) {
+    PiType out = (PiType) {
+        .sort = TFam,
+        .binder.vars = vars,
+        .binder.body = mem_alloc(sizeof(PiType), a),
+    };
+    *out.binder.body = body;
+    return out;
 }
 
 PiType mk_string_type(Allocator* a) {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -1100,6 +1100,7 @@ PiType* type_app (PiType family, PtrArray args, Allocator* a) {
 
         PiType* new_type = copy_pi_type_p(family.binder.body, a);
         type_app_subst (new_type, subst, a);
+        sdelete_sym_ptr_assoc(subst);
         return new_type;
     }
 }

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -193,8 +193,10 @@ PiType copy_pi_type(PiType t, Allocator* a) {
         out.distinct.type = copy_pi_type_p(t.distinct.type, a);
         out.distinct.id = t.distinct.id;
         out.distinct.source_module = t.distinct.source_module;
-        out.distinct.args = mem_alloc(sizeof(PtrArray), a);
-        *out.distinct.args = copy_ptr_array(*t.distinct.args,  (TyCopier)copy_pi_type_p, a);
+        if (t.distinct.args) {
+            out.distinct.args = mem_alloc(sizeof(PtrArray), a);
+            *out.distinct.args = copy_ptr_array(*t.distinct.args,  (TyCopier)copy_pi_type_p, a);
+        }
         break;
     case TVar:
         out.var = t.var;

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -245,7 +245,11 @@ Document* pretty_pi_value(void* val, PiType* type, Allocator* a) {
     Document* out = NULL;
     switch (type->sort) {
     case TProc: {
-        out = mk_str_doc(mv_string("#<proc>"), a);
+        void** addr = (void**) val;
+        PtrArray nodes = mk_ptr_array(2, a);
+        push_ptr(mk_str_doc(mv_string("proc"), a), &nodes);
+        push_ptr(pretty_ptr(*addr, a), &nodes);
+        out = mk_paren_doc("#<", ">", mv_sep_doc(nodes, a), a);
         break;
     }
     case TUVar:
@@ -314,6 +318,14 @@ Document* pretty_pi_value(void* val, PiType* type, Allocator* a) {
         case TFormer:  {
             TermFormer* pformer = (TermFormer*) val;
             out = pretty_former(*pformer, a);
+            break;
+        }
+        case TMacro:  {
+            void** addr = (void**) val;
+            PtrArray nodes = mk_ptr_array(2, a);
+            push_ptr(mk_str_doc(mv_string("macro"), a), &nodes);
+            push_ptr(pretty_ptr(*addr, a), &nodes);
+            out = mk_paren_doc("#<", ">", mv_sep_doc(nodes, a), a);
             break;
         }
         default: {
@@ -496,8 +508,8 @@ Document* pretty_type(PiType* type, Allocator* a) {
         case TFormer: 
             out = mv_str_doc(mk_string("Former", a), a);
             break;
-        case TTransformer: 
-            out = mv_str_doc(mk_string("Transformer", a), a);
+        case TMacro: 
+            out = mv_str_doc(mk_string("Macro", a), a);
             break;
         }
         break;
@@ -749,7 +761,7 @@ size_t pi_size_of(PiType type) {
             return sizeof(int8_t);
         case TFormer:
             return sizeof(TermFormer);
-        case TTransformer:
+        case TMacro:
             return ADDRESS_SIZE;
         default:
             panic(mv_string("pi-size-of: unrecognized primitive."));

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -988,7 +988,12 @@ void type_app_subst(PiType* body, SymPtrAssoc subst, Allocator* a) {
         type_app_subst(body->dynamic, subst, a);
         break;
     case TDistinct:
-        panic(mv_string("not implemetned type-app for distinct"));
+        type_app_subst(body->distinct.type, subst, a);
+        if (body->distinct.args) {
+            for (size_t i = 0; i < body->distinct.args->len; i++) {
+                type_app_subst(body->distinct.args->data[i], subst, a);
+            }
+        }
         break;
     case TTrait:
         for (size_t i = 0; i < body->trait.fields.len; i++) {

--- a/src/pico/values/values.c
+++ b/src/pico/values/values.c
@@ -229,6 +229,9 @@ Document* pretty_former(TermFormer op, Allocator* a) {
     case FAll:
         out = mk_str_doc(mv_string("::all"), a);
         break;
+    case FTransformer:
+        out = mk_str_doc(mv_string("::transformer"), a);
+        break;
     case FVariant:
         out = mk_str_doc(mv_string("::variant"), a);
         break;

--- a/src/pico/values/values.c
+++ b/src/pico/values/values.c
@@ -229,8 +229,8 @@ Document* pretty_former(TermFormer op, Allocator* a) {
     case FAll:
         out = mk_str_doc(mv_string("::all"), a);
         break;
-    case FTransformer:
-        out = mk_str_doc(mv_string("::transformer"), a);
+    case FMacro:
+        out = mk_str_doc(mv_string("::macro"), a);
         break;
     case FVariant:
         out = mk_str_doc(mv_string("::variant"), a);

--- a/src/platform/memory/executable.c
+++ b/src/platform/memory/executable.c
@@ -190,7 +190,7 @@ bool free_medium(void* ptr, exec_context* ctx) {
     MediumBlock** blk_ptr = &ctx->medium_blocks;
     MediumBlock* blk = ctx->medium_blocks;
     while (blk != NULL) {
-        if (ptr == blk) {
+        if (ptr == blk->block_memory.data) {
             *blk_ptr = blk->next;
             free_ex_mem(blk->block_memory);
             mem_free(blk, ctx->metadata_allocator);
@@ -212,7 +212,7 @@ bool free_large(void* ptr, exec_context* ctx) {
     LargeBlock** blk_ptr = &ctx->large_blocks;
     LargeBlock* blk = ctx->large_blocks;
     while (blk != NULL) {
-        if (ptr == blk) {
+        if (ptr == blk->block_memory.data) {
             *blk_ptr = blk->next;
             free_ex_mem(blk->block_memory);
             mem_free(blk, ctx->metadata_allocator);

--- a/src/platform/memory/executable.c
+++ b/src/platform/memory/executable.c
@@ -184,6 +184,7 @@ bool free_small(void* ptr, exec_context* ctx) {
     }
     return false;
 }
+
 bool free_medium(void* ptr, exec_context* ctx) {
     MediumBlock* blk_prev = NULL;
     MediumBlock** blk_ptr = &ctx->medium_blocks;

--- a/src/platform/memory/std_allocator.c
+++ b/src/platform/memory/std_allocator.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+#include "platform/signals.h"
 #include "platform/memory/std_allocator.h"
 
 
@@ -8,11 +9,19 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
 void* std_malloc(size_t memsize, void* ctx) {
-    return malloc(memsize);
+    void* val = malloc(memsize);
+    if (!val) {
+        panic(mv_string("malloc failed!"));
+    }
+    return val;
 }
 
 void* std_realloc(void* location, size_t memsize, void* ctx) {
-    return realloc(location, memsize);
+    void* val = realloc(location, memsize);
+    if (!val) {
+        panic(mv_string("malloc failed!"));
+    }
+    return val;
 }
 
 void std_free(void* location, void* ctx) {


### PR DESCRIPTION
Added macros, which adapt procedures of the from `Proc [(Array Syntax)] Syntax` to macros (compile-time transformers).

Also made some other improvements:
- More expressions can generate as polymorphic code (all-application, size-of, align-of)
- type-app for distinct implemented
- malloc/realloc panic instead of returning null
- Parser can now parse infix '.' and ':' as part of composite expressions,e .g. `(foo bar).baz`
- Segment and backlink codegen, meaning that nested functions are correct and string literals can be stored in definitions.
- minor fixes in several functions which had memory related UB
- fixed memory leak in executable allocator.
- `generate_size_of` returns correct value (0) for the unit type.