### PR TITLE
Floats and stdlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ DEBUG_FLAGS := -O0
 # Sanitisers currently aren't supported by gcc on windows
 ifneq ($(OS), Windows_NT)
 	DEBUG_FLAGS := $(DEBUG_FLAGS) # -fsanitize=address,leak
-	LINK_FLAGS := -ldl
+	LINK_FLAGS := -ldl -lm
 else
 	LINK_FLAGS := 
 endif

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DEBUG_FLAGS := -O0
 
 # Sanitisers currently aren't supported by gcc on windows
 ifneq ($(OS), Windows_NT)
-	DEBUG_FLAGS := $(DEBUG_FLAGS) # -fsanitize=address,leak
+	DEBUG_FLAGS := $(DEBUG_FLAGS) -fsanitize=address,leak
 	LINK_FLAGS := -ldl -lm
 else
 	LINK_FLAGS := 

--- a/include/data/float.h
+++ b/include/data/float.h
@@ -1,0 +1,7 @@
+#ifndef __DATA_FLOAT_H
+#define __DATA_FLOAT_H
+
+typedef float float32_t;
+typedef double float64_t;
+
+#endif

--- a/include/pico/stdlib/core.h
+++ b/include/pico/stdlib/core.h
@@ -4,6 +4,7 @@
 #include "pico/values/modular.h"
 
 PiType* get_array_type();
+PiType* get_maybe_type();
 PiType* get_syntax_type();
 PiType* get_either_type();
 

--- a/include/pico/stdlib/core.h
+++ b/include/pico/stdlib/core.h
@@ -4,8 +4,10 @@
 #include "pico/values/modular.h"
 
 PiType* get_array_type();
+PiType* get_ptr_type();
 PiType* get_maybe_type();
 PiType* get_syntax_type();
+PiType* get_pair_type();
 PiType* get_either_type();
 
 void add_core_module(Assembler* ass, Package* base, Allocator* a);

--- a/include/pico/stdlib/data/array.h
+++ b/include/pico/stdlib/data/array.h
@@ -1,0 +1,8 @@
+#ifndef __PICO_STDLIB_DATA_ARRAY_H
+#define __PICO_STDLIB_DATA_ARRAY_H
+
+#include "pico/values/modular.h"
+
+void add_array_module(Assembler* ass, Module* base, Allocator* a);
+
+#endif

--- a/include/pico/stdlib/data/data.h
+++ b/include/pico/stdlib/data/data.h
@@ -1,0 +1,8 @@
+#ifndef __PICO_STDLIB_DATA_DATA_H
+#define __PICO_STDLIB_DATA_DATA_H
+
+#include "pico/values/modular.h"
+
+void add_data_module(Assembler* ass, Package* base, Allocator* a);
+
+#endif

--- a/include/pico/stdlib/data/either.h
+++ b/include/pico/stdlib/data/either.h
@@ -1,0 +1,8 @@
+#ifndef __PICO_STDLIB_DATA_EITHER_H
+#define __PICO_STDLIB_DATA_EITHER_H
+
+#include "pico/values/modular.h"
+
+void add_either_module(Assembler* ass, Module* base, Allocator* a);
+
+#endif

--- a/include/pico/stdlib/data/maybe.h
+++ b/include/pico/stdlib/data/maybe.h
@@ -1,0 +1,8 @@
+#ifndef __PICO_STDLIB_DATA_MAYBE_H
+#define __PICO_STDLIB_DATA_MAYBE_H
+
+#include "pico/values/modular.h"
+
+void add_maybe_module(Assembler* ass, Module* base, Allocator* a);
+
+#endif

--- a/include/pico/stdlib/data/pair.h
+++ b/include/pico/stdlib/data/pair.h
@@ -1,0 +1,8 @@
+#ifndef __PICO_STDLIB_DATA_PAIR_H
+#define __PICO_STDLIB_DATA_PAIR_H
+
+#include "pico/values/modular.h"
+
+void add_pair_module(Assembler* ass, Module* base, Allocator* a);
+
+#endif

--- a/include/pico/stdlib/data/ptr.h
+++ b/include/pico/stdlib/data/ptr.h
@@ -1,0 +1,8 @@
+#ifndef __PICO_STDLIB_DATA_PTR_H
+#define __PICO_STDLIB_DATA_PTR_H
+
+#include "pico/values/modular.h"
+
+void add_ptr_module(Assembler* ass, Module* base, Allocator* a);
+
+#endif

--- a/include/pico/stdlib/helpers.h
+++ b/include/pico/stdlib/helpers.h
@@ -1,0 +1,13 @@
+#ifndef __PICO_STDLIB_FOREIGN_H
+#define __PICO_STDLIB_FOREIGN_H
+
+#include "pico/values/modular.h"
+
+// Compile a definition in the context of a module.
+// For example, we may be in the module "i64" and call
+// compile_toplevel("(def i64-addable instance Addable [I64] [.zero 0] [.add +])", 
+//                  ass, i64, point, a)
+// All memory allocated is free'd, 
+void compile_toplevel(const char *string, Module *module, ErrorPoint *final_point, Allocator *a);
+
+#endif

--- a/include/pico/syntax/concrete.h
+++ b/include/pico/syntax/concrete.h
@@ -13,6 +13,7 @@
 typedef enum : uint64_t {
     ABool,
     AIntegral,
+    AFloating,
     ASymbol,
     AString,
 } Atom_t;
@@ -22,6 +23,7 @@ typedef struct {
     Atom_t type;
     union {
         int64_t int_64;
+        double float_64;
         Symbol symbol;
         String string;
     };

--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -27,6 +27,8 @@ typedef enum {
     // Atoms
     SLitUntypedIntegral,
     SLitTypedIntegral,
+    SLitUntypedFloating,
+    SLitTypedFloating,
     SLitString,
     SLitBool,
     SVariable,
@@ -100,6 +102,11 @@ typedef struct {
     int64_t value;
     PrimType type;
 } SynIntegralLiteral;
+
+typedef struct {
+    double value;
+    PrimType type;
+} SynFloatingLiteral;
 
 typedef struct {
     size_t index;
@@ -301,6 +308,7 @@ struct Syntax {
     Syntax_t type;
     union {
         SynIntegralLiteral integral;
+        SynFloatingLiteral floating;
         bool boolean;
         String string;
 

--- a/include/pico/values/ctypes.h
+++ b/include/pico/values/ctypes.h
@@ -94,6 +94,8 @@ CType* copy_c_type_p(CType* t, Allocator* a);
 
 // Misc. and utility
 // Utilities for generating or manipulating types
+CType mk_void_ctype();
+
 CType mk_voidptr_ctype(Allocator* a);
 
 CType mk_primint_ctype(CPrimInt t);

--- a/include/pico/values/ctypes.h
+++ b/include/pico/values/ctypes.h
@@ -9,7 +9,9 @@ typedef struct CType CType;
 
 typedef enum {
     CSVoid,
-    CSPrim,
+    CSPrimInt,
+    CSFloat,
+    CSDouble,
     CSPtr,
     CSProc,
     CSIncomplete,
@@ -24,7 +26,7 @@ typedef enum {
     CInt,
     CLong,
     CLongLong,
-} CPrimType;
+} CIntType;
 
 typedef enum {
     Signed,
@@ -33,9 +35,9 @@ typedef enum {
 } CSigned;
 
 typedef struct {
-    CPrimType prim;
+    CIntType prim;
     CSigned is_signed;
-} CPrim;
+} CPrimInt;
 
 typedef struct {
     bool named;
@@ -51,7 +53,7 @@ typedef struct {
 } CStruct;
 
 typedef struct {
-    CPrim base;
+    CPrimInt base;
     SymI64Assoc vals;
 } CEnum;
 
@@ -66,7 +68,7 @@ typedef struct {
 struct CType {
     CSort sort;
     union {
-        CPrim prim;
+        CPrimInt prim;
         CProc proc;
         CStruct structure;
         CEnum enumeration;
@@ -76,7 +78,7 @@ struct CType {
     };
 };
 
-Document* pretty_cprim(CPrim prim, Allocator* a);
+Document* pretty_cprimint(CPrimInt prim, Allocator* a);
 Document* pretty_ctype(CType* type, Allocator* a);
 Document* pretty_cval(CType* type, void* value, Allocator* a);
 size_t c_size_align(size_t size, size_t align);
@@ -94,7 +96,7 @@ CType* copy_c_type_p(CType* t, Allocator* a);
 // Utilities for generating or manipulating types
 CType mk_voidptr_ctype(Allocator* a);
 
-CType mk_prim_ctype(CPrim t);
+CType mk_primint_ctype(CPrimInt t);
 
 // Sample usage: mk_proc_type(a, 2, arg_1_ty, arg_2_ty, ret_ty)
 CType mk_fn_ctype(Allocator* a, size_t nargs, ...);
@@ -103,7 +105,7 @@ CType mk_fn_ctype(Allocator* a, size_t nargs, ...);
 CType mk_struct_ctype(Allocator* a, size_t nfields, ...);
 
 // Sample usage: mk_enum_type(a, CInt, 2, "true", 0, "false", 1)
-CType mk_enum_ctype(Allocator* a, CPrim store, size_t nfields, ...);
+CType mk_enum_ctype(Allocator* a, CPrimInt store, size_t nfields, ...);
 
 // Sample usage: mk_union_type(a, 3, )
 CType mk_union_ctype(Allocator* a, size_t nfields, ...);

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -2,6 +2,7 @@
 #define __PICO_VALUES_TYPES_H
 
 #include "data/array.h"
+#include "data/result.h"
 #include "pretty/document.h"
 
 #include "pico/data/sym_ptr_amap.h"
@@ -178,6 +179,7 @@ bool pi_type_eql(PiType* lhs, PiType* rhs);
 
 size_t pi_size_of(PiType type);
 size_t pi_align_of(PiType type);
+Result_t pi_maybe_size_of(PiType type, size_t* out);
 
 size_t pi_size_align(size_t size, size_t align);
 size_t pi_stack_align(size_t in);

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -24,6 +24,9 @@ typedef enum {
     UInt_32 = 0b110,
     UInt_64 = 0b111,
 
+    Float_32,
+    Float_64,
+
     Unit,
     Bool,
     Address,
@@ -63,7 +66,8 @@ typedef enum {
 
   // Used only during unification
   TUVar,
-  TUVarDefaulted,
+  TUVarIntegral,
+  TUVarFloating,
 } PiType_t;
 
 typedef struct {
@@ -187,7 +191,8 @@ PiType copy_pi_type(PiType t, Allocator* a);
 PiType* copy_pi_type_p(PiType* t, Allocator* a);
 
 PiType* mk_uvar(UVarGenerator* gen, Allocator* a);
-PiType* mk_uvar_with_default(UVarGenerator* gen, Allocator* a);
+PiType* mk_uvar_integral(UVarGenerator* gen, Allocator* a);
+PiType* mk_uvar_floating(UVarGenerator* gen, Allocator* a);
 UVarGenerator* mk_gen(Allocator* a);
 void delete_gen(UVarGenerator* gen, Allocator* a);
 

--- a/include/pretty/standard_types.h
+++ b/include/pretty/standard_types.h
@@ -1,6 +1,7 @@
 #ifndef __PRETTY_STANDARD_TYPES_H
 #define __PRETTY_STANDARD_TYPES_H
 
+#include "data/float.h"
 #include "platform/memory/allocator.h"
 #include "pretty/document.h"
 
@@ -12,6 +13,8 @@ Document* pretty_u64(uint64_t val, Allocator* a);
 Document* pretty_u32(uint32_t val, Allocator* a);
 Document* pretty_u16(uint16_t val, Allocator* a);
 Document* pretty_u8 (uint8_t val,  Allocator* a);
+Document* pretty_f32(float32_t val, Allocator* a);
+Document* pretty_f64(float64_t val,  Allocator* a);
 Document* pretty_ptr(void*    val, Allocator* a);
 
 Document* pretty_hex_u8(uint8_t val, Allocator* a);
@@ -27,5 +30,8 @@ Document* pretty_ushort(unsigned short val, Allocator* a);
 Document* pretty_uint(unsigned int val, Allocator* a);
 Document* pretty_ulong(unsigned long val, Allocator* a);
 Document* pretty_ulong_long(unsigned long long val, Allocator* a);
+
+Document* pretty_float(float val, Allocator* a);
+Document* pretty_double(double val, Allocator* a);
 
 #endif

--- a/src/app/module_load.c
+++ b/src/app/module_load.c
@@ -70,6 +70,10 @@ void load_module_from_istream(IStream* in, OStream* serr, Package* package, Modu
             release_arena_allocator(arena);
             return;
         }
+        if (res.type == ParseNone) {
+            release_arena_allocator(arena);
+            return;
+        }
         if (res.type != ParseSuccess) {
             write_string(mv_string("Parse Returned Invalid Result!\n"), serr);
             release_arena_allocator(arena);
@@ -149,6 +153,10 @@ void run_script_from_istream(IStream* in, OStream* serr, Module* current, Alloca
 
         if (res.type == ParseFail) {
             write_string(mv_string("Parse Failed :(\n"), serr);
+            release_arena_allocator(arena);
+            return;
+        }
+        if (res.type == ParseNone) {
             release_arena_allocator(arena);
             return;
         }

--- a/src/app/module_load.c
+++ b/src/app/module_load.c
@@ -70,10 +70,6 @@ void load_module_from_istream(IStream* in, OStream* serr, Package* package, Modu
             release_arena_allocator(arena);
             return;
         }
-        if (res.type == ParseNone) {
-            release_arena_allocator(arena);
-            return;
-        }
         if (res.type != ParseSuccess) {
             write_string(mv_string("Parse Returned Invalid Result!\n"), serr);
             release_arena_allocator(arena);
@@ -153,10 +149,6 @@ void run_script_from_istream(IStream* in, OStream* serr, Module* current, Alloca
 
         if (res.type == ParseFail) {
             write_string(mv_string("Parse Failed :(\n"), serr);
-            release_arena_allocator(arena);
-            return;
-        }
-        if (res.type == ParseNone) {
             release_arena_allocator(arena);
             return;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -68,11 +68,6 @@ bool repl_iter(IStream* cin, OStream* cout, Allocator* a, Allocator* exec, Modul
         release_arena_allocator(arena);
         return true;
     }
-    if (res.type == ParseNone) {
-        // If parse is none, means encountered EOF, so exit!
-        release_arena_allocator(arena);
-        return false;
-    }
     if (res.type != ParseSuccess) {
         // If parse is invalid, means internal bug, so better exit soon!
         write_string(mv_string("Parse Returned Invalid Result!\n"), cout);

--- a/src/main.c
+++ b/src/main.c
@@ -68,6 +68,10 @@ bool repl_iter(IStream* cin, OStream* cout, Allocator* a, Allocator* exec, Modul
         release_arena_allocator(arena);
         return false;
     }
+    if (res.type == ParseNone) {
+        release_arena_allocator(arena);
+        return false;
+    }
     if (res.type != ParseSuccess) {
         write_string(mv_string("Parse Returned Invalid Result!\n"), cout);
         release_arena_allocator(arena);

--- a/src/main.c
+++ b/src/main.c
@@ -66,13 +66,15 @@ bool repl_iter(IStream* cin, OStream* cout, Allocator* a, Allocator* exec, Modul
     if (res.type == ParseFail) {
         write_string(mv_string("Parse Failed :(\n"), cout);
         release_arena_allocator(arena);
-        return false;
+        return true;
     }
     if (res.type == ParseNone) {
+        // If parse is none, means encountered EOF, so exit!
         release_arena_allocator(arena);
         return false;
     }
     if (res.type != ParseSuccess) {
+        // If parse is invalid, means internal bug, so better exit soon!
         write_string(mv_string("Parse Returned Invalid Result!\n"), cout);
         release_arena_allocator(arena);
         return false;

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -1422,6 +1422,14 @@ Syntax* abstract_expr_i(RawTree raw, ShadowEnv* env, Allocator* a, ErrorPoint* p
             };
             break;
         }
+        case AFloating: {
+            *res = (Syntax) {
+                .type = SLitUntypedFloating,
+                .ptype = NULL,
+                .floating.value = raw.atom.float_64,
+            };
+            break;
+        }
         case ABool: {
             *res = (Syntax) {
                 .type = SLitBool,

--- a/src/pico/analysis/abstraction.c
+++ b/src/pico/analysis/abstraction.c
@@ -670,7 +670,7 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         return res;
     }
     case FDynamic: {
-        if (raw.branch.nodes.len <= 2) {
+        if (raw.branch.nodes.len < 2) {
             throw_error(point, mv_string("Malformed dynamic expression: expects at least 1 arg."));
         }
         RawTree* body = raw.branch.nodes.len == 2 ? raw.branch.nodes.data[1] : raw_slice(&raw, 1, a);
@@ -750,10 +750,10 @@ Syntax* mk_term(TermFormer former, RawTree raw, ShadowEnv* env, Allocator* a, Er
         size_t index = 1;
 
         bool is_special = true;
-        while (is_special) {
+        while (is_special && index < raw.branch.nodes.len) {
             RawTree* bind = raw.branch.nodes.data[index];
-            // let [x₁ e₁]
-            //     [x₂ e₂]
+            // bind [x₁ e₁]
+            //      [x₂ e₂]
             //  body
             is_special = bind->type == RawBranch && bind->branch.hint == HSpecial;
             if (is_special) {

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -438,7 +438,7 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
 
         PiType* enum_type = untyped->match.val->ptype;
         if (enum_type->sort != TEnum) {
-            throw_error(point, mv_string("Match expects value to have an enum type!"));
+            throw_error(point, mv_string("Match expects value to have an enum type."));
         }
 
         // Typecheck each variant, ensure they are the same
@@ -455,6 +455,9 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
                 if (clause->tagname == enum_type->enumeration.variants.data[j].key) {
                     found_tag = true;
                     clause->tag = j;
+                    if (used_indices.data[j] != 0) {
+                        throw_error(point, mv_string("Same tag occurs twice in match body."));
+                    }
                     used_indices.data[j] = 1;
                 }
             }
@@ -464,7 +467,7 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
             }
 
             // Now we've found the tag, typecheck the body
-            PtrArray* types_to_bind = enum_type->enumeration.variants.data[i].val;
+            PtrArray* types_to_bind = enum_type->enumeration.variants.data[clause->tag].val;
             if (types_to_bind->len != clause->vars.len) {
                 throw_error(point,  mv_string("Bad number of binds!"));
             }

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -527,6 +527,9 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
     case SProjector: {
         type_infer_i(untyped->projector.val, env, gen, a, point);
         PiType source_type = *untyped->projector.val->ptype;
+        while (source_type.sort == TDistinct && source_type.distinct.source_module == NULL) {
+            source_type = *source_type.distinct.type;
+        }
         if (source_type.sort == TStruct) {
             // search for field
             PiType* ret_ty = NULL;

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -437,6 +437,11 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
         type_infer_i(untyped->match.val, env, gen, a, point);
 
         PiType* enum_type = untyped->match.val->ptype;
+        // Unwrap any distinct type. Note that we do NOT unwrap opaque types!
+        while (enum_type->sort == TDistinct && enum_type->distinct.source_module == NULL) {
+            enum_type = enum_type->distinct.type;
+        }
+
         if (enum_type->sort != TEnum) {
             throw_error(point, mv_string("Match expects value to have an enum type."));
         }

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -120,9 +120,16 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
     switch (untyped->type) {
     case SLitUntypedIntegral:
         untyped->type = SLitTypedIntegral;
-        untyped->ptype = mk_uvar_with_default(gen, a);
+        untyped->ptype = mk_uvar_integral(gen, a);
         break;
     case SLitTypedIntegral:
+        untyped->ptype = mk_prim_type(a, untyped->integral.type);
+        break;
+    case SLitUntypedFloating:
+        untyped->type = SLitTypedFloating;
+        untyped->ptype = mk_uvar_floating(gen, a);
+        break;
+    case SLitTypedFloating:
         untyped->ptype = mk_prim_type(a, untyped->integral.type);
         break;
     case SLitBool:
@@ -1070,6 +1077,8 @@ void instantiate_implicits(Syntax* syn, TypeEnv* env, Allocator* a, ErrorPoint* 
     switch (syn->type) {
     case SLitUntypedIntegral:
     case SLitTypedIntegral:
+    case SLitUntypedFloating:
+    case SLitTypedFloating:
     case SLitString:
     case SLitBool:
     case SVariable:
@@ -1357,6 +1366,8 @@ void squash_types(Syntax* typed, Allocator* a, ErrorPoint* point) {
     switch (typed->type) {
     case SLitUntypedIntegral:
     case SLitTypedIntegral:
+    case SLitUntypedFloating:
+    case SLitTypedFloating:
     case SLitBool:
     case SLitString:
     case SVariable:

--- a/src/pico/analysis/typecheck.c
+++ b/src/pico/analysis/typecheck.c
@@ -367,6 +367,9 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
     case SConstructor: {
         // Typecheck variant
         PiType* enum_type = eval_type(untyped->variant.enum_type, env, a, gen, point);
+        while (enum_type->sort == TDistinct && enum_type->distinct.source_module == NULL) {
+            enum_type = enum_type->distinct.type;
+        }
 
         if (enum_type->sort != TEnum) {
             throw_error(point, mv_string("Variant must be of enum type."));
@@ -398,8 +401,10 @@ void type_infer_i(Syntax* untyped, TypeEnv* env, UVarGenerator* gen, Allocator* 
     case SVariant: {
         // Typecheck variant
         PiType* enum_type = eval_type(untyped->variant.enum_type, env, a, gen, point);
+        while (enum_type->sort == TDistinct && enum_type->distinct.source_module == NULL) {
+            enum_type = enum_type->distinct.type;
+        }
 
-        // Typecheck is pretty simple: ensure that the tag is present in the
         if (enum_type->sort != TEnum) {
             throw_error(point, mv_string("Variant must be of enum type."));
         }

--- a/src/pico/analysis/unify.c
+++ b/src/pico/analysis/unify.c
@@ -466,8 +466,8 @@ void squash_type(PiType* type) {
         break;
     }
     case TTrait: {
-        // TODO (INVESTIGATE BUG): do we need to sqyash implicits also?
-        for (size_t i = 0; i < type->structure.fields.len; i++) {
+        // TODO (INVESTIGATE PERFORMANCE): do we need to squash implicits also?
+        for (size_t i = 0; i < type->trait.fields.len; i++) {
             squash_type((type->trait.fields.data + i)->val);
         }
         break;

--- a/src/pico/analysis/unify.c
+++ b/src/pico/analysis/unify.c
@@ -40,6 +40,14 @@ Result unify(PiType* lhs, PiType* rhs, Allocator* a) {
         out = assert_maybe_integral(rhs);
         if (out.type == Ok) lhs->uvar->subst = rhs;
     }
+    else if (rhs->sort == TUVarIntegral) {
+        out = assert_maybe_integral(rhs);
+        if (out.type == Ok) rhs->uvar->subst = lhs;
+    }
+    else if (lhs->sort == TUVarFloating) {
+        out = assert_maybe_floating(lhs);
+        if (out.type == Ok) lhs->uvar->subst = rhs;
+    }
     else if (rhs->sort == TUVarFloating) {
         out = assert_maybe_floating(lhs);
         if (out.type == Ok) rhs->uvar->subst = lhs;

--- a/src/pico/analysis/unify.c
+++ b/src/pico/analysis/unify.c
@@ -9,6 +9,7 @@ PiType* trace_uvar(PiType* uvar);
 Result unify_eq(PiType* lhs, PiType* rhs, Allocator* a);
 
 Result assert_maybe_integral(PiType* type);
+Result assert_maybe_floating(PiType* type);
 
 Result unify(PiType* lhs, PiType* rhs, Allocator* a) {
     // Unification Implementation:
@@ -35,12 +36,12 @@ Result unify(PiType* lhs, PiType* rhs, Allocator* a) {
         rhs->uvar->subst = lhs;
         out.type = Ok;
     }
-    else if (lhs->sort == TUVarDefaulted) {
+    else if (lhs->sort == TUVarIntegral) {
         out = assert_maybe_integral(rhs);
         if (out.type == Ok) lhs->uvar->subst = rhs;
     }
-    else if (rhs->sort == TUVarDefaulted) {
-        out = assert_maybe_integral(lhs);
+    else if (rhs->sort == TUVarFloating) {
+        out = assert_maybe_floating(lhs);
         if (out.type == Ok) rhs->uvar->subst = lhs;
     }
     else if (rhs->sort == lhs->sort)
@@ -251,7 +252,26 @@ Result assert_maybe_integral(PiType* type) {
         // If it is a primtive, check it is integral type
         if (type->sort == TPrim && (type->prim < 0b1000)) {
             return (Result) {.type = Ok};
-        } else if (type->sort == TUVar || type->sort == TUVarDefaulted) {
+        } else if (type->sort == TUVar || type->sort == TUVarIntegral) {
+            // continue on to next iteration
+            type = type->uvar->subst;
+        } else {
+            return (Result) {
+                .type = Err,
+                .error_message = mv_string("Cannot unify an integral type with a non-integral type!"),
+            };
+        }
+    }
+    return (Result) {.type = Ok};
+}
+
+Result assert_maybe_floating(PiType* type) {
+    // Use a while loop to trace through uvars
+    while (type) {
+        // If it is a primtive, check it is integral type
+        if (type->sort == TPrim && (type->prim == Float_32 || type->prim == Float_64)) {
+            return (Result) {.type = Ok};
+        } else if (type->sort == TUVar || type->sort == TUVarFloating) {
             // continue on to next iteration
             type = type->uvar->subst;
         } else {
@@ -367,7 +387,9 @@ bool has_unification_vars_p(PiType type) {
             return has_unification_vars_p(*type.uvar->subst);
         }
 
-    case TUVarDefaulted: return false;
+    case TUVarIntegral:
+    case TUVarFloating:
+        return false;
     }
 
     // If we are here, then none of the branches were taken!
@@ -375,7 +397,8 @@ bool has_unification_vars_p(PiType type) {
 }
 
 PiType* trace_uvar(PiType* uvar) {
-    while ((uvar->sort == TUVar || uvar->sort == TUVarDefaulted) && uvar->uvar->subst != NULL) {
+  while ((uvar->sort == TUVar || uvar->sort == TUVarIntegral || uvar->sort == TUVarFloating)
+         && uvar->uvar->subst != NULL) {
         uvar = uvar->uvar->subst;
     } 
     return uvar;
@@ -464,13 +487,23 @@ void squash_type(PiType* type) {
         } 
         break;
     }
-    case TUVarDefaulted: {
+    case TUVarIntegral: {
         PiType* subst = type->uvar->subst;
         if (subst) {
             squash_type(subst);
             *type = *subst;
         } else {
             *type = (PiType) {.sort = TPrim, .prim = Int_64,};
+        }
+        break;
+    }
+    case TUVarFloating: {
+        PiType* subst = type->uvar->subst;
+        if (subst) {
+            squash_type(subst);
+            *type = *subst;
+        } else {
+            *type = (PiType) {.sort = TPrim, .prim = Float_64,};
         }
         break;
     }

--- a/src/pico/binding/address_env.c
+++ b/src/pico/binding/address_env.c
@@ -60,7 +60,6 @@ typedef struct {
 } LocalAddrs;
 
 struct AddressEnv {
-    LocalType type;
     Environment* env;
 
     // To handle recursive top level definitions.

--- a/src/pico/binding/address_env.c
+++ b/src/pico/binding/address_env.c
@@ -381,9 +381,11 @@ void address_bind_enum_vars(SymSizeAssoc vars, AddressEnv* env) {
 
         // Variables are in reverse order!
         // due to how the stack pushes/pops args.
+
+        // TODO: in (some x), x getting bound to a sentinel!
         for (size_t i = 0; i < vars.len; i++) {
             SAddr local;
-            local.type = SASentinel;
+            local.type = SADirect;
 
             local.symbol = vars.data[i].key;
             local.stack_offset = stack_offset;

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -115,6 +115,16 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
         address_stack_grow(env, pi_size_of(*syn.ptype));
         break;
     }
+    case SLitUntypedFloating: 
+        panic(mv_string("Cannot generate monomorphic code for untyped floating!"));
+    case SLitTypedFloating: {
+        void* raw = &syn.integral.value;
+        int64_t immediate = *(int64_t*)raw;
+        build_binary_op(ass, Mov, reg(RAX,sz_64), imm64(immediate), a, point);
+        build_unary_op(ass, Push, reg(RAX,sz_64), a, point);
+        address_stack_grow(env, pi_size_of(*syn.ptype));
+        break;
+    }
     case SLitBool: {
         int8_t immediate = syn.boolean;
         build_unary_op(ass, Push, imm8(immediate), a, point);

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -183,6 +183,7 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
                 AsmResult out = build_binary_op(ass, Mov, reg(R9, sz_64), imm64(*(uint64_t*)e.value), a, point);
                 backlink_global(syn.variable, out.backlink, links, a);
                 build_unary_op(ass, Push, reg(R9, sz_64), a, point);
+
             // Primitives are (currently) all <= 64 bits, but may treating them
             // as 64-bits may overflow a allocated portion of memory, so we must
             // be more careful here.

--- a/src/pico/codegen/codegen.c
+++ b/src/pico/codegen/codegen.c
@@ -514,6 +514,11 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
     case SMatch: {
         // Generate code for the value
         Syntax* match_value = syn.match.val;
+        PiType* enum_type = syn.match.val->ptype;
+        // Unwrap any distinct type. Note that we do NOT unwrap opaque types!
+        while (enum_type->sort == TDistinct && enum_type->distinct.source_module == NULL) {
+            enum_type = enum_type->distinct.type;
+        }
         size_t enum_size = pi_size_of(*match_value->ptype);
         size_t out_size = pi_size_of(*syn.ptype);
 
@@ -552,7 +557,7 @@ void generate(Syntax syn, AddressEnv* env, Target target, InternalLinkData* link
             *branch_ref = (uint8_t)(body_pos - branch_pos);
 
             SynClause clause = *(SynClause*)syn.match.clauses.data[i];
-            PtrArray variant_types = *(PtrArray*)match_value->ptype->enumeration.variants.data[clause.tag].val; 
+            PtrArray variant_types = *(PtrArray*)enum_type->enumeration.variants.data[clause.tag].val; 
 
             // Bind Clause Vars 
             SymSizeAssoc arg_sizes = mk_sym_size_assoc(variant_types.len, a);

--- a/src/pico/codegen/foreign_adapters.c
+++ b/src/pico/codegen/foreign_adapters.c
@@ -211,17 +211,18 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
     }
 
     // We need knowledge of the stack layout of the input arguments when
-    // constructing the function call: We know that pico are pushed
+    // constructing the function call: We know that in pico args are pushed
     // left-to-right, meaning the last argument is on the bottom of the stack
-    // (offset 0). 
+    // (offset 8). This means we need to go through thelist backwards!
     U64Array arg_offsets = mk_u64_array(ctype->proc.args.len + 1, a);
+    arg_offsets.len = arg_offsets.size;
     uint64_t offset = ADDRESS_SIZE; // To account for return address
-    for (size_t i = 0; i < ptype->proc.args.len; i++) {
-        push_u64(offset, &arg_offsets); 
-        size_t idx = ctype->proc.args.len - (i + 1);
-        offset += pi_size_of(*(PiType*)ptype->proc.args.data[idx]);
+    for (size_t i = 0; i < ctype->proc.args.len; i++) {
+        size_t idx = arg_offsets.len - (i + 1);
+        arg_offsets.data[idx] = offset;
+        offset += pi_size_of(*(PiType*)ptype->proc.args.data[idx - 1]);
     }
-    push_u64(offset, &arg_offsets);
+    arg_offsets.data[0] = offset;
 
 #if ABI == SYSTEM_V_64
     // Notes: 
@@ -279,13 +280,13 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
               } else {
                   Regname next_reg = integer_registers[current_integer_register++];
                   // I8 max = 127
-                  if (arg_offsets.data[i] > 127) {
+                  if (arg_offsets.data[i + 1] > 127) {
                       throw_error(point, mv_string("convert_c_fn: arg offset exeeds I8 max."));
                   }
                   // Explanation - copy into current register
                   // copy from RSP + current offset + return address offset + eightbyte_index
                   build_binary_op(ass, Mov, reg(next_reg, sz_64),
-                                  rref8(RSP, arg_offsets.data[i] + 0x8 * j, sz_64),
+                                  rref8(RSP, arg_offsets.data[i + 1] + 0x8 * j, sz_64),
                                   a, point);
               }
               break;
@@ -364,10 +365,10 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
     for (size_t i = 0; i < in_memory_args.len; i++) {
         // pass in memory - reserve space on stack:
         size_t arg_idx = in_memory_args.data[i];
-        size_t arg_size = arg_offsets.data[arg_idx + 1] - arg_offsets.data[arg_idx];
+        size_t arg_size = arg_offsets.data[arg_idx] - arg_offsets.data[arg_idx + 1];
         build_binary_op(ass, Sub, reg(RSP, sz_64), imm32(arg_size), a, point);
         build_binary_op(ass, Mov, reg(R10, sz_64), reg(RBX, sz_64), a, point);
-        build_binary_op(ass, Add, reg(R10, sz_64), imm32(arg_offsets.data[arg_idx]), a, point);
+        build_binary_op(ass, Add, reg(R10, sz_64), imm32(arg_offsets.data[arg_idx + 1]), a, point);
         generate_monomorphic_copy(RSP, R10, arg_size, ass, a, point);
     }
 
@@ -392,7 +393,7 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
         //   0x10 = Return address + Align adjust
         //   However, arg_offsets include an extra + 0x8 to account for return
         //        address, so we subtract 0x8 from 0x10 to get 0x8 
-        size_t unadjusted_offset = 0x8 + input_area_size + arg_offsets.data[arg_offsets.len -  1] - return_arg_size;
+        size_t unadjusted_offset = 0x8 + input_area_size + arg_offsets.data[0] - return_arg_size;
 
         // in RBX, store the stack alignment adjust (i.e. the size of the align padding)
         build_binary_op(ass, Mov, reg(RBX, sz_64), rref8(RSP, input_area_size, sz_64), a, point);
@@ -415,7 +416,7 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
         // Then, pop all memory (sans the return arg) from the stack.
         build_binary_op(ass, Add, reg(RSP, sz_64), imm32(input_area_size), a, point);
         build_binary_op(ass, Add, reg(RSP, sz_64), reg(RBX, sz_64), a, point);
-        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(0x8 + arg_offsets.data[arg_offsets.len -  1] - return_arg_size), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(0x8 + arg_offsets.data[0] - return_arg_size), a, point);
 
         // Push return address
         build_unary_op(ass, Push, reg(RCX, sz_64), a, point);
@@ -427,7 +428,7 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
 
         build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
 
-        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(arg_offsets.data[arg_offsets.len -  1] - 0x8), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(arg_offsets.data[0] - 0x8), a, point);
 
         // Now, push registers onto stack
         size_t current_return_register = 0;
@@ -442,7 +443,7 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
                 } else {
                     Regname next_reg = return_integer_registers[current_return_register++];
                     // I8 max = 127
-                    if (arg_offsets.data[i] > 127) {
+                    if (arg_offsets.data[i + 1] > 127) {
                         throw_error(point, mv_string("convert_c_fn: arg offset exeeds I8 max."));
                     }
                     // Push from registers into memory
@@ -474,7 +475,6 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
             if (pass_return_in_memory) break;
         }
     }
-    build_unary_op(ass, Push, reg(RCX, sz_64), a, point);
     build_nullary_op(ass, Ret, a, point);
 
     sdelete_u8_array(return_classes);
@@ -541,7 +541,7 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
     // Note: for Win 64 ABI, arguments are push left-to-right, meaning the
     // rightmost argument is at the bottom of the stack. 
     for (size_t i = 0; i < ctype->proc.args.len; i++) {
-      if (i < 4) {
+      if (current_register < 4) {
           Win64ArgClass class = win_64_arg_class(ctype->proc.args.data[i].val);
           switch (class) {
           case Win64None: // Do nothing!
@@ -552,20 +552,25 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
           case Win64SmallAggregate: {
               Regname next_reg = integer_registers[current_register++];
               build_binary_op(ass, Mov, reg(next_reg, sz_64),
-                              rref8(RBX, arg_offsets.data[i], sz_64),
+                              rref8(RBX, arg_offsets.data[i + 1], sz_64),
                               a, point);
               break;
           }
           case Win64LargeAggregate: {
               Regname next_reg = integer_registers[current_register++];
-              // For windows, arguments are already on the stack (?), so just point them to the correct offset!
+              // we know that next_reg is about to hold a pointer to this
+              // argument, so we can safely use it as a scratch register.
+              // In this case, it stores the source of the stack argument (to copy)
               build_binary_op(ass, Mov, reg(next_reg, sz_64), reg(RBX, sz_64), a, point);
-              build_binary_op(ass, Add, reg(next_reg, sz_64), imm8(arg_offsets.data[i]), a, point);
+              build_binary_op(ass, Add, reg(next_reg, sz_64), imm8(arg_offsets.data[i + 1]), a, point);
 
               // TODO (IMPROVEMENT) what if different sizes?
-              size_t arg_size = arg_offsets.data[i + 1] - arg_offsets.data[i];
+              // Copy the argument to the bottom of the stack.
+              size_t arg_size = arg_offsets.data[i] - arg_offsets.data[i + 1];
               build_binary_op(ass, Sub, reg(RSP, sz_64), imm8(arg_size), a, point);
               generate_monomorphic_copy(RSP, next_reg, arg_size, ass, a, point);
+
+              // Now, update the register to point to the argument.
               build_binary_op(ass, Mov, reg(next_reg, sz_64), reg(RSP, sz_64), a, point);
               break;
           }
@@ -574,9 +579,14 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
           }
           }
       } else {
-          Regname next_reg = integer_registers[current_register++];
-          build_binary_op(ass, Mov, reg(next_reg, sz_64), reg(RBX, sz_64), a, point);
-          build_binary_op(ass, Add, reg(next_reg, sz_64), imm8(arg_offsets.data[i]), a, point);
+          build_binary_op(ass, Mov, reg(R10, sz_64), reg(RBX, sz_64), a, point);
+          build_binary_op(ass, Add, reg(R10, sz_64), imm8(arg_offsets.data[i + 1]), a, point);
+
+          // TODO (IMPROVEMENT) what if different sizes?
+          // Copy the argument to the bottom of the stack.
+          size_t arg_size = arg_offsets.data[i] - arg_offsets.data[i + 1];
+          build_binary_op(ass, Sub, reg(RSP, sz_64), imm8(arg_size), a, point);
+          generate_monomorphic_copy(RSP, R10, arg_size, ass, a, point);
       }
     }
     
@@ -598,7 +608,7 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
         //   0x10 = Return address + Align adjust
         //   However, arg_offsets include an extra + 0x8 to account for return
         //        address, so we subtract 0x8 from 0x10 to get 0x8 
-        size_t unadjusted_offset = 0x8 + input_area_size + arg_offsets.data[arg_offsets.len -  1] - return_arg_size;
+        size_t unadjusted_offset = 0x8 + input_area_size + arg_offsets.data[0] - return_arg_size;
 
         // in RBX, store the stack alignment adjust (i.e. the size of the align padding)
         build_binary_op(ass, Mov, reg(RBX, sz_64), rref8(RSP, input_area_size, sz_64), a, point);
@@ -624,10 +634,11 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
         // Then, pop all memory (sans the return arg) from the stack.
         build_binary_op(ass, Add, reg(RSP, sz_64), imm32(return_arg_size), a, point);
         build_binary_op(ass, Add, reg(RSP, sz_64), reg(RBX, sz_64), a, point);
-        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(0x8 + arg_offsets.data[arg_offsets.len -  1] - return_arg_size), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(0x8 + arg_offsets.data[0] - return_arg_size), a, point);
 
         // Push return address
         build_unary_op(ass, Push, reg(RCX, sz_64), a, point);
+
     } else {
         // Pop all memory arguments (both pico and c)
         build_binary_op(ass, Add, reg(RSP, sz_64), imm32(input_area_size), a, point);
@@ -638,7 +649,7 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
         build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
 
         // The offsets account for the return address (which we just popped!), therefore subtract 0x8
-        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(arg_offsets.data[arg_offsets.len -  1] - 0x8), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(arg_offsets.data[0] - 0x8), a, point);
 
         // Now, push result onto stack
         build_unary_op(ass, Push, reg(RAX, sz_64), a, point);

--- a/src/pico/codegen/foreign_adapters.c
+++ b/src/pico/codegen/foreign_adapters.c
@@ -423,9 +423,11 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
         // Pop all memory arguments (both pico and c)
         build_binary_op(ass, Add, reg(RSP, sz_64), imm32(input_area_size), a, point);
         build_binary_op(ass, Add, reg(RSP, sz_64), rref8(RSP, 0, sz_64), a, point);
-        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(0x8 + arg_offsets.data[arg_offsets.len -  1]), a, point);
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm8(8), a, point);
 
         build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+
+        build_binary_op(ass, Add, reg(RSP, sz_64), imm32(arg_offsets.data[arg_offsets.len -  1] - 0x8), a, point);
 
         // Now, push registers onto stack
         size_t current_return_register = 0;

--- a/src/pico/codegen/foreign_adapters.c
+++ b/src/pico/codegen/foreign_adapters.c
@@ -355,8 +355,8 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
     // Was RDX < R10? 
     build_binary_op(ass, CMovL, reg(R11, sz_64), reg(RDX, sz_64), a, point);
     
-    build_unary_op(ass, Push, reg(R11, sz_64), a, point);
     build_binary_op(ass, Sub, reg(RSP, sz_64), reg(R11, sz_64), a, point);
+    build_unary_op(ass, Push, reg(R11, sz_64), a, point);
 
     // Restore value of RDX
     build_binary_op(ass, Mov, reg(RDX, sz_64), reg(R12, sz_64), a, point);
@@ -528,8 +528,8 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
     // Was RDX < R10? 
     build_binary_op(ass, CMovL, reg(R11, sz_64), reg(RDX, sz_64), a, point);
     
-    build_unary_op(ass, Push, reg(R11, sz_64), a, point);
     build_binary_op(ass, Sub, reg(RSP, sz_64), reg(R11, sz_64), a, point);
+    build_unary_op(ass, Push, reg(R11, sz_64), a, point);
 
     // Check for return arg/space
     if (pass_in_memory) {

--- a/src/pico/codegen/foreign_adapters.c
+++ b/src/pico/codegen/foreign_adapters.c
@@ -425,6 +425,8 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
         build_binary_op(ass, Add, reg(RSP, sz_64), rref8(RSP, 0, sz_64), a, point);
         build_binary_op(ass, Add, reg(RSP, sz_64), imm32(0x8 + arg_offsets.data[arg_offsets.len -  1]), a, point);
 
+        build_unary_op(ass, Pop, reg(RCX, sz_64), a, point);
+
         // Now, push registers onto stack
         size_t current_return_register = 0;
         const Regname return_integer_registers[2] = {RAX, RDX};
@@ -470,6 +472,7 @@ void convert_c_fn(void* cfn, CType* ctype, PiType* ptype, Assembler* ass, Alloca
             if (pass_return_in_memory) break;
         }
     }
+    build_unary_op(ass, Push, reg(RCX, sz_64), a, point);
     build_nullary_op(ass, Ret, a, point);
 
     sdelete_u8_array(return_classes);

--- a/src/pico/codegen/internal.c
+++ b/src/pico/codegen/internal.c
@@ -92,11 +92,11 @@ void generate_stack_copy(Regname dest, size_t size, Assembler* ass, Allocator* a
 
     // First, assert that size_t is divisible by 8 ( we use rax for copies )
     if (size > 255)  {
-        throw_error(point, mv_string("Error in generate_monomorphic_copy: copy size must be smaller than 255!"));
+        throw_error(point, mv_string("Error in generate_stack_copy: copy size must be smaller than 255!"));
     };
 
     if (src == RAX || dest == RAX)  {
-        throw_error(point, mv_string("Error in generate_monomorphic_copy: cannoy copy from/to RAX"));
+        throw_error(point, mv_string("Error in generate_stack_copy: cannoy copy from/to RAX"));
     };
 
     for (size_t i = 0; i < size / 8; i++) {

--- a/src/pico/codegen/polymorphic.c
+++ b/src/pico/codegen/polymorphic.c
@@ -130,9 +130,12 @@ void generate_polymorphic_i(Syntax syn, AddressEnv* env, Target target, Internal
         build_unary_op(ass, Push, imm8(immediate), a, point);
         break;
     }
-    case SVariable: {
+    case SVariable:
+    case SAbsVariable: {
         // Lookup the variable in the assembly envionrment
-        AddressEntry e = address_env_lookup(syn.variable, env);
+        AddressEntry e = (syn.type == SVariable)
+            ? address_env_lookup(syn.variable, env)
+            : address_abs_lookup(syn.abvar, env);
         switch (e.type) {
         case ALocalDirect:
             // TODO (UB BUG): this won't work for values > 64 bits wide!

--- a/src/pico/codegen/polymorphic.c
+++ b/src/pico/codegen/polymorphic.c
@@ -557,51 +557,44 @@ void generate_align_of(Regname dest, PiType* type, AddressEnv* env, Assembler* a
 }
 
 void generate_stack_size_of(Regname dest, PiType* type, AddressEnv* env, Assembler* ass, Allocator* a, ErrorPoint* point) {
-    switch (type->sort) {
-    case TPrim:
-    case TProc:
-    case TTraitInstance:
-        build_binary_op(ass, Mov, reg(dest, sz_64), imm32(pi_stack_size_of(*type)), a, point);
-        break;
-    case TVar: {
-        AddressEntry e = address_env_lookup(type->var, env);
-        switch (e.type) {
-        case ALocalDirect:
-            build_binary_op(ass, Mov, reg(dest, sz_64), rref8(RBP, e.stack_offset, sz_64), a, point);
-            build_binary_op(ass, And, reg(dest, sz_64), imm32(0xFFFFFFF), a, point);
-            break;
-        case ALocalIndirect:
-            panic(mv_string("cannot generate code for local indirect."));
-            break;
-        case AGlobal:
-            panic(mv_string("Unexpected type variable sort: Global."));
-            break;
-        case ATypeVar:
-            panic(mv_string("Unexpected type variable sort: ATypeVar."));
-            break;
-        case ANotFound: {
-            panic(mv_string("Type Variable not found during codegen."));
-            break;
+    size_t sz; 
+    Result_t sz_res = pi_maybe_size_of(*type, &sz);
+    if (sz_res == Ok) {
+        build_binary_op(ass, Mov, reg(dest, sz_64), imm32(sz), a, point);
+    } else {
+        if (type->sort == TVar) {
+            AddressEntry e = address_env_lookup(type->var, env);
+            switch (e.type) {
+            case ALocalDirect:
+                build_binary_op(ass, Mov, reg(dest, sz_64), rref8(RBP, e.stack_offset, sz_64), a, point);
+                build_binary_op(ass, And, reg(dest, sz_64), imm32(0xFFFFFFF), a, point);
+                break;
+            case ALocalIndirect:
+                panic(mv_string("cannot generate code for local indirect."));
+                break;
+            case AGlobal:
+                panic(mv_string("Unexpected type variable sort: Global."));
+                break;
+            case ATypeVar:
+                panic(mv_string("Unexpected type variable sort: ATypeVar."));
+                break;
+            case ANotFound: {
+                panic(mv_string("Type Variable not found during codegen."));
+                break;
+            }
+            case ATooManyLocals: {
+                throw_error(point, mk_string("Too Many Local variables!", a));
+                break;
+            }
+            }
+        } else {
+            // TODO BUG: This seems to cause crashes!
+            PtrArray nodes = mk_ptr_array(4, a);
+            push_ptr(mv_str_doc(mv_string("Unrecognized type provided to generate_stack_size_of:"), a), &nodes);
+            push_ptr(pretty_type(type, a), &nodes);
+            Document* message = mk_sep_doc(nodes, a);
+            panic(doc_to_str(message, a));
         }
-        case ATooManyLocals: {
-            throw_error(point, mk_string("Too Many Local variables!", a));
-            break;
-        }
-        }
-        break;
-    }
-    case TDistinct: {
-        generate_stack_size_of(dest, type->distinct.type, env, ass, a, point);
-        break;
-    }
-    default: {
-        // TODO BUG: This seems to cause crashes!
-        PtrArray nodes = mk_ptr_array(4, a);
-        push_ptr(mv_str_doc(mv_string("Unrecognized type provided to generate_stack_size_of:"), a), &nodes);
-        push_ptr(pretty_type(type, a), &nodes);
-        Document* message = mk_sep_doc(nodes, a);
-        panic(doc_to_str(message, a));
-    }
     }
 }
 

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -100,6 +100,7 @@ void* pico_run_expr(Target target, size_t rsize, Allocator* a, ErrorPoint* point
         // NOTE: When updating to push more registers, make sure to also update assembly
         //       in abstraction.c
         "push %%rbp       \n"
+        "push %%rbx       \n"
         "push %%r15       \n"
         "push %%r14       \n"
         "push %%r13       \n"
@@ -113,6 +114,7 @@ void* pico_run_expr(Target target, size_t rsize, Allocator* a, ErrorPoint* point
         "pop %%r13        \n"
         "pop %%r14        \n"
         "pop %%r15        \n"
+        "pop %%rbx        \n"
         "pop %%rbp        \n"
         : "=r" (out)
 

--- a/src/pico/parse/parse.c
+++ b/src/pico/parse/parse.c
@@ -1,3 +1,4 @@
+#include <math.h>
 #include "pico/parse/parse.h"
 
 /* High Level overview of the grammar:
@@ -32,13 +33,15 @@ ParseResult parse_string(IStream* is, SourcePos* parse_state, Allocator* a);
 ParseResult parse_char(IStream* is, SourcePos* parse_state);
 
 // Helper functions
+StreamResult consume_until(uint32_t stop, IStream* is, SourcePos* parse_state);
 StreamResult consume_whitespace(IStream* is, SourcePos* parse_state);
 bool is_numchar(uint32_t codepoint);
 bool is_whitespace(uint32_t codepoint);
 bool is_symchar(uint32_t codepoint);
 
 ParseResult parse_main(IStream* is, SourcePos* parse_state, Allocator* a) {
-    ParseResult out;
+    // default if we never enter loop body 
+    ParseResult out = (ParseResult) {.type = ParseNone};
     uint32_t point;
 
     consume_whitespace(is, parse_state);
@@ -100,6 +103,9 @@ ParseResult parse_main(IStream* is, SourcePos* parse_state, Allocator* a) {
                 out = parse_number(is, parse_state, a);
             }
             else if (is_whitespace(point)) {
+                // Whitespace always terminates a unit, e.g. 
+                // "foo.bar" is pared as a single unit (. foo bar), while
+                // "foo . bar" requires parse_main to be called thrice.
                 out.type = ParseNone;
                 running = false;
                 break;
@@ -136,12 +142,24 @@ ParseResult parse_main(IStream* is, SourcePos* parse_state, Allocator* a) {
         }
     }
 
-    if (out.type == ParseSuccess && terms.len == 0) {
+    // Post-run cleanup: reduce the term list to a single term (or ParseNone)
+    if (out.type != ParseFail && terms.len == 0) {
         out.type = ParseNone;
     } else if (out.type == ParseNone && terms.len == 1) {
         out.type = ParseSuccess;
         out.data.result = *(RawTree*)terms.data[0];
     } else if ((out.type == ParseSuccess || out.type == ParseNone) && terms.len > 1) {
+        // Check that there is an appropriate (odd) number of terms for infix operator
+        // unrolling to function
+        if (terms.len % 2 == 0) {
+          out = (ParseResult) {
+            .type = ParseFail,
+            .data.range.start = *parse_state,
+            .data.range.end = *parse_state,
+          };
+          return out;
+        }
+
         // Now that the list has been accumulated, 'unroll' the list appropriately, 
         // meaning that (num : i64 . +) becomes (. + (: num i64))
         RawTree* current = terms.data[0];
@@ -308,9 +326,11 @@ ParseResult parse_atom(IStream* is, SourcePos* parse_state, Allocator* a) {
 ParseResult parse_number(IStream* is, SourcePos* parse_state, Allocator* a) {
     uint32_t codepoint;
     StreamResult result;
-    U8Array arr = mk_u8_array(10, a);
+    U8Array lhs = mk_u8_array(10, a);
+    U8Array rhs = mk_u8_array(10, a);
     bool is_positive = true;
     bool just_negation = true;
+    bool floating = false;
 
     result = peek(is, &codepoint);
     if (result == StreamSuccess && codepoint == '-') {
@@ -323,7 +343,19 @@ ParseResult parse_number(IStream* is, SourcePos* parse_state, Allocator* a) {
         next(is, &codepoint);
         // the cast is safe as is-numchar ensures codepoint < 256
         uint8_t val = (uint8_t) codepoint - 48;
-        push_u8(val, &arr);
+        push_u8(val, &lhs);
+    }
+
+    if (result == StreamSuccess && codepoint == '.') {
+        floating = true;
+        next(is, &codepoint);
+        while (((result = peek(is, &codepoint)) == StreamSuccess) && is_numchar(codepoint)) {
+            just_negation = false;
+            next(is, &codepoint);
+            // the cast is safe as is-numchar ensures codepoint < 256
+            uint8_t val = (uint8_t) codepoint - 48;
+            push_u8(val, &rhs);
+        }
     }
 
     if (just_negation) {
@@ -344,20 +376,46 @@ ParseResult parse_number(IStream* is, SourcePos* parse_state, Allocator* a) {
         };
     }
 
-    int64_t int_result = 0;
-    uint64_t tens = 1;
-    for (size_t i = arr.len; i > 0; i--) {
-        int_result += tens * arr.data[i-1];
-        tens *= 10;
-    }
-    int_result *= is_positive ? 1 : -1;
+    if (floating) {
+        int64_t lhs_result = 0;
+        uint64_t rhs_result = 0;
+        uint64_t tens = 1;
+        for (size_t i = lhs.len; i > 0; i--) {
+            lhs_result += tens * lhs.data[i-1];
+            tens *= 10;
+        }
+        tens = 1;
+        for (size_t i = rhs.len; i > 0; i--) {
+            rhs_result += tens * rhs.data[i-1];
+            tens *= 10;
+        }
+        lhs_result *= is_positive ? 1 : -1;
+        double dlhs = (double)lhs_result;
+        double drhs = (double)rhs_result;
+        drhs = drhs / powl(10, rhs.len);
 
-    return (ParseResult) {
-        .type = ParseSuccess,
-        .data.result.type = RawAtom,
-        .data.result.atom.type = AIntegral,
-        .data.result.atom.int_64 = int_result,
-    };
+        return (ParseResult) {
+            .type = ParseSuccess,
+            .data.result.type = RawAtom,
+            .data.result.atom.type = AFloating,
+            .data.result.atom.float_64 = dlhs + drhs,
+        };
+    } else {
+        int64_t int_result = 0;
+        uint64_t tens = 1;
+        for (size_t i = lhs.len; i > 0; i--) {
+            int_result += tens * rhs.data[i-1];
+            tens *= 10;
+        }
+        int_result *= is_positive ? 1 : -1;
+
+        return (ParseResult) {
+            .type = ParseSuccess,
+            .data.result.type = RawAtom,
+            .data.result.atom.type = AIntegral,
+            .data.result.atom.int_64 = int_result,
+        };
+    }
 }
 
 ParseResult parse_prefix(char prefix, IStream* is, SourcePos* parse_state, Allocator* a) {
@@ -469,16 +527,37 @@ ParseResult parse_char(IStream* is, SourcePos* parse_state) {
     };
 }
 
-StreamResult consume_whitespace(IStream* is, SourcePos* parse_state) {
+StreamResult consume_until(uint32_t stop, IStream* is, SourcePos* parse_state) {
     uint32_t codepoint;
     StreamResult result;
+
+    next(is, &codepoint); // consume token #)
+    result = next(is, &codepoint);
+
     while ((result = peek(is, &codepoint)) == StreamSuccess) {
-        if (is_whitespace(codepoint)) {
+        if (codepoint != stop) {
             // TODO: Check if newline!
             parse_state->col++;
             result = next(is, &codepoint);
         }
         else {
+            break;
+        }
+    }
+    return result;
+}
+
+StreamResult consume_whitespace(IStream* is, SourcePos* parse_state) {
+    uint32_t codepoint;
+    StreamResult result;
+    while ((result = peek(is, &codepoint)) == StreamSuccess) {
+        if (is_whitespace(codepoint) ) {
+            // TODO: Check if newline!
+            parse_state->col++;
+            result = next(is, &codepoint);
+        } else if (codepoint == ';') {
+            result = consume_until('\n', is, parse_state);
+        } else {
             break;
         }
     }

--- a/src/pico/parse/parse.c
+++ b/src/pico/parse/parse.c
@@ -113,7 +113,14 @@ ParseResult parse_main(IStream* is, SourcePos* parse_state, Allocator* a) {
             else if (is_symchar(point)){
                 out = parse_atom(is, parse_state, a);
             } else {
-                out.type = ParseNone;
+                out.type = ParseFail;
+                // Consume the character, so that we don't encounter an
+                // identidcal error next time!
+                next(is, &point);
+
+                // error location
+                out.data.range.start = *parse_state,
+                out.data.range.end = *parse_state,
                 running = false;
                 break;
             }

--- a/src/pico/parse/parse.c
+++ b/src/pico/parse/parse.c
@@ -124,6 +124,8 @@ ParseResult parse_expr(IStream* is, SourcePos* parse_state, Allocator* a, uint32
                 break;
             } else {
                 // We couldn't do a parse!
+                next(is, &point);
+
                 out.type = ParseFail;
                 out.data.range.start = *parse_state;
                 out.data.range.end = *parse_state;

--- a/src/pico/parse/parse.c
+++ b/src/pico/parse/parse.c
@@ -348,9 +348,9 @@ ParseResult parse_number(IStream* is, SourcePos* parse_state, Allocator* a) {
 
     if (result == StreamSuccess && codepoint == '.') {
         floating = true;
+        just_negation = false;
         next(is, &codepoint);
         while (((result = peek(is, &codepoint)) == StreamSuccess) && is_numchar(codepoint)) {
-            just_negation = false;
             next(is, &codepoint);
             // the cast is safe as is-numchar ensures codepoint < 256
             uint8_t val = (uint8_t) codepoint - 48;
@@ -404,7 +404,7 @@ ParseResult parse_number(IStream* is, SourcePos* parse_state, Allocator* a) {
         int64_t int_result = 0;
         uint64_t tens = 1;
         for (size_t i = lhs.len; i > 0; i--) {
-            int_result += tens * rhs.data[i-1];
+            int_result += tens * lhs.data[i-1];
             tens *= 10;
         }
         int_result *= is_positive ? 1 : -1;

--- a/src/pico/stdlib/core.c
+++ b/src/pico/stdlib/core.c
@@ -10,6 +10,11 @@ PiType* get_array_type() {
     return array_type;
 }
 
+static PiType* maybe_type;
+PiType* get_maybe_type() {
+    return maybe_type;
+}
+
 static PiType* syntax_type;
 PiType* get_syntax_type() {
     return syntax_type;
@@ -505,6 +510,24 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
         ModuleEntry* e = get_def(sym, module);
         array_type = e->value;
+        
+        // Maybe Type 
+        // Make a ptr
+        vars = mk_u64_array(1, a);
+        push_u64(string_to_symbol(mv_string("A")), &vars);
+        type.kind.nargs = 1;
+        type_val = mk_distinct_type(a, mk_type_family(a,
+                                                      vars,
+                                                      mk_enum_type(a, 2,
+                                                                   "some", 1, mk_var_type(a, "A"),
+                                                                   "none", 0)));
+        type_data = type_val;
+        sym = string_to_symbol(mv_string("Maybe"));
+        add_def(module, sym, type, &type_data, null_segments, NULL);
+        delete_pi_type_p(type_val, a);
+
+        e = get_def(sym, module);
+        maybe_type = e->value;
 
         // Either Type 
         // Make a ptr

--- a/src/pico/stdlib/core.c
+++ b/src/pico/stdlib/core.c
@@ -452,6 +452,14 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
     sym = string_to_symbol(mv_string("U8"));
     add_def(module, sym, type, &type_data, null_segments, NULL);
 
+    type_val = (PiType) {.sort = TPrim, .prim = Float_32};
+    sym = string_to_symbol(mv_string("F32"));
+    add_def(module, sym, type, &type_data, null_segments, NULL);
+
+    type_val = (PiType) {.sort = TPrim, .prim = Float_64};
+    sym = string_to_symbol(mv_string("F64"));
+    add_def(module, sym, type, &type_data, null_segments, NULL);
+
     // Syntax Type : components and definition 
     {
         // Ptr Type

--- a/src/pico/stdlib/core.c
+++ b/src/pico/stdlib/core.c
@@ -10,6 +10,11 @@ PiType* get_array_type() {
     return array_type;
 }
 
+static PiType* ptr_type;
+PiType* get_ptr_type() {
+    return ptr_type;
+}
+
 static PiType* maybe_type;
 PiType* get_maybe_type() {
     return maybe_type;
@@ -23,6 +28,11 @@ PiType* get_syntax_type() {
 static PiType* either_type;
 PiType* get_either_type() {
     return either_type;
+}
+
+static PiType* pair_type;
+PiType* get_pair_type() {
+    return pair_type;
 }
 
 PiType build_store_fn_ty(Allocator* a) {
@@ -467,14 +477,24 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
     // Syntax Type : components and definition 
     {
-        // Ptr Type
-        U64Array vars = mk_u64_array(1, a);
+        PiType *type_val;
+        SymbolArray vars;
+        ModuleEntry* e;
+
+        // Ptr Type 
+        vars = mk_u64_array(1, a);
         push_u64(string_to_symbol(mv_string("A")), &vars);
-        PiType* ptr_type = mk_distinct_type(a, mk_type_family(a, vars, mk_prim_type(a, Address)));
-        type_data = ptr_type;
-        sym = string_to_symbol(mv_string("Ptr"));
         type.kind.nargs = 1;
+        type_val = mk_distinct_type(a, mk_type_family(a,
+                                                      vars,
+                                                      mk_prim_type(a, Address)));
+        type_data = type_val;
+        sym = string_to_symbol(mv_string("Ptr"));
         add_def(module, sym, type, &type_data, null_segments, NULL);
+        delete_pi_type_p(type_val, a);
+
+        e = get_def(sym, module);
+        ptr_type = e->value;
 
         // Allocator Type 
         PiType* alloc_type = mk_struct_type(a, 3,
@@ -488,7 +508,6 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
         // (Ptr Alloc)
         PiType* alloc_ptr_type = mk_app_type(a, ptr_type, alloc_type);
-        delete_pi_type_p(ptr_type, a);
         delete_pi_type_p(alloc_type, a);
         
         // Array Type 
@@ -496,7 +515,7 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
         vars = mk_u64_array(1, a);
         push_u64(string_to_symbol(mv_string("A")), &vars);
         type.kind.nargs = 1;
-        PiType* type_val = mk_distinct_type(a, mk_type_family(a,
+        type_val = mk_distinct_type(a, mk_type_family(a,
                                                       vars,
                                                       mk_struct_type(a, 4,
                                                                      "data", mk_prim_type(a, Address),
@@ -508,11 +527,10 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
         add_def(module, sym, type, &type_data, null_segments, NULL);
         delete_pi_type_p(type_val, a);
 
-        ModuleEntry* e = get_def(sym, module);
+        e = get_def(sym, module);
         array_type = e->value;
         
         // Maybe Type 
-        // Make a ptr
         vars = mk_u64_array(1, a);
         push_u64(string_to_symbol(mv_string("A")), &vars);
         type.kind.nargs = 1;
@@ -530,7 +548,6 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
         maybe_type = e->value;
 
         // Either Type 
-        // Make a ptr
         vars = mk_u64_array(2, a);
         push_u64(string_to_symbol(mv_string("A")), &vars);
         push_u64(string_to_symbol(mv_string("B")), &vars);
@@ -548,6 +565,25 @@ void add_core_module(Assembler* ass, Package* base, Allocator* a) {
 
         e = get_def(sym, module);
         either_type = e->value;
+
+        // Pair Type 
+        vars = mk_u64_array(2, a);
+        push_u64(string_to_symbol(mv_string("A")), &vars);
+        push_u64(string_to_symbol(mv_string("B")), &vars);
+        type.kind.nargs = 2;
+
+        type_val = mk_distinct_type(a, mk_type_family(a,
+                                                      vars,
+                                                      mk_struct_type(a, 2,
+                                                                   "_1", mk_var_type(a, "A"),
+                                                                   "_2", mk_var_type(a, "B"))));
+        type_data = type_val;
+        sym = string_to_symbol(mv_string("Pair"));
+        add_def(module, sym, type, &type_data, null_segments, NULL);
+        delete_pi_type_p(type_val, a);
+
+        e = get_def(sym, module);
+        pair_type = e->value;
 
         type.kind.nargs = 0;
 

--- a/src/pico/stdlib/data/array.c
+++ b/src/pico/stdlib/data/array.c
@@ -1,0 +1,38 @@
+#include "platform/signals.h"
+#include "pico/stdlib/helpers.h"
+#include "pico/stdlib/data/array.h"
+
+
+// Interface
+// elt :: All [A] Proc [U64 (Array A)] A
+// map :: All [A B] Proc [(Proc [A] B) (Array A)] A
+// 
+
+
+void add_array_module(Assembler *ass, Module *data, Allocator *a) {
+    Imports imports = (Imports) {
+        .clauses = mk_import_clause_array(0, a),
+    };
+    Exports exports = (Exports) {
+        .export_all = true,
+        .clauses = mk_export_clause_array(0, a),
+    };
+    ModuleHeader header = (ModuleHeader) {
+        .name = string_to_symbol(mv_string("core")),
+        .imports = imports,
+        .exports = exports,
+    };
+    Module* module = mk_module(header, get_package(data), NULL, a);
+    delete_module_header(header);
+    Symbol sym;
+
+    PiType* typep;
+    ErrorPoint point;
+    if (catch_error(point)) {
+        panic(point.error_message);
+    }
+
+
+    Result r = add_module_def(data, string_to_symbol(mv_string("Array")), module);
+    if (r.type == Err) panic(r.error_message);
+}

--- a/src/pico/stdlib/data/data.c
+++ b/src/pico/stdlib/data/data.c
@@ -1,0 +1,34 @@
+// #include "platform/signals.h"
+
+#include "pico/stdlib/data/array.h"
+#include "pico/stdlib/data/either.h"
+#include "pico/stdlib/data/maybe.h"
+#include "pico/stdlib/data/pair.h"
+#include "pico/stdlib/data/ptr.h"
+
+#include "pico/stdlib/data/data.h"
+
+void add_data_module(Assembler* ass, Package* base, Allocator* a) {
+    Imports imports = (Imports) {
+        .clauses = mk_import_clause_array(0, a),
+    };
+    Exports exports = (Exports) {
+        .export_all = true,
+        .clauses = mk_export_clause_array(0, a),
+    };
+    ModuleHeader header = (ModuleHeader) {
+        .name = string_to_symbol(mv_string("core")),
+        .imports = imports,
+        .exports = exports,
+    };
+    Module* module = mk_module(header, base, NULL, a);
+    delete_module_header(header);
+
+    add_array_module(ass, module, a);
+    add_either_module(ass, module, a);
+    add_maybe_module(ass, module, a);
+    add_pair_module(ass, module, a);
+    add_ptr_module(ass, module, a);
+
+    add_module(string_to_symbol(mv_string("data")), module, base);
+}

--- a/src/pico/stdlib/data/either.c
+++ b/src/pico/stdlib/data/either.c
@@ -1,0 +1,29 @@
+#include "platform/signals.h"
+#include "pico/stdlib/data/either.h"
+
+void add_either_module(Assembler *ass, Module *data, Allocator *a) {
+    Imports imports = (Imports) {
+        .clauses = mk_import_clause_array(0, a),
+    };
+    Exports exports = (Exports) {
+        .export_all = true,
+        .clauses = mk_export_clause_array(0, a),
+    };
+    ModuleHeader header = (ModuleHeader) {
+        .name = string_to_symbol(mv_string("core")),
+        .imports = imports,
+        .exports = exports,
+    };
+    Module* module = mk_module(header, get_package(data), NULL, a);
+    delete_module_header(header);
+    Symbol sym;
+
+    PiType* typep;
+    ErrorPoint point;
+    if (catch_error(point)) {
+        panic(point.error_message);
+    }
+
+    Result r = add_module_def(data, string_to_symbol(mv_string("Either")), module);
+    if (r.type == Err) panic(r.error_message);
+}

--- a/src/pico/stdlib/data/maybe.c
+++ b/src/pico/stdlib/data/maybe.c
@@ -1,0 +1,29 @@
+#include "platform/signals.h"
+#include "pico/stdlib/data/maybe.h"
+
+void add_maybe_module(Assembler *ass, Module *data, Allocator *a) {
+    Imports imports = (Imports) {
+        .clauses = mk_import_clause_array(0, a),
+    };
+    Exports exports = (Exports) {
+        .export_all = true,
+        .clauses = mk_export_clause_array(0, a),
+    };
+    ModuleHeader header = (ModuleHeader) {
+        .name = string_to_symbol(mv_string("core")),
+        .imports = imports,
+        .exports = exports,
+    };
+    Module* module = mk_module(header, get_package(data), NULL, a);
+    delete_module_header(header);
+    Symbol sym;
+
+    PiType* typep;
+    ErrorPoint point;
+    if (catch_error(point)) {
+        panic(point.error_message);
+    }
+
+    Result r = add_module_def(data, string_to_symbol(mv_string("Maybe")), module);
+    if (r.type == Err) panic(r.error_message);
+}

--- a/src/pico/stdlib/data/pair.c
+++ b/src/pico/stdlib/data/pair.c
@@ -1,0 +1,29 @@
+#include "platform/signals.h"
+#include "pico/stdlib/data/pair.h"
+
+void add_pair_module(Assembler *ass, Module *data, Allocator *a) {
+    Imports imports = (Imports) {
+        .clauses = mk_import_clause_array(0, a),
+    };
+    Exports exports = (Exports) {
+        .export_all = true,
+        .clauses = mk_export_clause_array(0, a),
+    };
+    ModuleHeader header = (ModuleHeader) {
+        .name = string_to_symbol(mv_string("core")),
+        .imports = imports,
+        .exports = exports,
+    };
+    Module* module = mk_module(header, get_package(data), NULL, a);
+    delete_module_header(header);
+    Symbol sym;
+
+    PiType* typep;
+    ErrorPoint point;
+    if (catch_error(point)) {
+        panic(point.error_message);
+    }
+
+    Result r = add_module_def(data, string_to_symbol(mv_string("Pair")), module);
+    if (r.type == Err) panic(r.error_message);
+}

--- a/src/pico/stdlib/data/ptr.c
+++ b/src/pico/stdlib/data/ptr.c
@@ -1,0 +1,29 @@
+#include "platform/signals.h"
+#include "pico/stdlib/data/ptr.h"
+
+void add_ptr_module(Assembler *ass, Module *data, Allocator *a) {
+    Imports imports = (Imports) {
+        .clauses = mk_import_clause_array(0, a),
+    };
+    Exports exports = (Exports) {
+        .export_all = true,
+        .clauses = mk_export_clause_array(0, a),
+    };
+    ModuleHeader header = (ModuleHeader) {
+        .name = string_to_symbol(mv_string("core")),
+        .imports = imports,
+        .exports = exports,
+    };
+    Module* module = mk_module(header, get_package(data), NULL, a);
+    delete_module_header(header);
+    Symbol sym;
+
+    PiType* typep;
+    ErrorPoint point;
+    if (catch_error(point)) {
+        panic(point.error_message);
+    }
+
+    Result r = add_module_def(data, string_to_symbol(mv_string("Pair")), module);
+    if (r.type == Err) panic(r.error_message);
+}

--- a/src/pico/stdlib/foreign.c
+++ b/src/pico/stdlib/foreign.c
@@ -41,13 +41,13 @@ void build_dynlib_open_fn(PiType* type, Assembler* ass, Allocator* a, ErrorPoint
     // here, we use void pointers because we don't need the  
     // C API to check everything for us.
     CType string_ctype = mk_struct_ctype(a, 2,
-                                         "memsize", mk_prim_ctype((CPrim){.prim = CLong, .is_signed = Unsigned}),
+                                         "memsize", mk_primint_ctype((CPrimInt){.prim = CLong, .is_signed = Unsigned}),
                                          "bytes", mk_voidptr_ctype(a));
 
     // DynLibResult
     CType dynlib_result = mk_struct_ctype(
         a, 2, "tag",
-        mk_prim_ctype((CPrim){.prim = CLong, .is_signed = Unsigned}), "data",
+        mk_primint_ctype((CPrimInt){.prim = CLong, .is_signed = Unsigned}), "data",
         mk_union_ctype(a, 2,
                        "error_message", string_ctype,
                        "dynlib", mk_voidptr_ctype(a)));

--- a/src/pico/stdlib/foreign.c
+++ b/src/pico/stdlib/foreign.c
@@ -211,13 +211,20 @@ void add_foreign_module(Assembler* ass, Package *base, Allocator* a) {
         add_def(module, sym, type, &type_data, null_segments, NULL);
 
 
-        PiType* c_type = mk_enum_type(a, 3,
-                                      "void", 0,
-                                      "prim", 1, prim_type,
-                                      "float", 0,
-                                      "double", 0,
-                                      //"proc", 3,  // (Maybe Name) (Array (Pair Sym Ptr)) (Ptr CType)
-                                      "unspecified", 0);
+        PiType *c_type =
+            mk_named_type(a, "CType",
+                          mk_enum_type(a, 5,
+                                       "void", 0,
+                                       "prim-int", 1, prim_type,
+                                       "float", 0,
+                                       "double", 0,
+                                       // TODO: replace u64 with symbol
+                                       "ptr", 1, mk_app_type(a, get_ptr_type(), mk_var_type(a, "CType")),
+                                       //"proc", 3,
+                                       //mk_app_type(a, get_maybe_type(), mk_prim_type(a, UInt_64)),
+                                       //mk_app_type(a, get_ptr_type(), ),
+                                       // (Array (Pair Sym Ptr)) (Ptr CType)
+                                       "unspecified", 0));
         type_data = c_type;
         sym = string_to_symbol(mv_string("CType"));
         add_def(module, sym, type, &type_data, null_segments, NULL);

--- a/src/pico/stdlib/helpers.c
+++ b/src/pico/stdlib/helpers.c
@@ -1,0 +1,79 @@
+#include "platform/memory/arena.h"
+#include "platform/memory/executable.h"
+#include "platform/jump.h"
+#include "platform/error.h"
+
+#include "data/stream.h"
+
+#include "pico/parse/parse.h"
+#include "pico/stdlib/extra.h"
+#include "pico/analysis/abstraction.h"
+#include "pico/analysis/typecheck.h"
+#include "pico/codegen/codegen.h"
+#include "pico/eval/call.h"
+
+#include "pico/stdlib/helpers.h"
+
+void compile_toplevel(const char *string, Module *module, ErrorPoint *final_point, Allocator *a) {
+    IStream* sin = mk_string_istream(mv_string(string), a);
+    Allocator exalloc = mk_executable_allocator(a);
+    Allocator* exec = &exalloc;
+    // Note: we need to be aware of the arena and error point, as both are used
+    // by code in the 'true' branches of the nonlocal exits, and may be stored
+    // in registers, so they cannotbe changed (unless marked volatile).
+    Allocator arena = mk_arena_allocator(4096, a);
+
+    Target gen_target = {
+        .target = mk_assembler(exec),
+        .code_aux = mk_assembler(exec),
+        .data_aux = mem_alloc(sizeof(U8Array), &arena)
+    };
+    *gen_target.data_aux = mk_u8_array(128, &arena);
+
+    Environment* env = env_from_module(module, &arena);
+
+    jump_buf exit_point;
+    if (set_jump(exit_point)) goto on_exit;
+    set_exit_callback(&exit_point);
+
+    ErrorPoint point;
+    if (catch_error(point)) goto on_error;
+
+    ParseResult res = parse_rawtree(sin, &arena);
+    if (res.type == ParseNone) {
+        throw_error(&point, mv_string("Parse Returned None!"));
+    }
+    if (res.type == ParseFail) {
+        throw_error(&point, mv_string("Parse Failed :(\n"));
+    }
+    if (res.type != ParseSuccess) {
+        // If parse is invalid, means internal bug, so better exit soon!
+        throw_error(&point, mv_string("Parse Returned Invalid Result!\n"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Resolution
+    // -------------------------------------------------------------------------
+
+    TopLevel abs = abstract(res.data.result, env, &arena, &point);
+    type_check(&abs, env, &arena, &point);
+    LinkData links = generate_toplevel(abs, env, gen_target, &arena, &point);
+    pico_run_toplevel(abs, gen_target, links, module, &arena, &point);
+
+    delete_assembler(gen_target.target);
+    delete_assembler(gen_target.code_aux);
+    release_arena_allocator(arena);
+    return;
+
+ on_error:
+    delete_assembler(gen_target.target);
+    delete_assembler(gen_target.code_aux);
+    release_arena_allocator(arena);
+    throw_error(final_point, point.error_message);
+
+ on_exit:
+    delete_assembler(gen_target.target);
+    delete_assembler(gen_target.code_aux);
+    release_arena_allocator(arena);
+    throw_error(final_point, mv_string("Startup compiled definition not exepcted to exit!"));
+}

--- a/src/pico/stdlib/num.c
+++ b/src/pico/stdlib/num.c
@@ -51,7 +51,7 @@ void build_comp_fn(Assembler* ass, UnaryOp op, LocationSize sz, Allocator* a, Er
     build_nullary_op (ass, Ret, a, point);
 }
 
-void add_primitive_module(String name, LocationSize sz, bool is_signed, Assembler* ass, Module* num, Allocator* a) {
+void add_integral_module(String name, LocationSize sz, bool is_signed, Assembler* ass, Module* num, Allocator* a) {
     Imports imports = (Imports) {
         .clauses = mk_import_clause_array(0, a),
     };
@@ -140,7 +140,6 @@ void add_primitive_module(String name, LocationSize sz, bool is_signed, Assemble
 
     Result r = add_module_def(num, string_to_symbol(name), module);
     if (r.type == Err) panic(r.error_message);
-
 }
 
 void add_num_module(Assembler* ass, Package* base, Allocator* a) {
@@ -159,16 +158,15 @@ void add_num_module(Assembler* ass, Package* base, Allocator* a) {
     Module* module = mk_module(header, base, NULL, a);
     delete_module_header(header);
 
-    add_primitive_module(mv_string("u8"), sz_8, false, ass, module, a);
-    add_primitive_module(mv_string("u16"), sz_16, false, ass, module, a);
-    add_primitive_module(mv_string("u32"), sz_32, false, ass, module, a);
-    add_primitive_module(mv_string("u64"), sz_64, false, ass, module, a);
+    add_integral_module(mv_string("u8"), sz_8, false, ass, module, a);
+    add_integral_module(mv_string("u16"), sz_16, false, ass, module, a);
+    add_integral_module(mv_string("u32"), sz_32, false, ass, module, a);
+    add_integral_module(mv_string("u64"), sz_64, false, ass, module, a);
 
-    add_primitive_module(mv_string("i8"), sz_8, true, ass, module, a);
-    add_primitive_module(mv_string("i16"), sz_16, true, ass, module, a);
-    add_primitive_module(mv_string("i32"), sz_32, true, ass, module, a);
-    add_primitive_module(mv_string("i64"), sz_64, true, ass, module, a);
+    add_integral_module(mv_string("i8"), sz_8, true, ass, module, a);
+    add_integral_module(mv_string("i16"), sz_16, true, ass, module, a);
+    add_integral_module(mv_string("i32"), sz_32, true, ass, module, a);
+    add_integral_module(mv_string("i64"), sz_64, true, ass, module, a);
 
     add_module(string_to_symbol(mv_string("num")), module, base);
 }
-

--- a/src/pico/stdlib/stdlib.c
+++ b/src/pico/stdlib/stdlib.c
@@ -1,5 +1,6 @@
 #include "pico/stdlib/stdlib.h"
 #include "pico/stdlib/core.h"
+#include "pico/stdlib/data/data.h"
 #include "pico/stdlib/num.h"
 #include "pico/stdlib/extra.h"
 #include "pico/stdlib/foreign.h"
@@ -9,6 +10,7 @@
 Package* base_package(Assembler* ass, Allocator* a, Allocator* default_allocator) {
     Package* base = mk_package(string_to_symbol(mv_string("base")), a);
     add_core_module(ass, base, a);
+    add_data_module(ass, base, a);
     add_num_module(ass, base, a);
     add_extra_module(ass, base, default_allocator, a);
     add_foreign_module(ass, base, a);

--- a/src/pico/syntax/concrete.c
+++ b/src/pico/syntax/concrete.c
@@ -62,6 +62,10 @@ Document* pretty_atom(Atom atom, Allocator* a) {
         out = pretty_i64(atom.int_64, a);
         break;
     }
+    case AFloating: {
+        out = pretty_f64(atom.float_64, a);
+        break;
+    }
     case ABool: {
         if (atom.int_64 == 0) {
             out = mk_str_doc(mv_string("false"), a);

--- a/src/pico/syntax/syntax.c
+++ b/src/pico/syntax/syntax.c
@@ -37,6 +37,11 @@ Document* pretty_syntax(Syntax* syntax, Allocator* a) {
         out = pretty_i64(syntax->integral.value, a);
         break;
     }
+    case SLitUntypedFloating: {
+    case SLitTypedFloating: 
+        out = pretty_f64(syntax->floating.value, a);
+        break;
+    }
     case SLitBool: {
         if (syntax->integral.value == 0) {
             out = mk_str_doc(mv_string(":false"), a);

--- a/src/pico/values/ctypes.c
+++ b/src/pico/values/ctypes.c
@@ -456,9 +456,14 @@ CType* copy_c_type_p(CType* t, Allocator* a) {
     return ty;
 }
 
-
 // Constructors and Utilities
 // --------------------------
+CType mk_void_ctype() {
+    return (CType) {
+        .sort = CSVoid,
+    };
+}
+
 CType mk_voidptr_ctype(Allocator *a) {
     CType* void_ty = mem_alloc(sizeof(CType), a);
     *void_ty = (CType) {.sort = CSVoid};

--- a/src/pico/values/ctypes.c
+++ b/src/pico/values/ctypes.c
@@ -6,7 +6,7 @@
 
 #include "pico/values/ctypes.h"
 
-Document* pretty_cprim(CPrim prim, Allocator* a) {
+Document* pretty_cprim(CPrimInt prim, Allocator* a) {
     PtrArray nodes = mk_ptr_array(2, a);
     if (prim.is_signed == Signed) {
         push_ptr(mk_str_doc(mv_string("signed"), a), &nodes);
@@ -39,8 +39,12 @@ Document* pretty_ctype(CType* type, Allocator* a) {
     switch (type->sort) {
     case CSVoid:
         return mk_str_doc(mv_string("void"), a);
-    case CSPrim:
+    case CSPrimInt:
         return pretty_cprim(type->prim, a);
+    case CSFloat:
+        return mk_str_doc(mv_string("float"), a);
+    case CSDouble:
+        return mk_str_doc(mv_string("double"), a);
     case CSCEnum: {
         // enum name { l1 = n1, l2 = n2 }
         PtrArray main_nodes = mk_ptr_array(3, a);
@@ -131,7 +135,7 @@ Document* pretty_ctype(CType* type, Allocator* a) {
     panic(mv_string("Invalid CType"));
 }
 
-Document* pretty_cprimval(CPrim prim, void* data, Allocator* a) {
+Document* pretty_cprimval(CPrimInt prim, void* data, Allocator* a) {
     if (prim.is_signed == Unsigned) {
         switch (prim.prim) {
         case CChar:
@@ -170,8 +174,12 @@ Document* pretty_cval(CType* type, void* data, Allocator* a) {
     switch (type->sort) {
     case CSVoid:
         return mk_str_doc(mv_string("<void>"), a);
-    case CSPrim:
+    case CSPrimInt:
         return pretty_cprimval(type->prim, data, a);
+    case CSFloat:
+        return pretty_float(*(float*)data, a);
+    case CSDouble:
+        return pretty_double(*(double*)data, a);
     case CSCEnum: {
         return mk_str_doc(mv_string("pretty_cval not implemented for enum"), a);
     }
@@ -196,7 +204,7 @@ Document* pretty_cval(CType* type, void* data, Allocator* a) {
     panic(mv_string("Invalid CType provided to pretty_cval"));
 }
 
-size_t c_prim_size_of(CPrim type)
+size_t c_prim_size_of(CPrimInt type)
 {
 #if (ABI == SYSTEM_V_64 || ABI == WIN_64)
     switch (type.prim)
@@ -237,8 +245,12 @@ size_t c_size_of(CType type) {
     switch (type.sort) {
     case CSVoid:
         return 0;
-    case CSPrim:
+    case CSPrimInt:
         return c_prim_size_of(type.prim);
+    case CSFloat:
+        return 4;
+    case CSDouble:
+        return 8;
     case CSCEnum:
         return c_prim_size_of(type.enumeration.base);
     case CSProc:
@@ -298,8 +310,12 @@ size_t c_align_of(CType type) {
     switch (type.sort) {
     case CSVoid:
         return 0;
-    case CSPrim:
+    case CSPrimInt:
         // In System V, size = align for primitive types.
+        return c_prim_size_of(type.prim);
+    case CSFloat:
+        return c_prim_size_of(type.prim);
+    case CSDouble:
         return c_prim_size_of(type.prim);
     case CSCEnum:
         // In System V, size = align for primitive types.
@@ -354,7 +370,9 @@ size_t c_align_of(CType type) {
 void delete_c_type(CType t, Allocator* a) {
     switch(t.sort) {
     case CSVoid:
-    case CSPrim:
+    case CSPrimInt:
+    case CSFloat:
+    case CSDouble:
         break;
     case CSCEnum:
         sdelete_sym_i64_assoc(t.enumeration.vals);
@@ -396,7 +414,9 @@ void delete_c_type_p(CType* t, Allocator* a) {
 CType copy_c_type(CType t, Allocator* a) {
     CType out = t;
     switch(t.sort) {
-    case CSPrim:
+    case CSPrimInt:
+    case CSFloat:
+    case CSDouble:
     case CSVoid:
         break;
     case CSCEnum:
@@ -448,9 +468,9 @@ CType mk_voidptr_ctype(Allocator *a) {
     };
 }
 
-CType mk_prim_ctype(CPrim t) {
+CType mk_primint_ctype(CPrimInt t) {
     return (CType) {
-        .sort = CSPrim,
+        .sort = CSPrimInt,
         .prim = t,
     };
 }
@@ -501,7 +521,7 @@ CType mk_struct_ctype(Allocator* a, size_t nfields, ...) {
 }
 
 // Sample usage: mk_enum_type(a, CInt, 2, "true", 0, "false", 1)
-CType mk_enum_ctype(Allocator* a, CPrim store, size_t nfields, ...) {
+CType mk_enum_ctype(Allocator* a, CPrimInt store, size_t nfields, ...) {
     va_list args;
     va_start(args, nfields);
 

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -206,11 +206,11 @@ PiType copy_pi_type(PiType t, Allocator* a) {
     case TNamed:
         out.named.name = t.named.name;
         out.named.type = copy_pi_type_p(t.named.type, a);
-        if (t.distinct.args) {
+        if (t.named.args) {
             out.named.args = mem_alloc(sizeof(PtrArray), a);
             *out.named.args = copy_ptr_array(*t.named.args,  (TyCopier)copy_pi_type_p, a);
         } else {
-            out.distinct.args = NULL;
+            out.named.args = NULL;
         }
         break;
     case TDistinct:

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -1427,6 +1427,17 @@ PiType* mk_enum_type(Allocator* a, size_t nfields, ...) {
     return enumeration;
 }
 
+PiType *mk_named_type(Allocator *a, const char *name, PiType *inner) {
+    PiType* out = mem_alloc(sizeof(PiType), a);
+    *out = (PiType) {
+        .sort = TNamed,
+        .named.name = string_to_symbol(mv_string(name)),
+        .named.type = inner,
+        .named.args = NULL,
+    };
+    return out;
+}
+
 PiType* mk_distinct_type(Allocator* a, PiType* inner) {
     PiType* out = mem_alloc(sizeof(PiType), a);
     *out =(PiType) {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -728,8 +728,13 @@ Document* pretty_type(PiType* type, Allocator* a) {
         break;
     }
     case TTrait:  {
-        PtrArray nodes = mk_ptr_array(2 + type->trait.fields.len, a);
+        PtrArray nodes = mk_ptr_array(3 + type->trait.fields.len, a);
         push_ptr(mk_str_doc(mv_string("Trait" ), a), &nodes);
+        
+        PtrArray id_nodes = mk_ptr_array(2, a);
+        push_ptr(mk_str_doc(mv_string("#"), a), &id_nodes);
+        push_ptr(pretty_u64(type->trait.id, a), &id_nodes);
+        push_ptr(mv_cat_doc(id_nodes, a), &nodes);
 
         PtrArray vars = mk_ptr_array(type->trait.vars.len, a);
         for (size_t i = 0; i < type->trait.vars.len; i++) {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -403,11 +403,11 @@ Document* pretty_pi_value(void* val, PiType* type, Allocator* a) {
         uint64_t tagidx = *(uint64_t*)val;
 
         PtrArray variant_types = *(PtrArray*)type->enumeration.variants.data[tagidx].val;
-        PtrArray nodes = mk_ptr_array(2 + variant_types.len, a);
+        PtrArray nodes = mk_ptr_array(1 + variant_types.len, a);
 
         // Symbol 
         Symbol tagname = type->enumeration.variants.data[tagidx].key;
-        push_ptr(mk_str_doc(string_cat(mv_string("[:"), *symbol_to_string(tagname), a), a), &nodes);
+        push_ptr(mk_str_doc( *symbol_to_string(tagname), a), &nodes);
 
         size_t current_offset = sizeof(uint64_t); // Start after current tag
         for (size_t i = 0; i < variant_types.len; i++) {
@@ -416,8 +416,7 @@ Document* pretty_pi_value(void* val, PiType* type, Allocator* a) {
             push_ptr(arg, &nodes);
             current_offset += pi_size_of(*ftype);
         }
-        push_ptr(mk_str_doc(mv_string("]"), a), &nodes);
-        out = mv_sep_doc(nodes, a);
+        out = mk_paren_doc("[:", "]", mv_sep_doc(nodes, a), a);
         break;
     }
     case TReset: {

--- a/src/platform/dynamic_library.c
+++ b/src/platform/dynamic_library.c
@@ -36,7 +36,7 @@ void close_lib(DynLib *lib) {
 
 Result lib_sym(void **out, DynLib *lib, String symbol) {
     dlerror();
-    *out = dlsym(lib, (char*)symbol.bytes);
+    *out = dlsym(lib->ptr, (char*)symbol.bytes);
     char* error_message = dlerror();
     if (error_message) {
       return (Result) {

--- a/src/platform/dynamic_library.c
+++ b/src/platform/dynamic_library.c
@@ -1,4 +1,3 @@
-#include <stdio.h> 
 #include "platform/dynamic_library.h"
 #include "platform/machine_info.h"
 

--- a/src/pretty/standard_types.c
+++ b/src/pretty/standard_types.c
@@ -66,6 +66,20 @@ Document* pretty_ptr(void* val, Allocator* a) {
     return mv_str_doc(mv_string(str), a);
 }
 
+Document *pretty_f32(float32_t val, Allocator *a) {
+    int len = snprintf(NULL, 0, "%f", val) + 1;
+    char* str = (char*)mem_alloc(sizeof(char) * len, a);
+    snprintf(str, len, "%f", val);
+    return mv_str_doc(mv_string(str), a);
+}
+
+Document *pretty_f64(float64_t val, Allocator *a) {
+    int len = snprintf(NULL, 0, "%lf", val) + 1;
+    char* str = (char*)mem_alloc(sizeof(char) * len, a);
+    snprintf(str, len, "%lf", val);
+    return mv_str_doc(mv_string(str), a);
+}
+
 Document* pretty_hex_u8(uint8_t val, Allocator* a) {
     int len = snprintf(NULL, 0, "%" PRIx8, val) + 1;
     char* str = (char*)mem_alloc(sizeof(char) * len, a);
@@ -140,5 +154,19 @@ Document *pretty_ulong_long(unsigned long long val, Allocator *a) {
     int len = snprintf(NULL, 0, "%llu", val) + 1;
     char* str = (char*)mem_alloc(sizeof(char) * len, a);
     snprintf(str, len, "%llu", val);
+    return mv_str_doc(mv_string(str), a);
+}
+
+Document *pretty_float(float val, Allocator *a) {
+    int len = snprintf(NULL, 0, "%f", val) + 1;
+    char* str = (char*)mem_alloc(sizeof(char) * len, a);
+    snprintf(str, len, "%f", val);
+    return mv_str_doc(mv_string(str), a);
+}
+
+Document *pretty_double(double val, Allocator *a) {
+    int len = snprintf(NULL, 0, "%lf", val) + 1;
+    char* str = (char*)mem_alloc(sizeof(char) * len, a);
+    snprintf(str, len, "%lf", val);
     return mv_str_doc(mv_string(str), a);
 }


### PR DESCRIPTION
Merge the following changes

Features
- expanded foreign module
  - mk_symbol
  - dynlib-close
  - dynlib-symbol
- expanded core module
  - added `Maybe` type.
  - added `Ptr` type.
  - added `Pair` type.
- floating point
  - float literals added
Bugfixes:
- repl correctly handles parser returning None result
- segfault in `instantiate_implicits` for trait fixed
- foregin adapter for System V now correctly returns when the return argument is not passed in memory
- Enumeration: typecheck and codegen handled out of order for matches poorly  - now fixed.
- parsing fixes: unexpected characters now report an error
- foreign_adapter fixes