### PR TITLE
Release Beta 0.2.4

### DIFF
--- a/default.config
+++ b/default.config
@@ -16,7 +16,7 @@ HEDRON=YES
 # - X11, WAYLAND (linux only)
 # - DEFAULT (picks current running window system) 
 # - NONE (disables windowing in the standard library)
-WINDOW_SYSTEM=WAYLAND
+WINDOW_SYSTEM=DEFAULT
 
 # Dependency Configuration
 # ------------------------

--- a/default.config
+++ b/default.config
@@ -16,7 +16,7 @@ HEDRON=YES
 # - X11, WAYLAND (linux only)
 # - DEFAULT (picks current running window system) 
 # - NONE (disables windowing in the standard library)
-WINDOW_SYSTEM=DEFAULT
+WINDOW_SYSTEM=WAYLAND
 
 # Dependency Configuration
 # ------------------------

--- a/include/data/string.h
+++ b/include/data/string.h
@@ -25,6 +25,7 @@ String string_from_ASCII(U8Array arr, Allocator* a);
 
 // String utilities:
 
+bool string_eq(const String lhs, const String rhs);
 int string_cmp(const String lhs, const String rhs);
 String string_cat(const String lhs, const String rhs, Allocator* a);
 String string_ncat(Allocator* a, size_t n, ...);

--- a/include/pico/typecheck/unify.h
+++ b/include/pico/typecheck/unify.h
@@ -6,12 +6,14 @@
 #include "pico/data/range.h"
 #include "pico/values/types.h"
 
-// Unification Model:
-// Memory and Lifetimes:
-// Any type added as part of a constraint or unification should not be deleted
-// until the UVar has been squashed.
-// All memory belonging to the Uvar, or for errors is allocated by 'a'. Any memory
-// required for types is allocated by the 'PiAllocator'.
+/**
+ * Unification Model:
+ * Memory and Lifetimes:
+ * Any type added as part of a constraint or unification should not be deleted
+ * until the UVar has been squashed.
+ * All memory belonging to the Uvar, or for errors is allocated by 'a'. Any memory
+ * required for types is allocated by the 'PiAllocator'.
+ */
 
 typedef struct UVarType UVarType;
 
@@ -34,31 +36,41 @@ typedef struct {
     Logger* logger;
 } UnifyContext;
 
-// Instantiate uvars in the LHS and RHS so that they become equal
-// perform occurence checking.
-// Note: this destructively mutates the type
+/**
+ * Instantiate uvars in the LHS and RHS so that they become equal
+ * perform occurence checking.
+ * Note: this destructively mutates the type
+ */
 UnifyResult unify(PiType* lhs, PiType* rhs, UnifyContext ctx);
 
-// Copy uvar: note that this will create a separate copy, meaning
-//   that updates to one will not affect another and vice-versa
+/**
+ * Copy uvar: note that this will create a separate copy, meaning
+ *   that updates to one will not affect another and vice-versa
+ */
 UVarType* copy_uvar(UVarType* uvar, PiAllocator* pia);
 
 PiType* try_get_uvar(UVarType* uvar);
 
-// When typechecking, there may be a need to perform substitutions.
-//  For example, given id : All [A] Proc [A] A applied to 3, i.e. (id 3),
-//  it is necessary to substitute A for the type of 3. However, more generall
-//  if we are applying a 'forall' function f, the type of this function may be
-//  undecided, so we note in the unification variables representing its' type 
-//  that we (in the future) will need to substitute a type variable for sometype.
+/**
+ * When typechecking, there may be a need to perform substitutions.
+ *  For example, given id : All [A] Proc [A] A applied to 3, i.e. (id 3),
+ *  it is necessary to substitute A for the type of 3. However, more generall
+ *  if we are applying a 'forall' function f, the type of this function may be
+ *  undecided, so we note in the unification variables representing its' type 
+ *  that we (in the future) will need to substitute a type variable for sometype.
+*/
 void add_subst(UVarType* uvar, SymPtrAssoc binds, Allocator* a);
 
-// Return true if and only if the type has uninstantiated unification variables
+/**
+ * Return true if and only if the type has uninstantiated unification variables
+ */
 bool has_unification_vars_p(PiType type);
 
-// Return a deep copy of the original type, with all unification vars replaced
-// by their subsitutions, and all unification variables with default values
-// instantiated with those defaults.
+/**
+ * Return a deep copy of the original type, with all unification vars replaced
+ * by their subsitutions, and all unification variables with default values
+ * instantiated with those defaults.
+ */
 void squash_type(PiType* type, UnifyContext ctx);
 
 PiType* mk_uvar(PiAllocator* a);

--- a/include/pico/values/types.h
+++ b/include/pico/values/types.h
@@ -254,6 +254,8 @@ size_t pi_stack_align(size_t in);
 size_t pi_stack_size_of(PiType type);
 Result_t pi_maybe_stack_size_of(PiType type, size_t* out);
 
+uint64_t total_arr_len(DimPiList dim);
+
 // Resource Management
 void delete_pi_type(PiType t, PiAllocator* pia);
 void delete_pi_type_p(PiType* t, PiAllocator* pia);
@@ -269,22 +271,30 @@ uint64_t distinct_id();
 bool is_wider(PiType* narrow, PiType* wide);
 bool is_narrower(PiType* wide, PiType* narrow);
 
-// Recursively extracts the inner type from named types (but not distinct or opaque) 
-// Upon encountering a named type, it will substitute the name for the 
-// (wrapped) named type within the type, then contine descending.
+/**
+ * Recursively extracts the inner type from named types (but not distinct or opaque) 
+ * Upon encountering a named type, it will substitute the name for the 
+ * (wrapped) named type within the type, then contine descending.
+ */
 PiType* unname_type(PiType *ty, void* curr_module, PiAllocator* pia, Allocator* a);
 
-// Recursively extracts the inner type from named and distinct types (but not opaque)
-// Upon encountering a named type, it will substitute the name for the 
-// (wrapped) named type within the type, then contine descending.
+/**
+ * Recursively extracts the inner type from named and distinct types (but not opaque)
+ * Upon encountering a named type, it will substitute the name for the 
+ * (wrapped) named type within the type, then contine descending.
+ */
 PiType* unwrap_type(PiType *ty, void* curr_module, PiAllocator* pia, Allocator* a);
 
-// Recursively extracts the inner type from named, distinct and opaque types.
+/**
+ * Recursively extracts the inner type from named, distinct and opaque types.
+ */
 PiType* strip_type(PiType* ty);
 
-// type_app: apply the arguments (args) to a type family (fam)
-//  Memory guarantes: both the arguments (args) and famiy are untouched, and can
-//  be safely deleted etc. without affecting the returned type.
+/**
+ * Apply the arguments (args) to a type family (fam)
+ * • Memory guarantes: both the arguments (args) and famiy are untouched, and can
+ *   be safely deleted etc. without affecting the returned type.
+ */
 PiType* type_app (PiType family, PtrArray args, PiAllocator* pia, Allocator* a);
 
 // Generators 

--- a/src/data/string.c
+++ b/src/data/string.c
@@ -83,6 +83,9 @@ String string_from_ASCII(U8Array arr, Allocator* a) {
     return out;
 }
 
+bool string_eq(const String lhs, const String rhs) {
+    return string_cmp(lhs, rhs) == 0;
+}
 int string_cmp(const String lhs, const String rhs) {
     // TODO: use vector instructions to make this more efficient?
     size_t min_memsize = (lhs.memsize < rhs.memsize)

--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,7 @@
 #include "app/help_string.h"
 #include "app/repl.h"
 
-static const char* version = "0.2.3";
+static const char* version = "0.2.4";
 
 int main(int argc, char** argv) {
     // Setup

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -655,7 +655,10 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
                 build_unary_op(Push, reg(R9, sz_64), ass, a, point);
 
             // Structs and Enums are passed by value, and have variable size.
-            } else if (indistinct_type.sort == TStruct || indistinct_type.sort == TEnum || indistinct_type.sort == TSealed) {
+            } else if (indistinct_type.sort == TArray
+                       || indistinct_type.sort == TStruct
+                       || indistinct_type.sort == TEnum
+                       || indistinct_type.sort == TSealed) {
                 size_t value_size = pi_size_of(indistinct_type);
                 size_t stack_size = pi_stack_align(value_size);
                 AsmResult out = build_binary_op(Mov, reg(RCX, sz_64), imm64((uint64_t)e.value), ass, a, point);
@@ -1129,47 +1132,147 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
         break;
     }
     case SArrayElt: {
-        PiType* val_type = strip_type(type);
-        PiType* array_type = strip_type(get_type(syn.array_elt.array, ictx.tape));
-        size_t elt_size = pi_size_of(*val_type);
-        size_t offset_size = pi_size_align(elt_size, pi_align_of(*val_type));
-        size_t stack_size = pi_stack_align(elt_size);
+        if (is_variable_in(type, env)) {
+            PiType* val_type = strip_type(type);
+            PiType* array_type = strip_type(get_type(syn.array_elt.array, ictx.tape));
+            
+            // Store element size on stack
+            generate_size_of(R8, val_type, env, ass, a, point);
+            build_unary_op(Push, reg(R8, sz_64), ass, a, point);
 
-        build_binary_op(Sub, reg(RSP, sz_64), imm32(stack_size), ass, a, point);
-        data_stack_grow(env, stack_size);
-        int64_t dest_level = get_stack_head(env);
-        for (size_t i = 0; i < syn.array_elt.index.len; i++) {
-            generate_i(syn.array_elt.index.data[i], env, ictx);
+            // Store element aligned size on stack (x2)
+            generate_align_of(R9, val_type, env, ass, a, point);
+            build_binary_op(Mov, reg(R8, sz_64), rref8(RSP, 0, sz_64), ass, a, point);
+            generate_align_to(R8, R9, ass, a, point);
+            build_unary_op(Push, reg(R8, sz_64), ass, a, point);
+            build_unary_op(Push, reg(R8, sz_64), ass, a, point);
+
+            // Store element stack size on stack
+            build_binary_op(Mov, reg(R9, sz_64), imm32(REGISTER_SIZE), ass, a, point);
+            generate_align_to(R8, R9, ass, a, point);
+            build_unary_op(Push, reg(R8, sz_64), ass, a, point);
+
+            build_binary_op(Mov, rref8(RSP, 16, sz_64), reg(R8, sz_64), ass, a, point);
+
+            // Reserve space for element (return value) on dynamic stack, and
+            // overwrite raw element size with it
+            build_binary_op(Sub, reg(R14, sz_64), reg(R8, sz_64), ass, a, point);
+            build_binary_op(Mov, rref8(RSP, 24, sz_64), reg(R14, sz_64), ass, a, point);
+
+            data_stack_grow(env, 4 * REGISTER_SIZE);
+
+            // [RSP + 24] : Return Value
+            // [RSP + 16] : Aligned Element size
+            // [RSP + 8]  : Aligned Element size
+            // [RSP]      : Stack Element Size 
+            // ----------------------------------------
+
+            for (size_t i = 0; i < syn.array_elt.index.len; i++) {
+                generate_i(syn.array_elt.index.data[i], env, ictx);
+            }
+
+
+            size_t g_offset = syn.array_elt.index.len * REGISTER_SIZE;
+            // [RSP + 24 + g_offest] : Return value
+            // [RSP + 16 + g_offest] : Block size
+            // [RSP + 8 + g_offest]  : Aligned Element size
+            // [RSP + g_offest]      : Stack Element size
+            // .... <index>
+            // ----------------------------------------
+
+            // Keep the desired memory offset in RBX
+            build_binary_op(Mov, reg(RBX, sz_64), imm32(0), ass, a, point);
+            for (size_t i = 0; i < syn.array_elt.index.len; i++) {
+                g_offset -= REGISTER_SIZE;
+                size_t block_size_offset = g_offset + 16;
+
+                // Calculate the source offset contributed by this part of the array from the start
+                build_unary_op(Pop, reg(RAX, sz_64), ass, a, point);
+                build_binary_op(Mov, reg(RDX, sz_64), imm32(0), ass, a, point);
+                build_binary_op(Mov, reg(RCX, sz_64), rref8(RSP, block_size_offset, sz_64), ass, a, point);
+                build_unary_op(Mul, reg(RCX, sz_64), ass, a, point);
+                build_binary_op(Add, reg(RBX, sz_64), reg(RAX, sz_64), ass, a, point);
+
+                // Multiply block size
+                build_binary_op(Mov, reg(RCX, sz_64), rref8(RSP, block_size_offset, sz_64), ass, a, point);
+                build_binary_op(Mov, reg(RAX, sz_64), imm32(array_type->array.dimensions.data[syn.array_elt.index.len - (i + 1)].val), ass, a, point);
+                build_unary_op(Mul, reg(RCX, sz_64), ass, a, point);
+                build_binary_op(Mov, rref8(RSP, block_size_offset, sz_64), reg(RAX, sz_64), ass, a, point);
+            }
+            build_unary_op(Push, reg(RBX, sz_64), ass, a, point);
+            data_stack_shrink(env, (syn.array_elt.index.len - 1) * ADDRESS_SIZE);
+
+            generate_i(syn.array_elt.array, env, ictx);
+
+            // [RSP + 40] : Return value
+            // [RSP + 32] : Block size
+            // [RSP + 24] : Aligned Element size
+            // [RSP + 16] : Stack Element size
+            // [RSP + 8]  : Memory Offset (of element)
+            // [RSP]      : Array
+            // .... <index>
+            // ----------------------------------------
+            build_binary_op(Mov, reg(RDX, sz_64), rref8(RSP, 40, sz_64), ass, a, point);
+            // Src + 
+            build_binary_op(Mov, reg(RCX, sz_64), rref8(RSP, 0, sz_64), ass, a, point);
+            build_binary_op(Mov, reg(R9, sz_64), rref8(RSP, 8, sz_64), ass, a, point);
+            build_binary_op(Add, reg(RCX, sz_64), reg(R9, sz_64), ass, a, point);
+
+            // Size
+            build_binary_op(Mov, reg(R8, sz_64), rref8(RSP, 16, sz_64), ass, a, point);
+
+            generate_poly_move(reg(RDX, sz_64), reg(RCX, sz_64), reg(R8, sz_64), ass, a, point);
+
+            // Pop unneded values from static stack
+            build_binary_op(Add, reg(RSP, sz_64), imm32(40), ass, a, point);
+            data_stack_shrink(env, 40);
+
+            // Shrink variable stack
+            build_binary_op(Mov, reg(R14, sz_64), rref8(RSP, 0, sz_64), ass, a, point);
+
+        } else {
+            PiType* val_type = strip_type(type);
+            PiType* array_type = strip_type(get_type(syn.array_elt.array, ictx.tape));
+            size_t elt_size = pi_size_of(*val_type);
+            size_t offset_size = pi_size_align(elt_size, pi_align_of(*val_type));
+            size_t stack_size = pi_stack_align(elt_size);
+
+            build_binary_op(Sub, reg(RSP, sz_64), imm32(stack_size), ass, a, point);
+            data_stack_grow(env, stack_size);
+            int64_t dest_level = get_stack_head(env);
+            for (size_t i = 0; i < syn.array_elt.index.len; i++) {
+                generate_i(syn.array_elt.index.data[i], env, ictx);
+            }
+
+            size_t block_size = offset_size;
+            build_binary_op(Mov, reg(RAX, sz_64), imm32(0), ass, a, point);
+            for (size_t i = 0; i < syn.array_elt.index.len; i++) {
+                // Calculate the source offset from the array start
+                build_unary_op(Pop, reg(RDX, sz_64), ass, a, point);
+                build_binary_op(Add, reg(RAX, sz_64), reg(RDX, sz_64), ass, a, point);
+                build_binary_op(Mov, reg(RDX, sz_64), imm32(0), ass, a, point);
+                build_binary_op(Mov, reg(RCX, sz_64), imm32(block_size), ass, a, point);
+                build_unary_op(Mul, reg(RCX, sz_64), ass, a, point);
+
+                block_size *= array_type->array.dimensions.data[syn.array_elt.index.len - (i + 1)].val;
+            }
+            build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
+            data_stack_shrink(env, (syn.array_elt.index.len - 1) * ADDRESS_SIZE);
+
+            generate_i(syn.array_elt.array, env, ictx);
+            int64_t current_level = get_stack_head(env);
+
+            build_binary_op(Mov, reg(RDX, sz_64), reg(RSP, sz_64), ass, a, point);
+            build_binary_op(Add, reg(RDX, sz_64), imm32(dest_level - current_level), ass, a, point);
+
+            build_binary_op(Mov, reg(RCX, sz_64), reg(RSP, sz_64), ass, a, point);
+            build_binary_op(Add, reg(RCX, sz_64), rref32(RSP, dest_level - current_level - ADDRESS_SIZE, sz_64), ass, a, point);
+
+            generate_monomorphic_copy(RDX, RCX, elt_size, ass, a, point);
+            size_t discard = dest_level - current_level;
+            build_binary_op(Add, reg(RSP, sz_64), imm32(discard), ass, a, point);
+            data_stack_shrink(env, discard);
         }
-
-        size_t block_size = offset_size;
-        build_binary_op(Mov, reg(RAX, sz_64), imm32(0), ass, a, point);
-        for (size_t i = 0; i < syn.array_elt.index.len; i++) {
-            // Calculate the source offset from the array start
-            build_unary_op(Pop, reg(RDX, sz_64), ass, a, point);
-            build_binary_op(Add, reg(RAX, sz_64), reg(RDX, sz_64), ass, a, point);
-            build_binary_op(Mov, reg(RDX, sz_64), imm32(0), ass, a, point);
-            build_binary_op(Mov, reg(RCX, sz_64), imm32(block_size), ass, a, point);
-            build_unary_op(Mul, reg(RCX, sz_64), ass, a, point);
-
-            block_size *= array_type->array.dimensions.data[syn.array_elt.index.len - (i + 1)].val;
-        }
-        build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
-        data_stack_shrink(env, (syn.array_elt.index.len - 1) * ADDRESS_SIZE);
-
-        generate_i(syn.array_elt.array, env, ictx);
-        int64_t current_level = get_stack_head(env);
-
-        build_binary_op(Mov, reg(RDX, sz_64), reg(RSP, sz_64), ass, a, point);
-        build_binary_op(Add, reg(RDX, sz_64), imm32(dest_level - current_level), ass, a, point);
-
-        build_binary_op(Mov, reg(RCX, sz_64), reg(RSP, sz_64), ass, a, point);
-        build_binary_op(Add, reg(RCX, sz_64), rref32(RSP, dest_level - current_level - ADDRESS_SIZE, sz_64), ass, a, point);
-
-        generate_monomorphic_copy(RDX, RCX, elt_size, ass, a, point);
-        size_t discard = dest_level - current_level;
-        build_binary_op(Add, reg(RSP, sz_64), imm32(discard), ass, a, point);
-        data_stack_shrink(env, discard);
         break;
     }
     case SStructure: {

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -1029,23 +1029,102 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
         break; 
     }
     case SArray: {
-        // TODO: account for SIMD alignment
-        // TODO: account for polymorphism
-        PiType* array_type = strip_type(type);
-        size_t stack_size = pi_stack_size_of(*array_type);
-        build_binary_op(Sub, reg(RSP, sz_64), imm32(stack_size), ass, a, point);
-        data_stack_grow(env, stack_size);
+        // TODO: account for SIMD stuff (alignment, registers, etc.)
+        if (is_variable_in(type, env)) {
+            PiType* array_type = strip_type(type);
+            PiType* elt_type = strip_type(array_type->array.element);
+            // Size
+            generate_size_of(RAX, elt_type, env, ass, a, point);
+            build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
+            data_stack_grow(env, REGISTER_SIZE);
 
-        size_t dest_offset = 0;
-        size_t elt_size = pi_size_of(*array_type->array.element);
-        size_t elt_offset = pi_size_align(elt_size, pi_align_of(*array_type->array.element));
-        size_t elt_stack_size = pi_stack_align(elt_size);
-        for (size_t i = 0; i < syn.array.elements.len; i++) {
-            generate_i(syn.array.elements.data[i], env, ictx);
-            generate_stack_move(dest_offset + elt_stack_size, 0, elt_size, ass, a, point);
-            build_binary_op(Add, reg(RSP, sz_64), imm32(elt_stack_size), ass, a, point);
-            data_stack_shrink(env, elt_stack_size);
-            dest_offset += elt_offset;
+            // Align
+            generate_align_of(RAX, elt_type, env, ass, a, point);
+            build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
+            data_stack_grow(env, REGISTER_SIZE);
+
+            // Align size to element alignment
+            build_binary_op(Mov, reg(R8, sz_64), rref8(RSP, 8, sz_64), ass, a, point);
+            build_binary_op(Mov, reg(R9, sz_64), rref8(RSP, 0, sz_64), ass, a, point);
+            generate_align_to(R8, R9, ass, a, point);
+            build_binary_op(Mov, rref8(RSP, 0, sz_64), reg(R8, sz_64), ass, a, point);
+
+            // TODO (BUG UB): ensure downcast is correct!
+            // TODO (EFFICIENCY) add support for mov reg, imm8 and then
+            //                   downgrade this frim i32 to i8.
+            build_binary_op(Mov, reg(R9, sz_64), imm32(ADDRESS_SIZE), ass, a, point);
+            build_binary_op(Mov, reg(R8, sz_64), rref8(RSP, 8, sz_64), ass, a, point);
+            generate_align_to(R8, R9, ass, a, point);
+            build_binary_op(Mov, rref8(RSP, 8, sz_64), reg(RAX, sz_64), ass, a, point);
+
+            uint64_t len = total_arr_len(array_type->array.dimensions);
+            build_binary_op(Mov, reg(RAX, sz_64), imm32(len), ass, a, point);
+            build_unary_op(Mul, rref8(RSP, 8, sz_64), ass, a, point);
+
+            build_binary_op(Sub, reg(VSTACK_HEAD, sz_64), reg(RAX, sz_64), ass, a, point);
+            build_unary_op(Push, reg(VSTACK_HEAD, sz_64), ass, a, point);
+            build_unary_op(Push, reg(VSTACK_HEAD, sz_64), ass, a, point);
+            data_stack_grow(env, 2*REGISTER_SIZE);
+
+            // Current Relevant state:
+            // [RSP+24] : Element Stack Size
+            // [RSP+16] : Element Aligned Size
+            // [RSP+8]  : Pointer to array on variable stack
+            // [RSP]    : Pointer to current target on variable stack
+            //
+            // RAX : Array stack size
+            // -------------------------------------
+            // Next step: generate each element, copy it onto the stack
+            // 
+
+            for (size_t i = 0; i < syn.array.elements.len; i++) {
+                generate_i(syn.array.elements.data[i], env, ictx);
+                build_unary_op(Pop, reg(R9, sz_64), ass, a, point);
+                data_stack_shrink(env, ADDRESS_SIZE);
+
+                // TODO: elements may be static (when we may have variadic arrays)! double-check!
+                build_binary_op(Mov, reg(R8, sz_64), rref8(RSP, 0, sz_64), ass, a, point);
+                build_binary_op(Mov, reg(RAX, sz_64), rref8(RSP, 24, sz_64), ass, a, point);
+                generate_poly_move(reg(R8, sz_64), reg(R9, sz_64), reg(RAX, sz_64), ass, a, point);
+
+                // Incerment index
+                build_binary_op(Mov, reg(RAX, sz_64), rref8(RSP, 16, sz_64), ass, a, point);
+                build_binary_op(Add, rref8(RSP, 0, sz_64), reg(RAX, sz_64), ass, a, point);
+
+                // Pop value from variable stack
+                build_binary_op(Mov, reg(R8, sz_64), rref8(RSP, 24, sz_64), ass, a, point);
+                build_binary_op(Add, reg(VSTACK_HEAD, sz_64), reg(R8, sz_64), ass, a, point);
+            }
+
+            // Current Relevant state:
+            // [RSP+24] : Element Stack Size
+            // [RSP+16] : Element Aligned Size
+            // [RSP+8]  : Pointer to array on variable stack
+            // [RSP]    : Pointer to current target on variable stack
+            // ------------------------------------------------------
+            // Next step: move RSP+8 -> RSP +24, pop 3 elements from stack
+            build_binary_op(Mov, reg(R8, sz_64), rref8(RSP, 8, sz_64), ass, a, point);
+            build_binary_op(Mov, rref8(RSP, 24, sz_64), reg(R8, sz_64), ass, a, point);
+            build_binary_op(Add, reg(RSP, sz_64), imm8(3*REGISTER_SIZE), ass, a, point);
+
+            data_stack_shrink(env, 3*REGISTER_SIZE);
+        } else {
+            PiType* array_type = strip_type(type);
+            size_t stack_size = pi_stack_size_of(*array_type);
+            build_binary_op(Sub, reg(RSP, sz_64), imm32(stack_size), ass, a, point);
+            data_stack_grow(env, stack_size);
+
+            size_t dest_offset = 0;
+            size_t elt_size = pi_size_of(*array_type->array.element);
+            size_t elt_offset = pi_size_align(elt_size, pi_align_of(*array_type->array.element));
+            size_t elt_stack_size = pi_stack_align(elt_size);
+            for (size_t i = 0; i < syn.array.elements.len; i++) {
+                generate_i(syn.array.elements.data[i], env, ictx);
+                generate_stack_move(dest_offset + elt_stack_size, 0, elt_size, ass, a, point);
+                build_binary_op(Add, reg(RSP, sz_64), imm32(elt_stack_size), ass, a, point);
+                data_stack_shrink(env, elt_stack_size);
+                dest_offset += elt_offset;
+            }
         }
         break;
     }

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -1210,16 +1210,16 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
             // [RSP]      : Array
             // .... <index>
             // ----------------------------------------
-            build_binary_op(Mov, reg(RDX, sz_64), rref8(RSP, 40, sz_64), ass, a, point);
+            build_binary_op(Mov, reg(RCX, sz_64), rref8(RSP, 40, sz_64), ass, a, point);
             // Src + 
-            build_binary_op(Mov, reg(RCX, sz_64), rref8(RSP, 0, sz_64), ass, a, point);
+            build_binary_op(Mov, reg(RDX, sz_64), rref8(RSP, 0, sz_64), ass, a, point);
             build_binary_op(Mov, reg(R9, sz_64), rref8(RSP, 8, sz_64), ass, a, point);
-            build_binary_op(Add, reg(RCX, sz_64), reg(R9, sz_64), ass, a, point);
+            build_binary_op(Add, reg(RDX, sz_64), reg(R9, sz_64), ass, a, point);
 
             // Size
             build_binary_op(Mov, reg(R8, sz_64), rref8(RSP, 16, sz_64), ass, a, point);
 
-            generate_poly_move(reg(RDX, sz_64), reg(RCX, sz_64), reg(R8, sz_64), ass, a, point);
+            generate_poly_move(reg(RCX, sz_64), reg(RDX, sz_64), reg(R8, sz_64), ass, a, point);
 
             // Pop unneded values from static stack
             build_binary_op(Add, reg(RSP, sz_64), imm32(40), ass, a, point);

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -1152,8 +1152,6 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
             generate_align_to(R8, R9, ass, a, point);
             build_unary_op(Push, reg(R8, sz_64), ass, a, point);
 
-            build_binary_op(Mov, rref8(RSP, 16, sz_64), reg(R8, sz_64), ass, a, point);
-
             // Reserve space for element (return value) on dynamic stack, and
             // overwrite raw element size with it
             build_binary_op(Sub, reg(R14, sz_64), reg(R8, sz_64), ass, a, point);

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -1055,7 +1055,7 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
             build_binary_op(Mov, reg(R9, sz_64), imm32(ADDRESS_SIZE), ass, a, point);
             build_binary_op(Mov, reg(R8, sz_64), rref8(RSP, 8, sz_64), ass, a, point);
             generate_align_to(R8, R9, ass, a, point);
-            build_binary_op(Mov, rref8(RSP, 8, sz_64), reg(RAX, sz_64), ass, a, point);
+            build_binary_op(Mov, rref8(RSP, 8, sz_64), reg(R8, sz_64), ass, a, point);
 
             uint64_t len = total_arr_len(array_type->array.dimensions);
             build_binary_op(Mov, reg(RAX, sz_64), imm32(len), ass, a, point);

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -2895,6 +2895,7 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
 
             // Move false (not uvar)
             build_binary_op(Mov, reg(R9, sz_64), imm32(0), ass, a, point);
+            build_binary_op(Mov, sib(RAX, RCX, 8, sz_64), reg(R9, sz_64), ass, a, point);
             build_binary_op(Add, reg(RCX, sz_64), imm8(1), ass, a, point);
 
             // Move dimension (val)

--- a/src/pico/codegen/backend-direct/amd64/polymorphic.c
+++ b/src/pico/codegen/backend-direct/amd64/polymorphic.c
@@ -682,19 +682,26 @@ void generate_poly_move(Location dest, Location src, Location size, Assembler* a
 
     // memcpy (dest = rdi, src = rsi, size = rdx)
     // copy size into RDX
-    build_binary_op(Mov, reg(RDI, sz_64), dest, ass, a, point);
-    build_binary_op(Mov, reg(RSI, sz_64), src, ass, a, point);
-    build_binary_op(Mov, reg(RDX, sz_64), size, ass, a, point);
+    if (!reg_conflict(dest, RDI))
+        build_binary_op(Mov, reg(RDI, sz_64), dest, ass, a, point);
+    if (!reg_conflict(src, RSI))
+        build_binary_op(Mov, reg(RSI, sz_64), src, ass, a, point);
+    if (!reg_conflict(size, RDX))
+        build_binary_op(Mov, reg(RDX, sz_64), size, ass, a, point);
 
 #elif ABI == WIN_64
-    if (reg_conflict(src, RCX) || reg_conflict(size, RDX) || reg_conflict(size, R8)) {
+    if (reg_conflict(src, RCX) || reg_conflict(size, RCX) || reg_conflict(size, RDX)) {
         panic(mv_string("In generate_poly_move: invalid regitser provided to generate_poly_move"));
     }
 
     // memcpy (dest = rcx, src = rdx, size = r8)
-    build_binary_op(Mov, reg(RCX, sz_64), dest, ass, a, point);
-    build_binary_op(Mov, reg(RDX, sz_64), src, ass, a, point);
-    build_binary_op(Mov, reg(R8, sz_64), size, ass, a, point);
+    if (!reg_conflict(dest, RCX))
+        build_binary_op(Mov, reg(RCX, sz_64), dest, ass, a, point);
+    if (!reg_conflict(src, RDX))
+        build_binary_op(Mov, reg(RDX, sz_64), src, ass, a, point);
+    if (!reg_conflict(size, R8))
+        build_binary_op(Mov, reg(R8, sz_64), size, ass, a, point);
+
 #else
 #error "Unknown calling convention"
 #endif

--- a/src/pico/codegen/backend-direct/amd64/polymorphic.c
+++ b/src/pico/codegen/backend-direct/amd64/polymorphic.c
@@ -290,6 +290,21 @@ void generate_size_of(Regname dest, PiType* type, AddressEnv* env, Assembler* as
             }
             break;
         }
+        case TArray: {
+            generate_align_of(R9, type->array.element, env, ass, a, point);
+            build_unary_op(Push, reg(R9, sz_64), ass, a, point);
+            generate_size_of(R8, type->array.element, env, ass, a, point);
+            build_unary_op(Pop, reg(R9, sz_64), ass, a, point);
+            generate_align_to(R8, R9, ass, a, point);
+
+            build_binary_op(Mov, reg(RAX, sz_64), reg(R8, sz_64), ass, a, point);
+            build_binary_op(Mov, reg(RCX, sz_64), imm64(total_arr_len(type->array.dimensions)), ass, a, point);
+            build_unary_op(Mul, reg(RCX, sz_64), ass, a, point);
+            if (dest != RAX) {
+                build_binary_op(Mov, reg(dest, sz_64), reg(RAX, sz_64), ass, a, point);
+            }
+            break;
+        }
         case TStruct: {
             build_unary_op(Push, imm32(0), ass, a, point);
             for (size_t i = 0; i < type->structure.fields.len; i++) {
@@ -384,6 +399,10 @@ void generate_align_of(Regname dest, PiType* type, AddressEnv* env, Assembler* a
                 break;
             }
             }
+            break;
+        }
+        case TArray: {
+            generate_align_of(dest, type->array.element, env, ass, a, point);
             break;
         }
         case TStruct: {

--- a/src/pico/eval/call.c
+++ b/src/pico/eval/call.c
@@ -239,7 +239,7 @@ void* call_instance_fn(void *function, U64Array types, PtrArray implicits, size_
           , "r" (implicits.len)
           // Clobbers are either registers we change (output cannot be trusted)
           // or registers we don't want compiler to assign to input values
-        : "rax", "r12", "r13", "r14", "r15");
+        : "rbx", "rax", "r12", "r13", "r14", "r15");
 #elif ARCH == AARCH64
     panic(mv_string("not implemented: unit call for aarch64"));
 #else

--- a/src/pico/parse/parse.c
+++ b/src/pico/parse/parse.c
@@ -771,6 +771,16 @@ ParseResult parse_rawstring(IStream* is, PiAllocator* pia, Allocator* a) {
     };
 }
 
+ParseResult build_char_lit(int64_t codepoint, Range range) {
+    return (ParseResult) {
+        .type = ParseSuccess,
+        .result.type = RawAtom,
+        .result.range = range,
+        .result.atom.type = AIntegral,
+        .result.atom.int_64 = codepoint,
+    };
+}
+
 ParseResult parse_hash(IStream* is, PiAllocator* pia, Allocator* a) {
     StreamResult result;
     uint32_t codepoint;
@@ -790,14 +800,11 @@ ParseResult parse_hash(IStream* is, PiAllocator* pia, Allocator* a) {
     uint32_t char_lit = codepoint;
     peek(is, &codepoint);
     if (is_whitespace(codepoint) || is_special_char(codepoint)) {
-        return (ParseResult) {
-            .type = ParseSuccess,
-            .result.type = RawAtom,
-            .result.range.start = start,
-            .result.range.end = bytecount(is),
-            .result.atom.type = AIntegral,
-            .result.atom.int_64 = char_lit,
+        Range range = {
+            .start = start,
+            .end = bytecount(is),
         };
+        return build_char_lit(char_lit, range);
     } else if (codepoint == '_') {
         switch (char_lit) {
         case 'b':
@@ -815,15 +822,42 @@ ParseResult parse_hash(IStream* is, PiAllocator* pia, Allocator* a) {
             break;
         }
     } else {
-        return (ParseResult) {
-            .type = ParseFail,
-            .error.message = mv_cstr_doc("Unexpected literal beginning with '#': if you meant a char literal\n "
-                                         "ensure there is only one character following the '#' then a space.\n"
-                                         "If you wanted a numeric literal, follow the '#' with a base indicator\n" 
-                                         "character then an underscore, e.g. #b_11 for binary 3" , a),
-            .error.range.start = bytecount(is),
-            .error.range.end = bytecount(is),
+        U32Array u32_name = mk_u32_array(8, a);
+        push_u32(char_lit, &u32_name);
+        while (!(is_whitespace(codepoint) || is_special_char(codepoint))) {
+            push_u32(codepoint, &u32_name);
+            next(is, &codepoint); // consume current token
+            peek(is, &codepoint); // to check if next token is end
+        }
+        String name = string_from_UTF_32(u32_name, a);
+
+        Range range = {
+            .start = start,
+            .end = bytecount(is),
         };
+        if (string_eq(mv_string("null"), name)) {
+            return build_char_lit('\0', range);
+        } else if (string_eq(mv_string("space"), name)) {
+            return build_char_lit(' ', range);
+        } else if (string_eq(mv_string("tab"), name)) {
+            return build_char_lit('\t', range);
+        } else if (string_eq(mv_string("newline"), name)) {
+            return build_char_lit('\n', range);
+        } else if (string_eq(mv_string("return"), name)) {
+            return build_char_lit('\r', range);
+        } else {
+            return (ParseResult) {
+                .type = ParseFail,
+                .error.message = mv_cstr_doc("Unexpected charater literall name '#': most character literals\n "
+                                             "need there is only one character following the '#' then a space or .\n"
+                                             "special character.\n If you wanted a numeric literal, follow the '#' \n"
+                                             "  with a base indicator character then an underscore, e.g. #b_11 for binary 3.\n"
+                                             "If you wanted a named charater, such as #space or #tab, please check \n"
+                                             "  the spelling, and the documentation, to ensure your charater is supported."
+                                             , a),
+                .error.range = range,
+            };
+        }
     }
 }
 

--- a/src/pico/stdlib/abs/equality.c
+++ b/src/pico/stdlib/abs/equality.c
@@ -100,7 +100,7 @@ void add_equality_module(Target target, Module *abs, RegionAllocator* region) {
     compile_toplevel(eq_u8_trait, module, target, &point, &pi_point, region);
 
     const char* eq_string_trait = 
-        "(def u8-eq instance (Eq string.String)"
+        "(def string-eq instance (Eq string.String)"
         "  [.= string.=]"
         "  [.!= string.!=])\n";
     compile_toplevel(eq_string_trait, module, target, &point, &pi_point, region);

--- a/src/pico/stdlib/extra.c
+++ b/src/pico/stdlib/extra.c
@@ -139,6 +139,8 @@ MacroResult loop_macro(RawTreePiList nodes) {
     push_rawtree((RawTree){}, &loop_body_nodes);
     AddrPiList loop_fors = mk_addr_list(2, pia);
     AddrPiList loop_whiles = mk_addr_list(2, pia);
+    AddrPiList loop_end_whiles = mk_addr_list(2, pia);
+    int stage = 0; // 0 = begin conditions, 1 = body terms, 2 = end conditions
     for (size_t i = 1; i < nodes.len; i++) {
         RawTree branch = nodes.data[i];
         if (branch.type == RawBranch && branch.branch.hint == HSpecial) {
@@ -158,6 +160,13 @@ MacroResult loop_macro(RawTreePiList nodes) {
                 };
             }
             if (eq_symbol(&branch.branch.nodes.data[0], string_to_symbol(mv_string("for")))) {
+                if (stage != 0) {
+                    return (MacroResult) {
+                        .result_type = Left,
+                        .err.message = mv_string("For clauses can only appear at the beginning of a loop"),
+                        .err.range = branch.branch.nodes.data[0].range,
+                    };
+                }
                 ForRange range;
                 if (branch.branch.nodes.len != 6) {
                     return (MacroResult) {
@@ -235,10 +244,15 @@ MacroResult loop_macro(RawTreePiList nodes) {
                     };
                 }
             } else if (eq_symbol(&branch.branch.nodes.data[0], string_to_symbol(mv_string("while")))) {
+                if (stage == 1) stage++;
                 RawTree *raw_term = (branch.branch.nodes.len == 2)
                     ? &branch.branch.nodes.data[1]
                     : raw_slice(&branch, 1, pia);
-                push_addr(raw_term, &loop_whiles);
+                if (stage == 0) {
+                    push_addr(raw_term, &loop_whiles);
+                } else {
+                    push_addr(raw_term, &loop_end_whiles);
+                }
             } else if (eq_symbol(&branch.branch.nodes.data[0], string_to_symbol(mv_string("let!")))) {
                 // let! gets an exception because loop bodies contain an
                 // implicit 'seq'
@@ -251,7 +265,17 @@ MacroResult loop_macro(RawTreePiList nodes) {
                 };
             }
         } else {
-            push_rawtree(nodes.data[i], &loop_body_nodes);
+            if (stage == 0) stage ++;
+            // TODO: add error message if stage is 2
+            if (stage == 2) {
+                return (MacroResult) {
+                    .result_type = Left,
+                    .err.message = mv_string("Malformed loop clause: expected on of 'while', 'for'"),
+                    .err.range = branch.branch.nodes.data[0].range,
+                };
+            } else {
+                push_rawtree(nodes.data[i], &loop_body_nodes);
+            }
         }
     }
 
@@ -336,7 +360,6 @@ MacroResult loop_macro(RawTreePiList nodes) {
             };
         }
     }
-
     RawTreePiList loop_body_arg_nodes = mk_rawtree_list(loop_fors.len, pia);
     
     for (size_t i = 0; i < loop_fors.len; i++) {
@@ -438,12 +461,60 @@ MacroResult loop_macro(RawTreePiList nodes) {
     // This index was reserved earlier
     loop_body_nodes.data[1] = if_expr;
 
+
+    // Loop end:
+
     RawTree goto_continue = (RawTree) {
         .type = RawBranch,
         .branch.hint = HExpression,
         .branch.nodes = continue_go_to_nodes,
     };
-    push_rawtree(goto_continue, &loop_body_nodes);
+    if (loop_end_whiles.len > 0) {
+        size_t start_idx = 0;
+        if (!cond_initialized) {
+            loop_condition = *(RawTree*)loop_end_whiles.data[0];
+            start_idx++;
+        }
+        for (size_t i = start_idx; i < loop_end_whiles.len; i++) {
+            RawTree new_condition = *(RawTree*)loop_end_whiles.data[i];
+            RawTreePiList and_fn_nodes = mk_rawtree_list(3, pia);
+            push_rawtree(atom_symbol("."), &and_fn_nodes);
+            push_rawtree(atom_symbol("and"), &and_fn_nodes);
+            push_rawtree(atom_symbol("bool"), &and_fn_nodes);
+            RawTree and = (RawTree) {
+                .type = RawBranch,
+                .branch.hint = HExpression,
+                .branch.nodes = and_fn_nodes,
+            };
+
+            RawTreePiList and_nodes = mk_rawtree_list(3, pia);
+
+            push_rawtree(and, &and_nodes);
+            push_rawtree(loop_condition, &and_nodes);
+            push_rawtree(new_condition, &and_nodes);
+            loop_condition = (RawTree) {
+                .type = RawBranch,
+                .branch.hint = HExpression,
+                .branch.nodes = and_nodes,
+            };
+        }
+
+
+        RawTreePiList if_nodes = mk_rawtree_list(4, pia);
+        push_rawtree(atom_symbol("if"), &if_nodes);
+        push_rawtree(loop_condition, &if_nodes);
+        push_rawtree(goto_continue, &if_nodes);
+        push_rawtree(goto_exit, &if_nodes);
+
+        RawTree end_cond = (RawTree) {
+            .type = RawBranch,
+            .branch.hint = HExpression,
+            .branch.nodes = if_nodes,
+        };
+        push_rawtree(end_cond, &loop_body_nodes);
+    } else {
+        push_rawtree(goto_continue, &loop_body_nodes);
+    }
 
     RawTree loop_body = (RawTree) {
         .type = RawBranch,

--- a/src/pico/stdlib/platform/filesystem.c
+++ b/src/pico/stdlib/platform/filesystem.c
@@ -34,7 +34,7 @@ uint8_t relic_read_byte(File *file) {
 U8Array relic_read_chunk(File *file, MaybeSize msize) {
     // TODO: The allocator pointer goes on to live in the output array,
     //       and so it will be dangling when this function exits
-    PiAllocator pia = get_std_perm_allocator();
+    PiAllocator pia = get_std_current_allocator();
     Allocator a = convert_to_callocator(&pia);
     return read_chunk(file, !msize.tag, msize.size, &a);
 }
@@ -47,7 +47,10 @@ CType build_file_result_ctype(PiAllocator* pia) {
                                                    "errcode", mk_primint_ctype((CPrimInt){.is_signed = Unsigned, .prim = CLongLong})));
 }
 
-void relic_current_directory() {
+String relic_current_directory() {
+    PiAllocator pia = get_std_current_allocator();
+    Allocator a = convert_to_callocator(&pia);
+    return get_current_directory(&a);
 }
 
 void build_current_dir_fn(PiType* type, Assembler* ass, PiAllocator* pia, Allocator* a, ErrorPoint* point) {
@@ -194,7 +197,7 @@ void add_filesystem_module(Assembler *ass, Module *platform, RegionAllocator* re
 
     typep = mk_proc_type(pia, 0, mk_string_type(pia));
     build_current_dir_fn(typep, ass, pia, &ra, &point);
-    sym = string_to_symbol(mv_string("current-directory"));
+    sym = string_to_symbol(mv_string("get-current-directory"));
     fn_segments.code = get_instructions(ass);
     prepped = prep_target(module, fn_segments, ass, NULL);
     add_def(module, sym, *typep, &prepped.code.data, prepped, NULL);

--- a/src/pico/syntax/syntax.c
+++ b/src/pico/syntax/syntax.c
@@ -516,7 +516,48 @@ Document* pretty_syntax_internal(SynRef ref, SynTape tape, PrettyContext ctx, Al
         break;
     }
     case SArray: {
-        panic(mv_string("not implemented: pretty syntax for array"));
+        PtrArray nodes = mk_ptr_array(2, a);
+        push_ptr(mk_str_doc(mv_string("array"), a), &nodes);
+        U64Array dims = syntax.array.dimensions;
+
+        U64Array index = mk_zero_index(dims.len, a);
+        PtrArray array_stack = mk_ptr_array(dims.len, a);
+        for (size_t i = 0; i < dims.len; i++) {
+            PtrArray* arr = mem_alloc(sizeof(PtrArray), a);
+            *arr = mk_ptr_array(dims.data[i], a);
+            push_ptr(arr, &array_stack);
+        }
+        while (index_less(index, dims)) {
+            size_t base = index_offset(index, dims);
+            size_t inner_len = dims.data[dims.len - 1];
+            PtrArray* inner_nodes = array_stack.data[array_stack.len - 1];
+            for (size_t i = 0; i < inner_len; i++) {
+                size_t index = base + i;
+                push_ptr(pretty_syntax_internal(syntax.array.elements.data[index], tape, ctx, a), inner_nodes);
+            }
+            index.data[dims.len - 1] = inner_len;
+
+            // We are done, now increment the index!
+            size_t level = 1;
+            uint64_t curr_idx = index.data[dims.len - level];
+            while (level < dims.len && curr_idx > dims.data[dims.len - level]) {
+                if (level + 1 < dims.len) {
+                    PtrArray* array_nodes = array_stack.data[array_stack.len - level];
+                    PtrArray* parent_nodes = array_stack.data[array_stack.len - (level + 1)];
+                    push_ptr(mk_paren_doc("[", "]", mv_sep_doc(*array_nodes, a), a), parent_nodes);
+                    *array_nodes = mk_ptr_array(dims.data[dims.len - level], a);
+                }
+
+                index.data[dims.len - level] = 0;
+                level++;
+                if (level < dims.len) curr_idx = index.data[dims.len - level] + 1;
+            }
+            index.data[dims.len - level] = curr_idx + 1;
+        }
+        PtrArray* array_nodes = array_stack.data[0];
+        push_ptr(mk_paren_doc("[", "]", mv_sep_doc(*array_nodes, a), a), &nodes);
+        out = mk_paren_doc("(",")", mv_sep_doc(nodes, a), a);
+        break;
     }
     case SArrayElt: {
         panic(mv_string("not implemented: pretty syntax for array-elt"));
@@ -880,7 +921,6 @@ Document* pretty_syntax_internal(SynRef ref, SynTape tape, PrettyContext ctx, Al
         break;
     }
     case SArrayType: {
-        panic(mv_string("not implemented: pretty syntax for array"));
         PtrArray nodes = mk_ptr_array(3, a) ;
         push_ptr(mv_style_doc(ty_former_style, mv_str_doc(mk_string("Array", a), a), a), &nodes);
 

--- a/src/pico/typecheck/typecheck.c
+++ b/src/pico/typecheck/typecheck.c
@@ -930,7 +930,7 @@ void type_infer_i(SynRef ref, TypeEnv* env, TypeCheckContext ctx) {
                     push_ptr(mv_cstr_doc(
                         "Attempting to create a structure "
                         "based off of an opaque type. "
-                        "Note that instances of opaque types can only be "
+                        "Note that values of opaque types can only be "
                         "created in the module that the opaque type is defined."
                         , a), &nodes);
                     push_ptr(pretty_type(struct_type, default_ptp, a), &nodes);

--- a/src/pico/typecheck/typecheck.c
+++ b/src/pico/typecheck/typecheck.c
@@ -383,6 +383,14 @@ void type_infer_i(SynRef ref, TypeEnv* env, TypeCheckContext ctx) {
         type_infer_i(untyped.all.body, env, ctx); 
         pop_types(env, untyped.all.args.len);
         all_ty->binder.body = get_type(untyped.all.body, ctx.tape);
+
+        UnifyContext uctx = (UnifyContext) {
+            .a = ctx.a,
+            .pia = ctx.pia,
+            .current_module = type_env_module(env),
+            .logger = ctx.logger,
+        };
+        squash_type(all_ty, uctx);
         break;
     }
     case SMacro: {

--- a/src/pico/typecheck/unify.c
+++ b/src/pico/typecheck/unify.c
@@ -671,9 +671,14 @@ PiType* try_get_uvar(UVarType *uvar) {
 void add_subst(UVarType* uvar, SymPtrAssoc binds, Allocator* a) {
     // NOTE: We shallow copy here due to the allocation guarantees made 
     //       by the typecheck (caller) function.
-    SymPtrAssoc* subst = mem_alloc(sizeof(SymPtrAssoc), a);
-    *subst = scopy_sym_ptr_assoc(binds, a);
-    push_addr(subst, &uvar->substitutions);
+
+    // Eliminate all substitutions that are severed
+    // Note: we start by copying the binds because deletion is destructive
+    if (binds.len > 0) {
+        SymPtrAssoc* subst = mem_alloc(sizeof(SymPtrAssoc), a);
+        *subst = scopy_sym_ptr_assoc(binds, a);
+        push_addr(subst, &uvar->substitutions);
+    }
 }
 
 bool has_unification_vars_p(PiType type) {
@@ -1020,7 +1025,7 @@ PiType* mk_uvar(PiAllocator* pia) {
         .subst = NULL,
         .constraints = mk_constraint_list(4, pia),
         .default_behaviour = NoDefault,
-        .substitutions = mk_addr_list(8, pia),
+        .substitutions = mk_addr_list(1, pia),
     };
     
     return uvar;
@@ -1035,7 +1040,7 @@ PiType* mk_uvar_integral(PiAllocator* pia, Range range) {
         .subst = NULL,
         .constraints = mk_constraint_list(4, pia),
         .default_behaviour = Integral,
-        .substitutions = mk_addr_list(8, pia),
+        .substitutions = mk_addr_list(1, pia),
     };
 
     Constraint con = (Constraint) {
@@ -1056,7 +1061,7 @@ PiType* mk_uvar_floating(PiAllocator* pia, Range range) {
         .subst = NULL,
         .constraints = mk_constraint_list(4, pia),
         .default_behaviour = Floating,
-        .substitutions = mk_addr_list(8, pia),
+        .substitutions = mk_addr_list(1, pia),
     };
 
     Constraint con = (Constraint) {

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -407,7 +407,7 @@ Document* pretty_pi_value(void* val, PiType* type, PrettyValParams params, Alloc
             if (type->array.dimensions.data[i].is_uvar) {
                 panic(mv_string("Cannot print array when type has undefined ."));
             }
-            push_u64(type->array.dimensions.data[i].val, &dims);
+            dims.data[i] = type->array.dimensions.data[i].val;
         }
 
         U64Array index = mk_zero_index(dims.len, a);
@@ -1485,6 +1485,19 @@ Result_t pi_maybe_align_of(PiType type, size_t* out) {
     panic(mv_string("pi_maye_align_of received invalid type."));
 }
 
+
+uint64_t total_arr_len(DimPiList dim) {
+    uint64_t total = 1;
+    for (size_t i = 0; i < dim.len; i++) {
+        if (dim.data[i].is_uvar) {
+            panic(mv_string("pi_maye_align_of received invalid type."));
+        } else {
+            total *= dim.data[i].val;
+        }
+    }
+    return total;
+}
+
 // TODO (UB): make this thread safe
 // Note: this counter starts at 1 as 0 is a reserved value,
 // which means 'not unique/no ID'
@@ -1635,7 +1648,7 @@ void type_app_subst(PiType* body, SymPtrAssoc subst, SymbolArray* shadowed, PiAl
         break;
     case TEnum:
         for (size_t i = 0; i < body->enumeration.variants.len; i++) {
-            PtrArray* variant = body->enumeration.variants.data[i].val;
+            AddrPiList* variant = body->enumeration.variants.data[i].val;
             for (size_t j = 0; j < variant->len; j++) {
                 type_app_subst(variant->data[j], subst, shadowed, pia, logger, a);
             }

--- a/src/pico/values/types.c
+++ b/src/pico/values/types.c
@@ -2319,6 +2319,9 @@ bool is_variable_for_recur(PiType *ty, SymbolArray vars, SymbolArray shadowed) {
     }
     case TProc:
         return false;
+    case TArray:
+        // TODO: update me when dimension can vary 
+        return is_variable_for_recur(ty->array.element, vars, shadowed);
     case TStruct:
         for (size_t i = 0; i < ty->structure.fields.len; i++) {
             if (is_variable_for_recur(ty->structure.fields.data[i].val, vars, shadowed))

--- a/src/platform/window/impl_wayland.c
+++ b/src/platform/window/impl_wayland.c
@@ -345,7 +345,9 @@ PlWindow *pl_create_window(String name, int width, int height) {
 
     // TODO (INVESTIGATE BUG): check the encoding used by wayland - if not
     // UTF-8, convert!
-    xdg_toplevel_set_title(top, (char*)name.bytes);
+    char* c_name = to_c_string(name, wsa);
+    xdg_toplevel_set_title(top, c_name);
+    mem_free(c_name, wsa);
 
     wl_surface_commit(surface); // TOOD: necessary?
     push_ptr(window, &windows);

--- a/src/platform/window/impl_win32.c
+++ b/src/platform/window/impl_win32.c
@@ -110,16 +110,18 @@ void pl_teardown_window_system() {
 
 PlWindow* pl_create_window(String name, int width, int height) {
     PlWindow *win = mem_alloc(sizeof(PlWindow), wsa);
+    char* c_name = to_c_string(name, wsa);
     HWND window = CreateWindowEx(0, // styles (optional)
                                  wind_class_name,
-                                 (char*)name.bytes,
+                                 c_name,
                                  WS_OVERLAPPEDWINDOW, // window style/type
                                  CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,  // position/size
                                  NULL, // parent
                                  NULL, // Menu
                                  app_handle,
                                  win // This will get passed into the WindowProc function as LPARAM
-                                );
+                                 );
+    mem_free(c_name, wsa);
     if (window) {
         ShowWindow(window, SW_SHOWDEFAULT);
         return win;

--- a/src/platform/window/impl_x11.c
+++ b/src/platform/window/impl_x11.c
@@ -51,7 +51,6 @@ PlWindow* pl_create_window(String name, int width, int height) {
 
     int blackColour = BlackPixel(x11_display, DefaultScreen(x11_display));
 
-
     Window xwin = XCreateSimpleWindow(x11_display, DefaultRootWindow(x11_display), 0, 0, width, height, 0, blackColour, blackColour);
 	XSetWMProtocols(x11_display, xwin, &WM_DELETE_WINDOW, 1);
 

--- a/src/platform/window/xkb_translate.c
+++ b/src/platform/window/xkb_translate.c
@@ -446,6 +446,7 @@ static uint32_t invert_key[] = {
     0,/* KEY_RPAREN, */
     KEY_MINUS,
     KEY_KPPLUS,
+    0,/* Divide */
 
     0,/* KEY_LBRACE, */
     0,/* KEY_RBRACE, */
@@ -457,6 +458,7 @@ static uint32_t invert_key[] = {
 
     KEY_SPACE,
 
+    0 /*KEY_SHIFT*/,
     KEY_ENTER,
     KEY_BACKSPACE,
 };

--- a/test/src/test_pico/eval/eval.c
+++ b/test/src/test_pico/eval/eval.c
@@ -23,6 +23,8 @@ void run_pico_eval_tests(TestLog* log, Target target, RegionAllocator* region) {
     add_import_all(&imports.clauses, a, 1, "platform");
     add_import_all(&imports.clauses, a, 2, "platform", "memory");
 
+    add_import_all(&imports.clauses, a, 2, "abs", "numeric");
+
     Exports exports = (Exports) {
         .export_all = true,
         .clauses = mk_export_clause_array(0, a),

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -282,6 +282,12 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
         TEST_EQ("((all [A] proc [(a (Array [4] A))] aelt 2 a) my-array)");
     }
 
+    if (test_start(log, mv_string("array-polymorphic-element-small"))) {
+        RUN("(def my-array array [(is 1 U8) (is 2 U8) (is 3 U8) (is 4 U8)])");
+        uint8_t expected = 3;
+        TEST_EQ("((all [A] proc [(a (Array [4] A))] aelt 2 a) my-array)");
+    }
+
     // -----------------------------------------------------
     // 
     //      Variant

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -265,13 +265,22 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
         TEST_EQ("((all [A] proc [(a A) (b A) (c A) (d A)] array {4} [a b c d]) {I32} 1 2 3 4)");
     }
 
-    /*
-    if (test_start(log, mv_string("array-polymorphic-element"))) {
-        RUN("(def my-array )");
-        int64_t expected[4] = {1, 2, 3, 4};
-        TEST_EQ("((all [A] proc [(a A) (b A) (c A) (d A)] array {4} [a b c d]) 1 2 3 4)");
+    if (test_start(log, mv_string("array-polymorphic-constructor-align!=size"))) {
+        typedef struct {
+            uint64_t v1;
+            uint32_t v2;
+        } Expected;
+        Expected expected[4] = {{.v1 = 1, .v2 = 3}, {.v1 = 2, .v2 = 4}, {.v1 = 5, .v2 = 7}, {.v1 = 6, .v2 = 8}};
+        RUN("(def SCT Struct [.v1 U64] [.v2 U32])");
+        TEST_EQ("((all [A] proc [(a A) (b A) (c A) (d A)] array {4} [a b c d]) {SCT}"
+                "  (struct [.v1 1] [.v2 3]) (struct [.v1 2] [.v2 4]) (struct [.v1 5] [.v2 7]) (struct [.v1 6] [.v2 8]))");
     }
-    */
+
+    if (test_start(log, mv_string("array-polymorphic-element"))) {
+        RUN("(def my-array array [1 2 3 4])");
+        int64_t expected = 3;
+        TEST_EQ("((all [A] proc [(a (Array [4] A))] aelt 2 a) my-array)");
+    }
 
     // -----------------------------------------------------
     // 

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -251,6 +251,17 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
 
     // -----------------------------------------------------
     // 
+    //      Array
+    // 
+    // -----------------------------------------------------
+
+    if (test_start(log, mv_string("array-polymorphic-constructor"))) {
+        int64_t expected[4] = {1, 2, 3, 4};
+        TEST_EQ("((all [A] proc [(a A) (b A) (c A) (d A)] array {4} [a b c d]) 1 2 3 4)");
+    }
+
+    // -----------------------------------------------------
+    // 
     //      Variant
     // 
     // -----------------------------------------------------

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -260,6 +260,19 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
         TEST_EQ("((all [A] proc [(a A) (b A) (c A) (d A)] array {4} [a b c d]) 1 2 3 4)");
     }
 
+    if (test_start(log, mv_string("array-polymorphic-constructor-align!=stack"))) {
+        int32_t expected[4] = {1, 2, 3, 4};
+        TEST_EQ("((all [A] proc [(a A) (b A) (c A) (d A)] array {4} [a b c d]) {I32} 1 2 3 4)");
+    }
+
+    /*
+    if (test_start(log, mv_string("array-polymorphic-element"))) {
+        RUN("(def my-array )");
+        int64_t expected[4] = {1, 2, 3, 4};
+        TEST_EQ("((all [A] proc [(a A) (b A) (c A) (d A)] array {4} [a b c d]) 1 2 3 4)");
+    }
+    */
+
     // -----------------------------------------------------
     // 
     //      Variant

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -91,6 +91,25 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
 
     // -------------------------------------------------------------------------
     //
+    //     Polymorphism in Traits/Instances
+    //
+    // -------------------------------------------------------------------------
+
+    if (test_start(log, mv_string("poly-internal-return-large"))) {
+      RUN("(def Eql Trait Eql [A] [.eql Proc [A A] Bool])\n");
+      RUN("(def eql-i64 instance (Eql I64) [.eql proc [l r] (i64.= l r)])\n");
+      RUN("(def eql-arr2 instance [A] {(eq (Eql A))} (Eql (Array [2] A))\n"
+          "  [.eql proc [l r]\n"
+          "      (bool.and (eq.eql (aelt 0 l) (aelt 0 r))\n"
+          "           (eq.eql (aelt 1 l) (aelt 1 r)))])\n");
+      RUN("(def eql all [A] proc {(eql (Eql A))} [(l A) (r A)] (eql.eql l r))\n");
+      bool expected = true;
+      TEST_EQ("(eql (array [1 2]) (array [1 2]))");
+    }
+
+
+    // -------------------------------------------------------------------------
+    //
     //     Static control and binding - seq/let/if/
     //
     // -------------------------------------------------------------------------
@@ -286,6 +305,12 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
         RUN("(def my-array array [(is 1 U8) (is 2 U8) (is 3 U8) (is 4 U8)])");
         uint8_t expected = 3;
         TEST_EQ("((all [A] proc [(a (Array [4] A))] aelt 2 a) my-array)");
+    }
+
+    if (test_start(log, mv_string("array-polymorphic-multi-element-access"))) {
+        RUN("(def my-array array [(is 1 U8) (is 2 U8) (is 3 U8) (is 4 U8)])");
+        uint8_t expected = 5;
+        TEST_EQ("((all [A] proc {(n (Num A))} [(a (Array [4] A))] (n.+ (aelt 2 a) (aelt 1 a))) my-array)");
     }
 
     // -----------------------------------------------------

--- a/test/src/test_pico/stdlib/core/core.c
+++ b/test/src/test_pico/stdlib/core/core.c
@@ -627,7 +627,7 @@ void run_pico_stdlib_core_tests(TestLog *log, Module* module, Environment* env, 
     }
 
     // -----------------------------------------------------
-    // 
+    ///
     //  Instances
     // 
     // -----------------------------------------------------
@@ -668,10 +668,8 @@ void run_pico_stdlib_core_tests(TestLog *log, Module* module, Environment* env, 
         int64_t expected = -98;
         RUN("(def Inhabited Trait Inhabited [A] [.value A])");
 
-        // TODO (BUG)
-        // swapping the order of below statements gives an 'ambiguous instance' error?
-        RUN("(def i8-inhabited instance (Inhabited I8) [.value -98])");
         RUN("(def get-value all [A] proc {(in (Inhabited A))} [(x A)] in.value)");
+        RUN("(def i8-inhabited instance (Inhabited I8) [.value -98])");
         TEST_EQ("(get-value {I8} 5)");
     }
 
@@ -686,7 +684,6 @@ void run_pico_stdlib_core_tests(TestLog *log, Module* module, Environment* env, 
             "      (out-of (ID A) x) "
             "      (out-of (ID A) y)))])");
         RUN("(def poly-add all [A] proc {(add (Addable A))} [(x A) (y A)] (add.add x y))");
-        //        TEST_EQ()
 
         int64_t expected = 72;
         TEST_EQ("(poly-add (into (ID I64) 42) (into (ID I64) 30))");


### PR DESCRIPTION
## Improvements
- Can place `while` condition at end of loop
- Added support for polymorphic array construction + element

## Bugfixes
- Fixed crash related to window titles (from string change)
- Fixed bug where `string-eq` instance was incorrectly named `u8-eq`, incorrectly overriding the actual `u8-eq` instance.
- Fixed bug where array values would print incorrectly
- Fixed crash from desynced `rawkey_to_scancode` definition.
- Fix bug where array code may exhibit UB
- Fix crash when using dependent instances
- Fix codegen crash on windows when using arrays