### PR TITLE
Release Beta 0.2.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,10 @@ TARGET_EXEC := pico
 else
 TARGET_EXEC := pico.exe
 endif
+TARGET_IMAGE := pico_image_template
 
 MAIN_SRC := ./src/main.c
+IMAGE_SRC := ./image/unlinked_image.c
 BUILD_DIR := ./build
 RELEASE_DIR := $(BUILD_DIR)/release
 DEBUG_DIR := $(BUILD_DIR)/debug
@@ -123,6 +125,7 @@ RELEASE_OBJS := $(SRCS:%=$(RELEASE_DIR)/%.o)
 DEBUG_OBJS := $(SRCS:%=$(DEBUG_DIR)/%.o)
 MAIN_RELEASE_OBJ := $(MAIN_SRC:%=$(RELEASE_DIR)/%.o)
 MAIN_DEBUG_OBJ := $(MAIN_SRC:%=$(DEBUG_DIR)/%.o)
+UNLINKED_IMAGE_OBJ := $(IMAGE_SRC:%=$(RELEASE_DIR)/%.o)
 
 # String substitution (suffix version without %).
 # As an example, ./build/hello.c turns into ./build/hello.c.d
@@ -143,6 +146,9 @@ CFLAGS := $(CFLAGS) -Wall -Wextra -Wundef -Wno-unused-parameter -Wnull-dereferen
 CFLAGS := $(CFLAGS) # -Wconversion -Wsign-conversion
 
 # The final build step.
+$(RELEASE_DIR)/$(TARGET_IMAGE): $(RELEASE_OBJS) $(IMAGE_OBJ)
+	$(CC) $(RELEASE_OBJS) $(MAIN_RELEASE_OBJ) -o $@ $(CFLAGS) $(RELEASE_FLAGS) $(LINK_FLAGS)
+
 $(RELEASE_DIR)/$(TARGET_EXEC): $(RELEASE_OBJS) $(MAIN_RELEASE_OBJ)
 	$(CC) $(RELEASE_OBJS) $(MAIN_RELEASE_OBJ) -o $@ $(CFLAGS) $(RELEASE_FLAGS) $(LINK_FLAGS)
 
@@ -256,6 +262,9 @@ release: $(RELEASE_DIR)/$(TARGET_EXEC)
 .PHONY: debug
 debug: $(DEBUG_DIR)/$(TARGET_EXEC)
 
+.PHONY: image
+release: $(RELEASE_DIR)/$(TARGET_IMAGE)
+
 
 # Run tests with make test
 .PHONY: test
@@ -288,7 +297,7 @@ run-debug: $(DEBUG_DIR)/$(TARGET_EXEC)
 	$(DEBUG_DIR)/$(TARGET_EXEC)
 
 .PHONY: all
-all: debug release test keeper installer prep-install
+all: debug release test keeper installer installer
 
 # TODO: (FEAT) check shell; set appropriately
 .PHONY: debug_mode
@@ -300,19 +309,20 @@ ASSET_DIR := $(INSTALLER_DIR)/assets
 
 # 
 .PHONY: installer
-installer: build_installer release keeper
+installer: build_installer release keeper image
 	mkdir -p $(INSTALLER_DIR)
 	cp $(INSTALLER_BUILD_DIR)/$(TARGET_INSTALLER) $(INSTALLER_DIR)/$(TARGET_INSTALLER) 
 	mkdir -p $(ASSET_DIR)
 	cp -r installer/scripts $(ASSET_DIR)
 	cp $(RELEASE_DIR)/$(TARGET_EXEC) $(ASSET_DIR)
+	cp $(RELEASE_DIR)/$(TARGET_IMAGE) $(ASSET_DIR)
 	cp $(KEEPER_DIR)/$(TARGET_KEEPER) $(ASSET_DIR)/$(TARGET_KEEPER)
 # TODO: ensure that rsync is supported in w64 devkit.
 	rsync -lr --exclude=*.~undo-tree~ archive $(ASSET_DIR)
 
 # Installation
 .PHONY: install
-install: prep-install
+install: installer
 	cd $(INSTALLER_DIR); ./$(TARGET_INSTALLER)
 
 .PHONY: suppress-config-changes

--- a/Makefile
+++ b/Makefile
@@ -183,36 +183,7 @@ $(TEST_DIR)/%.c.o: %.c
 	mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -I $(TEST_INC_DIR) -c $< -o $@ $(TEST_FLAGS) 
 
-# Installer
-# ---------------------------------------------
-# Objects from the 'platform' and 'components' diretories
-# that may be useful regardless of application...
-GENERIC_SRC_DIRS := ./src/data ./src/components ./src/platform/filesystem ./src/platform/memory ./src/platform/terminal
-GENERIC_SRCS := $(shell find $(GENERIC_SRC_DIRS) -name '*.c' | grep -v $(MAIN_SRC)) 
-GENERIC_SRCS := $(GENERIC_SRCS) ./src/platform/signals.c ./src/platform/thread.c ./src/platform/error.c ./src/platform/jump.c ./src/platform/environment.c
-GENERIC_OBJS := $(GENERIC_SRCS:%=$(RELEASE_DIR)/%.o)
-
-
-INSTALLER_DIR := $(BUILD_DIR)/installer
-INSTALLER_INC_DIR := ./installer/include
-INSTALLER_SRC_DIRS := ./installer/src
-TARGET_INSTALLER := pico_installer
-
-INSTALLER_FLAGS := $(RELEASE_FLAGS)
-
-INSTALLER_SRCS := $(shell find $(INSTALLER_SRC_DIRS) -name '*.c')
-INSTALLER_OBJS := $(INSTALLER_SRCS:%=$(INSTALLER_DIR)/%.o) $(GENERIC_OBJS)
-
-# Final build step for installer 
-$(INSTALLER_DIR)/$(TARGET_INSTALLER): $(INSTALLER_OBJS)
-	$(CC) $(INSTALLER_OBJS) -I $(INSTALLER_INC_DIR) -o $@ $(LINK_FLAGS) $(INSTALLER_FLAGS) 
-
-# Build step for C tests
-$(INSTALLER_DIR)/%.c.o: %.c
-	mkdir -p $(dir $@)
-	$(CC) $(CFLAGS) -I $(INSTALLER_INC_DIR) -c $< -o $@ $(INSTALLER_FLAGS) 
-
-# Installer
+# Keeper
 # ---------------------------------------------
 ## Same process as above but for tests
 
@@ -240,6 +211,38 @@ $(KEEPER_DIR)/%.c.o: %.c
 	$(CC) $(CFLAGS) -I $(KEEPER_INC_DIR) -c $< -o $@ $(KEEPER_FLAGS) 
 
 
+# Installer
+# ---------------------------------------------
+# Objects from the 'platform' and 'components' diretories
+# that may be useful regardless of application...
+GENERIC_SRC_DIRS := ./src/data ./src/components ./src/platform/filesystem ./src/platform/memory ./src/platform/terminal
+GENERIC_SRCS := $(shell find $(GENERIC_SRC_DIRS) -name '*.c' | grep -v $(MAIN_SRC)) 
+GENERIC_SRCS := $(GENERIC_SRCS) ./src/platform/signals.c ./src/platform/thread.c ./src/platform/error.c ./src/platform/jump.c ./src/platform/environment.c
+GENERIC_OBJS := $(GENERIC_SRCS:%=$(RELEASE_DIR)/%.o)
+
+
+INSTALLER_DIR := $(BUILD_DIR)/installer
+INSTALLER_BUILD_DIR := $(BUILD_DIR)/installer_build
+INSTALLER_INC_DIR := ./installer/include
+INSTALLER_SRC_DIRS := ./installer/src
+TARGET_INSTALLER := pico_installer
+
+INSTALLER_FLAGS := $(RELEASE_FLAGS)
+
+INSTALLER_SRCS := $(shell find $(INSTALLER_SRC_DIRS) -name '*.c')
+INSTALLER_OBJS := $(INSTALLER_SRCS:%=$(INSTALLER_BUILD_DIR)/%.o) $(GENERIC_OBJS)
+
+# Final build step for installer 
+$(INSTALLER_BUILD_DIR)/$(TARGET_INSTALLER): $(INSTALLER_OBJS)
+	$(CC) $(INSTALLER_OBJS) -I $(INSTALLER_INC_DIR) -o $@ $(LINK_FLAGS) $(INSTALLER_FLAGS) 
+
+# Build step for C tests
+$(INSTALLER_BUILD_DIR)/%.c.o: %.c
+	mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -I $(INSTALLER_INC_DIR) -c $< -o $@ $(INSTALLER_FLAGS) 
+
+
+
 #  Phony targets
 # ---------------
 
@@ -259,8 +262,8 @@ debug: $(DEBUG_DIR)/$(TARGET_EXEC)
 test: $(TEST_DIR)/$(TARGET_TEST)
 	$(TEST_DIR)/$(TARGET_TEST)
 
-.PHONY: installer
-installer: $(INSTALLER_DIR)/$(TARGET_INSTALLER)
+.PHONY: build_installer
+build_installer: $(INSTALLER_BUILD_DIR)/$(TARGET_INSTALLER)
 
 .PHONY: keeper
 keeper: $(KEEPER_DIR)/$(TARGET_KEEPER)
@@ -296,13 +299,16 @@ debug_mode:
 ASSET_DIR := $(INSTALLER_DIR)/assets
 
 # 
-.PHONY: prep-install
-prep-install: $(INSTALLER_DIR)/$(TARGET_INSTALLER) release keeper
+.PHONY: installer
+installer: build_installer release keeper
+	mkdir -p $(INSTALLER_DIR)
+	cp $(INSTALLER_BUILD_DIR)/$(TARGET_INSTALLER) $(INSTALLER_DIR)/$(TARGET_INSTALLER) 
 	mkdir -p $(ASSET_DIR)
 	cp -r installer/scripts $(ASSET_DIR)
 	cp $(RELEASE_DIR)/$(TARGET_EXEC) $(ASSET_DIR)
 	cp $(KEEPER_DIR)/$(TARGET_KEEPER) $(ASSET_DIR)/$(TARGET_KEEPER)
-	cp -r archive $(ASSET_DIR)
+# TODO: ensure that rsync is supported in w64 devkit.
+	rsync -lr --exclude=*.~undo-tree~ archive $(ASSET_DIR)
 
 # Installation
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ MAIN_SRC := ./src/main.c
 IMAGE_SRC := ./image/unlinked_image.c
 BUILD_DIR := ./build
 RELEASE_DIR := $(BUILD_DIR)/release
+IMAGE_DIR := $(BUILD_DIR)/image
 DEBUG_DIR := $(BUILD_DIR)/debug
 SRC_DIRS := ./src
 LINK_FLAGS :=
@@ -125,7 +126,7 @@ RELEASE_OBJS := $(SRCS:%=$(RELEASE_DIR)/%.o)
 DEBUG_OBJS := $(SRCS:%=$(DEBUG_DIR)/%.o)
 MAIN_RELEASE_OBJ := $(MAIN_SRC:%=$(RELEASE_DIR)/%.o)
 MAIN_DEBUG_OBJ := $(MAIN_SRC:%=$(DEBUG_DIR)/%.o)
-UNLINKED_IMAGE_OBJ := $(IMAGE_SRC:%=$(RELEASE_DIR)/%.o)
+MAIN_IMAGE_OBJ := $(IMAGE_SRC:%=$(IMAGE_DIR)/%.o)
 
 GENERIC_SRC_DIRS := ./src/data ./src/components ./src/platform/filesystem ./src/platform/memory ./src/platform/terminal
 GENERIC_SRCS := $(shell find $(GENERIC_SRC_DIRS) -name '*.c' | grep -v $(MAIN_SRC)) 
@@ -150,10 +151,13 @@ CFLAGS := $(CFLAGS) -Wall -Wextra -Wundef -Wno-unused-parameter -Wnull-dereferen
 # these warnings are a bit pedantic, so are turned off for now
 CFLAGS := $(CFLAGS) # -Wconversion -Wsign-conversion
 
-# The final build step.
-$(RELEASE_DIR)/$(TARGET_IMAGE): $(RELEASE_OBJS) $(IMAGE_OBJ)
-	$(CC) $(RELEASE_OBJS) $(MAIN_RELEASE_OBJ) -o $@ $(CFLAGS) $(RELEASE_FLAGS) $(LINK_FLAGS)
+# Build step for image + dependency
 
+
+$(IMAGE_DIR)/$(TARGET_IMAGE): $(RELEASE_OBJS) $(MAIN_IMAGE_OBJ)
+	ld $(RELEASE_OBJS) $(MAIN_IMAGE_OBJ) -relocatable -o $@ $(LINK_FLAGS)
+
+# The final build step. for debug + release
 $(RELEASE_DIR)/$(TARGET_EXEC): $(RELEASE_OBJS) $(MAIN_RELEASE_OBJ)
 	$(CC) $(RELEASE_OBJS) $(MAIN_RELEASE_OBJ) -o $@ $(CFLAGS) $(RELEASE_FLAGS) $(LINK_FLAGS)
 
@@ -161,6 +165,10 @@ $(DEBUG_DIR)/$(TARGET_EXEC): $(DEBUG_OBJS) $(MAIN_DEBUG_OBJ)
 	$(CC) $(DEBUG_OBJS) $(MAIN_DEBUG_OBJ) -o $@ $(CFLAGS) $(DEBUG_FLAGS) $(LINK_FLAGS)
 
 # Build step for C source (release)
+$(IMAGE_DIR)/%.c.o: %.c
+	mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -c $< -o $@ $(RELEASE_FLAGS)
+
 $(RELEASE_DIR)/%.c.o: %.c
 	mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@ $(RELEASE_FLAGS)
@@ -230,7 +238,12 @@ INSTALLER_DIR := $(BUILD_DIR)/installer
 INSTALLER_BUILD_DIR := $(BUILD_DIR)/installer_build
 INSTALLER_INC_DIR := ./installer/include
 INSTALLER_SRC_DIRS := ./installer/src
+
+ifneq ($(OS), Windows_NT)
 TARGET_INSTALLER := pico_installer
+else
+TARGET_INSTALLER := pico_installer.exe
+endif
 
 INSTALLER_FLAGS := $(RELEASE_FLAGS)
 
@@ -262,7 +275,7 @@ release: $(RELEASE_DIR)/$(TARGET_EXEC)
 debug: $(DEBUG_DIR)/$(TARGET_EXEC)
 
 .PHONY: image
-release: $(RELEASE_DIR)/$(TARGET_IMAGE)
+image: $(IMAGE_DIR)/$(TARGET_IMAGE)
 
 
 # Run tests with make test
@@ -314,7 +327,7 @@ installer: build_installer release keeper image
 	mkdir -p $(ASSET_DIR)
 	cp -r installer/scripts $(ASSET_DIR)
 	cp $(RELEASE_DIR)/$(TARGET_EXEC) $(ASSET_DIR)
-	cp $(RELEASE_DIR)/$(TARGET_IMAGE) $(ASSET_DIR)
+	cp $(IMAGE_DIR)/$(TARGET_IMAGE) $(ASSET_DIR)
 	cp $(KEEPER_DIR)/$(TARGET_KEEPER) $(ASSET_DIR)/$(TARGET_KEEPER)
 # TODO: ensure that rsync is supported in w64 devkit.
 	rsync -lr --exclude=*.~undo-tree~ archive $(ASSET_DIR)

--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,10 @@ CFLAGS := $(CFLAGS) # -Wconversion -Wsign-conversion
 
 # Build step for image + dependency
 
-
+#$(LINK_FLAGS)
 $(IMAGE_DIR)/$(TARGET_IMAGE): $(RELEASE_OBJS) $(MAIN_IMAGE_OBJ)
-	ld $(RELEASE_OBJS) $(MAIN_IMAGE_OBJ) -relocatable -o $@ $(LINK_FLAGS)
+	ld $(RELEASE_OBJS) $(MAIN_IMAGE_OBJ) -relocatable -o $@ 
+
 
 # The final build step. for debug + release
 $(RELEASE_DIR)/$(TARGET_EXEC): $(RELEASE_OBJS) $(MAIN_RELEASE_OBJ)
@@ -329,8 +330,7 @@ installer: build_installer release keeper image
 	cp $(RELEASE_DIR)/$(TARGET_EXEC) $(ASSET_DIR)
 	cp $(IMAGE_DIR)/$(TARGET_IMAGE) $(ASSET_DIR)
 	cp $(KEEPER_DIR)/$(TARGET_KEEPER) $(ASSET_DIR)/$(TARGET_KEEPER)
-# TODO: ensure that rsync is supported in w64 devkit.
-	rsync -lr --exclude=*.~undo-tree~ archive $(ASSET_DIR)
+	cd archive && find . -type f -not -name "*.~undo-tree~" -exec cp --parents -t ../$(ASSET_DIR) {} +
 
 # Installation
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ installer: build_installer release keeper image
 	cp $(RELEASE_DIR)/$(TARGET_EXEC) $(ASSET_DIR)
 	cp $(IMAGE_DIR)/$(TARGET_IMAGE) $(ASSET_DIR)
 	cp $(KEEPER_DIR)/$(TARGET_KEEPER) $(ASSET_DIR)/$(TARGET_KEEPER)
-	cd archive && find . -type f -not -name "*.~undo-tree~" -exec cp --parents -t ../$(ASSET_DIR) {} +
+	find archive -type f -not -name "*.~undo-tree~" -exec cp --parents -t $(ASSET_DIR) {} +
 
 # Installation
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,11 @@ MAIN_RELEASE_OBJ := $(MAIN_SRC:%=$(RELEASE_DIR)/%.o)
 MAIN_DEBUG_OBJ := $(MAIN_SRC:%=$(DEBUG_DIR)/%.o)
 UNLINKED_IMAGE_OBJ := $(IMAGE_SRC:%=$(RELEASE_DIR)/%.o)
 
+GENERIC_SRC_DIRS := ./src/data ./src/components ./src/platform/filesystem ./src/platform/memory ./src/platform/terminal
+GENERIC_SRCS := $(shell find $(GENERIC_SRC_DIRS) -name '*.c' | grep -v $(MAIN_SRC)) 
+GENERIC_SRCS := $(GENERIC_SRCS) ./src/platform/signals.c ./src/platform/thread.c ./src/platform/error.c ./src/platform/jump.c ./src/platform/environment.c
+GENERIC_OBJS := $(GENERIC_SRCS:%=$(RELEASE_DIR)/%.o)
+
 # String substitution (suffix version without %).
 # As an example, ./build/hello.c turns into ./build/hello.c.d
 MAKE_DEPS := $(SRCS:%=$(BUILD_DIR)/%.d) $(MAIN_SRC:%=$(BUILD_DIR)/%.d)
@@ -166,7 +171,7 @@ $(DEBUG_DIR)/%.c.o: %.c
 	$(CC) $(CFLAGS) -c $< -o $@ $(DEBUG_FLAGS)
 
 
-# Test stuff
+# Tett stuff
 # ---------------------------------------------
 ## Same process as above but for tests
 
@@ -221,12 +226,6 @@ $(KEEPER_DIR)/%.c.o: %.c
 # ---------------------------------------------
 # Objects from the 'platform' and 'components' diretories
 # that may be useful regardless of application...
-GENERIC_SRC_DIRS := ./src/data ./src/components ./src/platform/filesystem ./src/platform/memory ./src/platform/terminal
-GENERIC_SRCS := $(shell find $(GENERIC_SRC_DIRS) -name '*.c' | grep -v $(MAIN_SRC)) 
-GENERIC_SRCS := $(GENERIC_SRCS) ./src/platform/signals.c ./src/platform/thread.c ./src/platform/error.c ./src/platform/jump.c ./src/platform/environment.c
-GENERIC_OBJS := $(GENERIC_SRCS:%=$(RELEASE_DIR)/%.o)
-
-
 INSTALLER_DIR := $(BUILD_DIR)/installer
 INSTALLER_BUILD_DIR := $(BUILD_DIR)/installer_build
 INSTALLER_INC_DIR := ./installer/include
@@ -297,7 +296,7 @@ run-debug: $(DEBUG_DIR)/$(TARGET_EXEC)
 	$(DEBUG_DIR)/$(TARGET_EXEC)
 
 .PHONY: all
-all: debug release test keeper installer installer
+all: debug release test keeper installer installer image
 
 # TODO: (FEAT) check shell; set appropriately
 .PHONY: debug_mode

--- a/image/unlinked_image.c
+++ b/image/unlinked_image.c
@@ -1,0 +1,69 @@
+#include "data/string.h"
+#include "data/stream.h"
+
+#include "platform/memory/std_allocator.h"
+#include "platform/terminal/terminal.h"
+#include "platform/window/window.h"
+#include "platform/hedron/hedron.h"
+
+#include "components/assembler/assembler.h"
+#include "pico/stdlib/platform/submodules.h"
+#include "pico/eval/call.h"
+
+void* pico_entry_point;
+
+int main(int argc, char** argv) {
+    // Setup
+    Allocator* stdalloc = get_std_allocator();
+    IStream* cin = get_stdin_stream();
+    OStream* cout = get_stdout_stream();
+
+    // Init terminal first, as other initializers may panic, therefore writing
+    //   to stdout, which uses the terminal module.
+    init_terminal(stdalloc);
+
+    // Initialization order here is not important
+    init_ctypes();
+    init_asm();
+    init_dynamic_vars(stdalloc);
+
+#ifdef WINDOW_SYSTEM
+    if (pl_init_window_system(stdalloc)) {
+        st_write_string(mv_string("Warning: failed to init window system!\n"), cout);
+    }
+#endif
+
+#ifdef USE_VULKAN
+    if (init_hedron(stdalloc)) {
+        st_write_string(mv_string("Warning: failed to init hedron!\n"), cout);
+    }
+#endif
+
+    thread_init_dynamic_vars();
+
+    /** TODO: current package/module?? */
+    //set_std_current_module(module);
+    //set_current_package(base);
+    set_std_istream(cin);
+    set_std_ostream(cout);
+
+    /**
+     * Run the main symbol
+     */
+    call_unit_fn(pico_entry_point, stdalloc);
+
+
+    // Cleanup
+    thread_clear_dynamic_vars();
+    clear_dynamic_vars();
+
+#ifdef USE_VULKAN
+    teardown_hedron();
+#endif
+
+#ifdef WINDOW_SYSYTEM
+    pl_teardown_window_system();
+#endif
+
+    return 0;
+}

--- a/include/atlas/app/command_line_opts.h
+++ b/include/atlas/app/command_line_opts.h
@@ -3,12 +3,13 @@
 
 #include "data/string.h"
 #include "pico/data/string_array.h"
-#include "pico/codegen/codegen.h"
 #include <stdbool.h>
 
 typedef enum {
     CInit,
+    CBuild,
     CRun,
+    CTest,
     CHelp,
     CVersion,
     CInvalid,
@@ -17,6 +18,10 @@ typedef enum {
 typedef struct {
     String name;
 } InitOpts;
+
+typedef struct {
+    String target;
+} BuildOpts;
 
 typedef struct {
     String target;
@@ -31,6 +36,7 @@ typedef struct {
     SubCommand_t type;
     union {
         InitOpts init;
+        BuildOpts build;
         RunOpts run;
         HelpOpts help;
         String error_message;

--- a/include/atlas/eval/instance.h
+++ b/include/atlas/eval/instance.h
@@ -23,9 +23,24 @@ typedef struct AtlasInstance AtlasInstance;
 AtlasInstance* make_atlas_instance(Allocator* a);
 void delete_atlas_instance(AtlasInstance* instance);
 
+/**
+ * Given that a project has been loaded, lookup the 'target' in the atlas
+ * configuration. If it is an executable, call the function which is designated
+ * as the entry point. Otherwise, throw an error.
+ */
 void atlas_run(AtlasInstance* instance, String target, RegionAllocator* region, AtErrorPoint* point);
 
-/* Register a package so that projects can use it as a dependency.
+/**
+ * Given that a project has been loaded, lookup the 'target' in the atlas
+ * configuration. If it is an executable, produce a file whose execution starts
+ * at the entry point, place it in the 'build/' directory, and call it either
+ * '<target>' or '<target>.exe', where <target> is the value of the target
+ * parameter. Otherwise, throw an error.
+ */
+void atlas_build(AtlasInstance* instance, String target, RegionAllocator* region, AtErrorPoint* point);
+
+/**
+ * Register a package so that projects can use it as a dependency.
  */
 void register_package(AtlasInstance* instance, Package* package);
 

--- a/include/components/object_files/coff_pe.h
+++ b/include/components/object_files/coff_pe.h
@@ -22,8 +22,8 @@
 
 typedef enum : uint16_t {
     Unknown = 0,
-    Coff_AMD64 = 0x8664,
-    Coff_AARCH64 = 0xaa64,
+    CoffAMD64 = 0x8664,
+    CoffAARCH64 = 0xaa64,
 } CoffMachine;
 
 typedef enum : uint16_t {
@@ -53,11 +53,11 @@ typedef struct __attribute__((packed)) {
     uint32_t num_symbols;
     uint16_t optional_header_size;
     Characteristics characteristics;
-} COFF_Header;
+} CoffHeader;
 
 typedef struct __attribute__((packed)) {
 
-} PE_Header;
+} PeHeader;
 
 typedef struct __attribute__((packed)) {
   /**

--- a/include/components/object_files/coff_pe.h
+++ b/include/components/object_files/coff_pe.h
@@ -1,0 +1,87 @@
+#ifndef __COMPONENTS_OBJECT_FILES_COFF_PE_H
+#define __COMPONENTS_OBJECT_FILES_COFF_PE_H
+
+#include <stdint.h>
+
+/* Step 1: Representation of ELF file in memory:
+ *  For now, we assume a 64-bit ELF file format
+ */
+
+/* Overview of the ELF format - ELF files are divided into N components
+ * 
+ * ELF HEADER
+ *  The elf header
+ * 
+ *
+ *
+ * SECTION_HEADER_TABLE
+ * PROGRAM_HEADER_TABLE
+ */
+
+#define N_DOS_EXE_BYTES 4
+
+typedef enum : uint16_t {
+    Unknown = 0,
+    Coff_AMD64 = 0x8664,
+    Coff_AARCH64 = 0xaa64,
+} CoffMachine;
+
+typedef enum : uint16_t {
+    NoRelocation      = 0x0001, /** Tell the loader that addresses cannot be
+                                    relocated (image only). */
+    ExecutableImage   = 0x0002, /** Indicates that can be run */
+    LargeAddressAware = 0x0020, /** Can handle addresses > 2GB*/
+    Is32BitArch       = 0x0100, /** Set if architecture is 32-bit */
+    NoDebugInfo       = 0x0200, /** Set if there is no debug info in the file */
+    MediaRunFromSwap  = 0x0400, /** If set and file is on removable media, load
+                                    it into swap before executing */
+    NetRunFromSwap    = 0x0800, /** If set and file is on network, load it into
+                                    swap before executing */
+    IsSystemFile      = 0x1000, /** Set if executable is system file (not user
+                                    program) */
+    IsDLLFile         = 0x2000, /** Set if file is a DLL file. Note that */
+    UniProcessorOnly  = 0x4000, /** Set if the file should only be run on a
+                                    uniprocessor machine. */
+} Characteristics;
+
+
+typedef struct __attribute__((packed)) {
+    CoffMachine machine;
+    uint16_t num_sections;
+    uint32_t timestamp;
+    uint32_t symtable_offset;
+    uint32_t num_symbols;
+    uint16_t optional_header_size;
+    Characteristics characteristics;
+} COFF_Header;
+
+typedef struct __attribute__((packed)) {
+
+} PE_Header;
+
+typedef struct __attribute__((packed)) {
+  /**
+     Layout of PE File
+
+    MS-DOS 2.0 Compatible EXE Header
+    unused
+    OEM Identifier
+    OEM Information
+    Offset to PE Header
+    MS-DOS 2.0 Stub Program and Relocation Table
+    unused
+
+    PE Header (aligned on 8-byte boundary)
+    Section Headers
+    Image Pages:
+    import info
+    export info
+    base relocations
+    resource info
+
+   */
+    uint8_t        dos_executable [N_DOS_EXE_BYTES];
+} ImageHeader;
+
+
+#endif

--- a/include/components/object_files/elf.h
+++ b/include/components/object_files/elf.h
@@ -96,7 +96,7 @@ typedef struct __attribute__((packed)) {
     uint16_t header_size;
 
     // 
-    uint16_t program_hedaer_entry_size;
+    uint16_t program_header_entry_size;
     uint16_t num_program_header_entries;
 
     uint16_t section_hedaer_entry_size;
@@ -106,8 +106,32 @@ typedef struct __attribute__((packed)) {
     uint16_t section_names;
 } Elf64_Header;
 
+typedef enum : uint32_t {
+    PTNull    = 0x0,
+    PTLoad    = 0x1,
+    PTDynamic = 0x2,
+    PTInterp  = 0x3,
+    PTNote    = 0x4,
+    PTSHLIB   = 0x5,
+    PTPHDR    = 0x6,
+    PTTLS     = 0x7,
+} ProgHeaderType;
+
+typedef enum : uint32_t {
+    PFExecutable = 0x1,
+    PFWritable   = 0x2,
+    PFReadable   = 0x4,
+} ProgHeaderFlags;
+
 typedef struct {
-    
+    ProgHeaderType type; 
+    ProgHeaderFlags flags;
+    uint64_t offset;
+    uint64_t virtual_address;
+    uint64_t physical_address;
+    uint64_t file_size;
+    uint64_t memory_size;
+    uint64_t alignment;
 } Elf64ProgramHeader;
 
 

--- a/include/components/object_files/elf.h
+++ b/include/components/object_files/elf.h
@@ -18,7 +18,29 @@
  * PROGRAM_HEADER_TABLE
  */
 
-#define ELF_N_IDENTIFICATION_BYTES 16
+#define ELF_N_MAGI_BYTES 4
+
+typedef enum : uint8_t {
+    Elf_32bit = 1,
+    Elf_64bit = 2,
+} ElfClass;
+
+typedef enum : uint8_t {
+    Elf_Little_Endian = 1,
+    Elf_Big_Endian = 2,
+} ElfEndianness;
+
+typedef enum : uint8_t {
+    SystemV  = 0x00,
+    NetBSD   = 0x02,
+    Linux    = 0x03,
+    GNUHurd  = 0x03,
+    FreeBSD  = 0x09,
+    OpenBSD  = 0x0C,
+    OpenVMS  = 0x0D,
+    AROS     = 0x0F,
+    CloudABI = 0x11,
+} ElfOSABI;
 
 typedef enum : uint16_t {
     Elf_None = 0x0,
@@ -29,18 +51,33 @@ typedef enum : uint16_t {
 } ElfFileType;
 
 typedef enum : uint16_t {
-    Elf_AMD64 = 0x3E,
+    Elf_AMD64   = 0x3E,
+    Elf_AARCH64 = 0xB7,
+    Elf_RiscV   = 0xF3,
 } ElfArchitecture;
 
-typedef struct {
+
+typedef struct __attribute__((packed)) {
+    /**
+     * The first 16 bytes of the header are referred to as the 
+     * 'identification bytes'
+     */
     // The set of identification bytes. Begins with
     // [ 0x7, 'E', 'L', 'F' ]
-    // followed by class (32 or 64 bit), endianness, 
-    uint8_t     identification[ELF_N_IDENTIFICATION_BYTES];
+    uint8_t        magic [ELF_N_MAGI_BYTES];
+    ElfClass       class;
+    ElfEndianness  endianness;
+    uint8_t        version;
+    ElfOSABI       osabi;
+    uint8_t        osabi_extra;
+    uint8_t        padding [7];
 
+    /**
+     * The rest of the Elf header information follows after the 7 padding bytes.
+     */
     ElfFileType type;
     ElfArchitecture architecture;
-    uint32_t version;
+    uint32_t version_2;
 
     // Entry is the address at which to start execution (if one exists)
     // or NULL otherwise.

--- a/include/pico/binding/build_env.h
+++ b/include/pico/binding/build_env.h
@@ -1,0 +1,25 @@
+#ifndef __PICO_BINDING_BUILD_ENV_H
+#define __PICO_BINDING_BUILD_ENV_H
+
+#include "platform/memory/allocator.h"
+#include "pico/binding/environment.h"
+#include "pico/data/path.h"
+
+typedef struct PathEnv PathEnv;
+
+typedef enum PathEntry_t {
+  PEPath,
+  PEErr,
+} PathEntry_t;
+
+typedef struct {
+  PathEntry_t type;
+  Path path;
+} PathEntry;
+
+PathEnv* mk_build_env(Allocator* a, Environment* env);
+void delete_path_env(PathEnv* env, Allocator* a);
+
+PathEntry path_env_lookup(Symbol s, PathEnv* env);
+
+#endif

--- a/include/pico/build/build.h
+++ b/include/pico/build/build.h
@@ -2,6 +2,7 @@
 #define __PICO_BUILD_BUILD_H
 
 #include "pico/values/modular.h"
+#include "pico/data/build_error.h"
 
 /**
  * The build interface for relic (currently) is very simple:
@@ -18,7 +19,7 @@
 
 typedef struct RelicProgram RelicProgram;
 
-RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a);
+RelicProgram* build_program(Module* module, Symbol entry_point, BuildErrorPoint* point, Allocator* a);
 void write_program(RelicProgram* program, String filename, Allocator* a);
 void link_program(String program, String lib, String out_name);
 

--- a/include/pico/build/build.h
+++ b/include/pico/build/build.h
@@ -1,0 +1,25 @@
+#ifndef __PICO_BUILD_BUILD_H
+#define __PICO_BUILD_BUILD_H
+
+#include "pico/values/modular.h"
+
+/**
+ * The build interface for relic (currently) is very simple:
+ *   Provide a module and an entry-point (start function), and the build process
+ *   will:
+ *   • Walk through all dependencies of the entry-point
+ *   • Build up a representation of an executable file by copying and
+ *     linking all *relic* functions. This representation
+ *   • Write the program to disk.
+ *   • Call the system linker to link this file to a plain 'library' file,
+ *     containing all symbols needed by the base package.
+ */
+
+
+typedef struct RelicProgram RelicProgram;
+
+RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a);
+void write_program(RelicProgram* program, String filename);
+void link_program(String program, String lib, String out_name);
+
+#endif

--- a/include/pico/build/build.h
+++ b/include/pico/build/build.h
@@ -19,7 +19,7 @@
 typedef struct RelicProgram RelicProgram;
 
 RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a);
-void write_program(RelicProgram* program, String filename);
+void write_program(RelicProgram* program, String filename, Allocator* a);
 void link_program(String program, String lib, String out_name);
 
 #endif

--- a/include/pico/build/gather.h
+++ b/include/pico/build/gather.h
@@ -3,6 +3,7 @@
 
 #include "data/meta/array_header.h"
 #include "pico/values/modular.h"
+#include "pico/data/build_error.h"
 
 /**
  * Generally, the output of a build is highly platform dependent,
@@ -47,6 +48,6 @@ typedef struct {
     size_t data_size;
 } ProgramFragments;
 
-ProgramFragments gather_fragments(Symbol entry_point, Module* module, Allocator* allocator);
+ProgramFragments gather_fragments(Symbol entry_point, Module* module, BuildErrorPoint* point, Allocator* allocator);
 
 #endif

--- a/include/pico/build/gather.h
+++ b/include/pico/build/gather.h
@@ -9,10 +9,10 @@
  * with unix systems producing ELF files and windows systems producing COFF/PE
  * files.
  *
- * However, the process of 'flattening' the existing module structure into flat
- * arrays of both data and code fragments with linking information is necessary
- * for both. As such, the relevant types + functions are stored in a shared impl
- * unit.
+ * However, the process of 'flattening' gathered fragments about  the existing
+ * module structure into flat arrays of both data and code fragments with
+ * linking information is necessary for both. As such, the relevant types +
+ * functions are stored in a shared impl unit.
  */
 
 typedef enum {
@@ -43,8 +43,8 @@ ARRAY_HEADER(DataFragment, df, DataFragment);
 typedef struct {
     CodeFragmentArray code_frags;
     DataFragmentArray data_frags;
-} GatherFragmentResult;
+} ProgramFragments;
 
-GatherFragmentResult gather_fragments(Symbol entry_point, Module* module, Allocator* allocator);
+ProgramFragments gather_fragments(Symbol entry_point, Module* module, Allocator* allocator);
 
 #endif

--- a/include/pico/build/gather.h
+++ b/include/pico/build/gather.h
@@ -1,0 +1,50 @@
+#ifndef __PICO_BUILD_GATHER_H
+#define __PICO_BUILD_GATHER_H
+
+#include "data/meta/array_header.h"
+#include "pico/values/modular.h"
+
+/**
+ * Generally, the output of a build is highly platform dependent,
+ * with unix systems producing ELF files and windows systems producing COFF/PE
+ * files.
+ *
+ * However, the process of 'flattening' the existing module structure into flat
+ * arrays of both data and code fragments with linking information is necessary
+ * for both. As such, the relevant types + functions are stored in a shared impl
+ * unit.
+ */
+
+typedef enum {
+    DFString,
+} DataFragmentType;
+
+typedef struct {
+    size_t source_offest;
+
+    size_t fragment_id;
+    size_t offest;
+} GlobalLink;
+
+typedef struct {
+    size_t code_size;
+    void* binary;
+} CodeFragment;
+
+typedef struct {
+    DataFragmentType type;
+    size_t data_size;
+    void* data;
+} DataFragment;
+
+ARRAY_HEADER(CodeFragment, cf, CodeFragment);
+ARRAY_HEADER(DataFragment, df, DataFragment);
+
+typedef struct {
+    CodeFragmentArray code_frags;
+    DataFragmentArray data_frags;
+} GatherFragmentResult;
+
+GatherFragmentResult gather_fragments(Symbol entry_point, Module* module, Allocator* allocator);
+
+#endif

--- a/include/pico/build/gather.h
+++ b/include/pico/build/gather.h
@@ -43,6 +43,8 @@ ARRAY_HEADER(DataFragment, df, DataFragment);
 typedef struct {
     CodeFragmentArray code_frags;
     DataFragmentArray data_frags;
+    size_t code_size;
+    size_t data_size;
 } ProgramFragments;
 
 ProgramFragments gather_fragments(Symbol entry_point, Module* module, Allocator* allocator);

--- a/include/pico/build/serialize.h
+++ b/include/pico/build/serialize.h
@@ -1,0 +1,21 @@
+#ifndef __PICO_BUILD_SERIALIZE_H
+#define __PICO_BUILD_SERIALIZE_H
+
+#include "data/meta/array_header.h"
+#include "pico/build/gather.h"
+#include "pico/values/modular.h"
+
+/**
+ * Generally, the output of a build is highly platform dependent,
+ * with unix systems producing ELF files and windows systems producing COFF/PE
+ * files.
+ *
+ * However, the process of 'flattening' the existing module structure into flat
+ * arrays of both data and code fragments with linking information is necessary
+ * for both. As such, the relevant types + functions are stored in a shared impl
+ * unit.
+ */
+
+U8Array serialize_fragments(ProgramFragments fragments, Allocator* allocator);
+
+#endif

--- a/include/pico/codegen/backend-direct/address_env.h
+++ b/include/pico/codegen/backend-direct/address_env.h
@@ -28,6 +28,7 @@ typedef struct AddressEnv AddressEnv;
 typedef enum {
     ALocalDirect,
     ALocalIndexed,
+    ACodeOffset,
     AGlobal,
     ATypeVar,
     ANotFound,
@@ -39,6 +40,7 @@ typedef struct {
     union {
         void* value;
         int32_t stack_offset;
+        uint32_t code_offset;
     };
 } AddressEntry;
 
@@ -49,6 +51,11 @@ typedef struct {
 
 typedef struct {
     Symbol sym;
+    uint64_t offset;
+} RecBinding;
+
+typedef struct {
+    Symbol sym;
     uint32_t size;
     uint32_t align;
     bool is_variable;
@@ -56,8 +63,8 @@ typedef struct {
 
 ARRAY_HEADER(Binding, binding, Binding)
 
-AddressEnv* mk_address_env(Environment* env, Symbol* sym, Allocator* a);
-AddressEnv* mk_type_address_env(TypeEnv* env, Symbol* sym, Allocator* a);
+AddressEnv* mk_address_env(Environment* env, Allocator* a);
+AddressEnv* mk_type_address_env(TypeEnv* env, Allocator* a);
 
 void delete_address_env(AddressEnv* env, Allocator* a);
 
@@ -66,7 +73,8 @@ void delete_address_env(AddressEnv* env, Allocator* a);
 // relative to the stack base ($RBP).
 int64_t get_stack_head(AddressEnv* env);
 
-/* Address environment interface
+/**
+ * Address environment interface
  * Lookups return either:
  * • An error
  * • A local variable (returned as an offset from RBP)
@@ -85,7 +93,7 @@ AddressEntry address_abs_lookup(AbsVariable s, AddressEnv* env);
 LabelEntry label_env_lookup(Symbol s, AddressEnv* env);
 
 // Push and pop a new local environment to deal with procedure
-void address_start_proc(SymSizeAssoc implicits, SymSizeAssoc vars, AddressEnv* env, Allocator* a);
+void address_start_proc(RecBinding* rec, SymSizeAssoc implicits, SymSizeAssoc vars, AddressEnv* env, Allocator* a);
 void address_end_proc(AddressEnv* env, Allocator* a);
 
 void address_start_poly(SymbolArray types, BindingArray args, AddressEnv* env, Allocator* a);

--- a/include/pico/codegen/link_data.h
+++ b/include/pico/codegen/link_data.h
@@ -37,9 +37,11 @@ typedef struct {
     LinkMetaArray ec_links;
     LinkMetaArray ed_links;
 
+    U64Array code_starts;
     LinkMetaArray cc_links;
     LinkMetaArray cd_links;
 
+    U64Array data_starts;
     LinkMetaArray dd_links;
 
     // Instance Information

--- a/include/pico/data/build_error.h
+++ b/include/pico/data/build_error.h
@@ -1,0 +1,34 @@
+#ifndef __PICO_DATA_BULID_ERROR_H
+#define __PICO_DATA_BULID_ERROR_H
+
+#include "platform/jump.h"
+#include "components/pretty/document.h"
+
+#include "pico/values/modular.h"
+
+typedef struct {
+    Document* message;
+    Module* module;
+    Symbol definition;
+} BuildError;
+
+typedef struct {
+    bool has_many;
+    union {
+        BuildError error;
+        PtrArray errors;
+    }; 
+} MultiBuildError;
+
+typedef struct {
+    volatile MultiBuildError multi;
+    jump_buf buf; 
+} BuildErrorPoint;
+
+void display_build_error(MultiBuildError error, FormattedOStream* fos, Allocator* a);
+
+_Noreturn void throw_build_error(BuildErrorPoint* point, BuildError err); 
+_Noreturn void throw_build_errors(BuildErrorPoint* point, PtrArray errors); 
+
+
+#endif

--- a/include/pico/data/error.h
+++ b/include/pico/data/error.h
@@ -2,7 +2,6 @@
 #define __PICO_DATA_ERROR_H
 
 #include "platform/jump.h"
-#include "data/stream.h"
 #include "components/pretty/document.h"
 
 #include "pico/data/range.h"

--- a/include/pico/data/meta/#path_table_header.h#
+++ b/include/pico/data/meta/#path_table_header.h#
@@ -1,0 +1,40 @@
+#ifndef __PICO_DATA_META_PATH_TABLE_HEADER_H
+#define __PICO_DATA_META_PATH_TABLE_HEADER_H
+
+/**
+ * The path table is a specific type of hashtable mapping paths to values of
+ * some type A.
+ * 
+ */
+
+#include "platform/memory/allocator.h"
+#include "pico/values/values.h"
+#include "pico/data/path.h"
+
+#define PATH_TABLE_HEADER(type, fprefix, tprefix)                       \
+    typedef struct Path##tprefix##Cell Path##tprefix##Cell;             \
+    struct Path##tprefix##Cell {                                        \
+        Path path;                                                      \
+        type value;                                                     \
+        Path##tprefix##Cell* next_node;                                 \
+    };                                                                  \
+                                                                        \
+    typedef struct {                                                    \
+        uint64_t capacity;                                              \
+        Path##tprefix##Cell* cells;                                     \
+        Allocator gpa;                                                  \
+    } Path##tprefix##Table;                                             \
+                                                                        \
+    Path##tprefix##Table mk_##fprefix##_path_table(size_t capacity, Allocator* a); \
+                                                                        \
+    type* lookup_##fprefix##_path_table(Path key, Path##tprefix##Table table); \
+                                                                        \
+    void insert_##fprefix##_path_table_entry(Path key, type value, Path##tprefix##Table* table); \
+                                                                        \
+    void delete_##fprefix##_path_table_entry(Path key, Path##tprefix##Table* table); \
+                                                                        \
+    void delete_##fprefix##_path_table(Path##tprefix##Table table);     \
+
+
+
+#endif

--- a/include/pico/data/meta/#path_table_impl.h#
+++ b/include/pico/data/meta/#path_table_impl.h#
@@ -1,0 +1,124 @@
+#ifndef __PICO_DATA_META_PATH_TABLE_IMPL_H
+#define __PICO_DATA_META_PATH_TABLE_IMPL_H
+
+#include <string.h>
+
+#include "platform/signals.h"
+#include "platform/memory/allocator.h"
+
+#include "pico/data/meta/path_table_header.h"
+
+#define PATH_TABLE_IMPL(type, fprefix, tprefix)                         \
+                                                                        \
+    Path##tprefix##Table mk_##fprefix##_path_table(size_t capacity, Allocator* a) { \
+        Path##tprefix##Cell* memory = mem_alloc(sizeof(Path##tprefix##Cell) * capacity, a); \
+        memset(memory, 0, sizeof(Path##tprefix##Cell) * capacity);      \
+        return (Path##tprefix##Table) {                                 \
+            .capacity = capacity,                                       \
+            .cells = memory,                                            \
+            .gpa = *a,                                                  \
+        };                                                              \
+    }                                                                   \
+                                                                        \
+    type* lookup_##fprefix##_path_table(Path key, Path##tprefix##Table table) { \
+        uint64_t hash_val = hash_path(key);                             \
+        size_t index = hash_val % table.capacity;                       \
+        Path##tprefix##Cell* cell = &table.cells[index];                \
+                                                                        \
+        /* TODO: encode this assumption more properly somewhere */      \
+        if (cell->path.data == NULL) {                                  \
+            return NULL;                                                \
+        } else {                                                        \
+            do {                                                        \
+                if (path_eq(cell->path, key))                           \
+                    return &cell->value;                                \
+                if (cell->next_node) {                                  \
+                    cell = cell->next_node;                             \
+                }                                                       \
+            } while (cell->next_node);                                  \
+        }                                                               \
+                                                                        \
+        return NULL;                                                    \
+    }                                                                   \
+                                                                        \
+    void insert_##fprefix##_path_table_entry(Path key, type value, Path##tprefix##Table* table) { \
+        /* TODO add ability for path table to grow! */                  \
+                                                                        \
+        uint64_t hash_val = hash_path(key);                             \
+        size_t index = hash_val % table->capacity;                      \
+        Path##tprefix##Cell* cell = &table->cells[index];               \
+        Path##tprefix##Cell new_cell = {                                \
+            .path = key,                                                \
+            .value = value,                                             \
+            .next_node = NULL,                                          \
+        };                                                              \
+                                                                        \
+        if (cell->path.data == NULL) {                                  \
+            *cell = new_cell;                                           \
+        } else {                                                        \
+            while (cell->next_node && !path_eq(key, cell->path)) {      \
+                cell = cell->next_node;                                 \
+            }                                                           \
+            if (cell->next_node) {                                      \
+                /** Replacing existing cell */                          \
+                new_cell.next_node = cell->next_node;                   \
+                *cell = new_cell;                                       \
+            } else {                                                    \
+                /** Inserting new cell */                               \
+                cell->next_node = mem_alloc(sizeof(Path##tprefix##Cell), &table->gpa); \
+                *cell->next_node = new_cell;                            \
+            }                                                           \
+        }                                                               \
+    }                                                                   \
+                                                                        \
+    void delete_##fprefix##_path_table_entry(Path key, Path##tprefix##Table* table) { \
+        uint64_t hash_val = hash_path(key);                             \
+        size_t index = hash_val % table->capacity;                      \
+        Path##tprefix##Cell* cell = &table->cells[index];               \
+                                                                        \
+        if (cell->path.data == NULL) {                                  \
+            /* Deleting a value that isn't in the map */                \
+            panic(mv_string("TODO: determine contract when deleting nonexistant entry from path_table")); \
+        } else if (path_eq(key, cell->path)) {                          \
+            /* ripple delete*/                                          \
+            bool ripple = false;                                        \
+            while (cell->next_node) {                                   \
+                Path##tprefix##Cell* next = cell->next_node;            \
+                *cell = *next;                                          \
+                cell = next;                                            \
+                ripple = true;                                          \
+            }                                                           \
+            if (ripple) {                                               \
+                mem_free(cell, &table->gpa);                            \
+            }                                                           \
+        } else {                                                        \
+            while (cell->next_node && !path_eq(key, cell->path)) {      \
+                cell = cell->next_node;                                 \
+            }                                                           \
+            if (!path_eq(key, cell->path)) {                            \
+                panic(mv_string("TODO: determine contract when deleting nonexistant entry from path_table")); \
+            }                                                           \
+            /* Ripple delete */                                         \
+            while (cell->next_node) {                                   \
+                Path##tprefix##Cell* next = cell->next_node;            \
+                *cell = *next;                                          \
+                cell = next;                                            \
+            }                                                           \
+            mem_free(cell, &table->gpa);                                \
+        }                                                               \
+    }                                                                   \
+                                                                        \
+    void delete_##fprefix##_path_table(Path##tprefix##Table table) {    \
+        for (size_t i = 0; i < table.capacity; i++) {                   \
+            Path##tprefix##Cell cell = table.cells[i];                  \
+            Path##tprefix##Cell* next = cell.next_node;                 \
+            while (next) {                                              \
+                Path##tprefix##Cell* next_next = next->next_node;       \
+                mem_free(next, &table.gpa);                             \
+                next = next_next;                                       \
+            }                                                           \
+        }                                                               \
+        mem_free(table.cells, &table.gpa);                              \
+    }                                                                   \
+
+#endif

--- a/include/pico/data/meta/path_table_header.h
+++ b/include/pico/data/meta/path_table_header.h
@@ -1,0 +1,41 @@
+#ifndef __PICO_DATA_META_PATH_TABLE_HEADER_H
+#define __PICO_DATA_META_PATH_TABLE_HEADER_H
+
+/**
+ * The path table is a specific type of hashtable mapping paths to values of
+ * some type A.
+ * 
+ */
+
+#include "platform/memory/allocator.h"
+#include "pico/values/values.h"
+#include "pico/data/path.h"
+typedef NameArray Path;
+
+#define PATH_TABLE_HEADER(type, fprefix, tprefix)                       \
+    typedef struct Path##tprefix##Cell Path##tprefix##Cell;             \
+    struct Path##tprefix##Cell {                                        \
+        Path path;                                                      \
+        type value;                                                     \
+        Path##tprefix##Cell* next_node;                                 \
+    };                                                                  \
+                                                                        \
+    typedef struct {                                                    \
+        uint64_t capacity;                                              \
+        Path##tprefix##Cell* cells;                                     \
+        Allocator gpa;                                                  \
+    } Path##tprefix##Table;                                             \
+                                                                        \
+    Path##tprefix##Table mk_##fprefix##_path_table(size_t capacity, Allocator* a); \
+                                                                        \
+    type* lookup_##fprefix##_path_table(Path key, Path##tprefix##Table table); \
+                                                                        \
+    void insert_##fprefix##_path_table_entry(Path key, type value, Path##tprefix##Table* table); \
+                                                                        \
+    void delete_##fprefix##_path_table_entry(Path key, Path##tprefix##Table* table); \
+                                                                        \
+    void delete_##fprefix##_path_table(Path##tprefix##Table table);     \
+
+
+
+#endif

--- a/include/pico/data/meta/path_table_impl.h
+++ b/include/pico/data/meta/path_table_impl.h
@@ -1,0 +1,127 @@
+#ifndef __PICO_DATA_META_PATH_TABLE_IMPL_H
+#define __PICO_DATA_META_PATH_TABLE_IMPL_H
+
+#include <string.h>
+
+#include "platform/signals.h"
+#include "platform/memory/allocator.h"
+
+#include "pico/data/meta/path_table_header.h"
+
+bool path_eq(Path lhs, Path rhs);
+uint64_t hash_path(Path path);
+
+#define PATH_TABLE_IMPL(type, fprefix, tprefix)                         \
+                                                                        \
+    Path##tprefix##Table mk_##fprefix##_path_table(size_t capacity, Allocator* a) { \
+        Path##tprefix##Cell* memory = mem_alloc(sizeof(Path##tprefix##Cell) * capacity, a); \
+        memset(memory, 0, sizeof(Path##tprefix##Cell) * capacity);      \
+        return (Path##tprefix##Table) {                                 \
+            .capacity = capacity,                                       \
+            .cells = memory,                                            \
+            .gpa = *a,                                                  \
+        };                                                              \
+    }                                                                   \
+                                                                        \
+    type* lookup_##fprefix##_path_table(Path key, Path##tprefix##Table table) { \
+        uint64_t hash_val = hash_path(key);                             \
+        size_t index = hash_val % table.capacity;                       \
+        Path##tprefix##Cell* cell = &table.cells[index];                \
+                                                                        \
+        /* TODO: encode this assumption more properly somewhere */      \
+        if (cell->path.data == NULL) {                                  \
+            return NULL;                                                \
+        } else {                                                        \
+            do {                                                        \
+                if (path_eq(cell->path, key))                           \
+                    return &cell->value;                                \
+                if (cell->next_node) {                                  \
+                    cell = cell->next_node;                             \
+                }                                                       \
+            } while (cell->next_node);                                  \
+        }                                                               \
+                                                                        \
+        return NULL;                                                    \
+    }                                                                   \
+                                                                        \
+    void insert_##fprefix##_path_table_entry(Path key, type value, Path##tprefix##Table* table) { \
+        /* TODO add ability for path table to grow! */                  \
+                                                                        \
+        uint64_t hash_val = hash_path(key);                             \
+        size_t index = hash_val % table->capacity;                      \
+        Path##tprefix##Cell* cell = &table->cells[index];               \
+        Path##tprefix##Cell new_cell = {                                \
+            .path = key,                                                \
+            .value = value,                                             \
+            .next_node = NULL,                                          \
+        };                                                              \
+                                                                        \
+        if (cell->path.data == NULL) {                                  \
+            *cell = new_cell;                                           \
+        } else {                                                        \
+            while (cell->next_node && !path_eq(key, cell->path)) {      \
+                cell = cell->next_node;                                 \
+            }                                                           \
+            if (cell->next_node) {                                      \
+                /** Replacing existing cell */                          \
+                new_cell.next_node = cell->next_node;                   \
+                *cell = new_cell;                                       \
+            } else {                                                    \
+                /** Inserting new cell */                               \
+                cell->next_node = mem_alloc(sizeof(Path##tprefix##Cell), &table->gpa); \
+                *cell->next_node = new_cell;                            \
+            }                                                           \
+        }                                                               \
+    }                                                                   \
+                                                                        \
+    void delete_##fprefix##_path_table_entry(Path key, Path##tprefix##Table* table) { \
+        uint64_t hash_val = hash_path(key);                             \
+        size_t index = hash_val % table->capacity;                      \
+        Path##tprefix##Cell* cell = &table->cells[index];               \
+                                                                        \
+        if (cell->path.data == NULL) {                                  \
+            /* Deleting a value that isn't in the map */                \
+            panic(mv_string("TODO: determine contract when deleting nonexistant entry from path_table")); \
+        } else if (path_eq(key, cell->path)) {                          \
+            /* ripple delete*/                                          \
+            bool ripple = false;                                        \
+            while (cell->next_node) {                                   \
+                Path##tprefix##Cell* next = cell->next_node;            \
+                *cell = *next;                                          \
+                cell = next;                                            \
+                ripple = true;                                          \
+            }                                                           \
+            if (ripple) {                                               \
+                mem_free(cell, &table->gpa);                            \
+            }                                                           \
+        } else {                                                        \
+            while (cell->next_node && !path_eq(key, cell->path)) {      \
+                cell = cell->next_node;                                 \
+            }                                                           \
+            if (!path_eq(key, cell->path)) {                            \
+                panic(mv_string("TODO: determine contract when deleting nonexistant entry from path_table")); \
+            }                                                           \
+            /* Ripple delete */                                         \
+            while (cell->next_node) {                                   \
+                Path##tprefix##Cell* next = cell->next_node;            \
+                *cell = *next;                                          \
+                cell = next;                                            \
+            }                                                           \
+            mem_free(cell, &table->gpa);                                \
+        }                                                               \
+    }                                                                   \
+                                                                        \
+    void delete_##fprefix##_path_table(Path##tprefix##Table table) {    \
+        for (size_t i = 0; i < table.capacity; i++) {                   \
+            Path##tprefix##Cell cell = table.cells[i];                  \
+            Path##tprefix##Cell* next = cell.next_node;                 \
+            while (next) {                                              \
+                Path##tprefix##Cell* next_next = next->next_node;       \
+                mem_free(next, &table.gpa);                             \
+                next = next_next;                                       \
+            }                                                           \
+        }                                                               \
+        mem_free(table.cells, &table.gpa);                              \
+    }                                                                   \
+
+#endif

--- a/include/pico/data/path.h
+++ b/include/pico/data/path.h
@@ -1,0 +1,19 @@
+#ifndef __PICO_DATA_PATH_H
+#define __PICO_DATA_PATH_H
+
+/**
+ * The symbol table is a global data-structure used by pico to map 
+ * strings (slow to compare) to symbols (fast to compare). 
+ * 
+ * The table is string-specfic, so takes advantage of foreknowledge of string layout 
+ */
+
+#include "platform/memory/allocator.h"
+#include "pico/values/values.h"
+
+typedef NameArray Path;
+
+bool path_eq(Path lhs, Path rhs);
+uint64_t hash_path(Path path);
+
+#endif

--- a/include/pico/data/symbol_table.h
+++ b/include/pico/data/symbol_table.h
@@ -1,10 +1,12 @@
 #ifndef __PICO_DATA_SYMBOL_TABLE_H
 #define __PICO_DATA_SYMBOL_TABLE_H
 
-/* The symbol table is a global data-structure used by pico to map 
+/**
+ * The symbol table is a global data-structure used by pico to map 
  * strings (slow to compare) to symbols (fast to compare). 
  * 
- * The table is string-specfic, so takes advantage of foreknowledge of string layout 
+ * The table is string-specfic, so takes advantage of foreknowledge of string
+ * layout to compactly and efficintly store backing strings.
  */
 
 #include <string.h>

--- a/include/pico/syntax/syntax.h
+++ b/include/pico/syntax/syntax.h
@@ -153,6 +153,8 @@ typedef struct {
     SymPtrAMap args;
     SymPtrAMap implicits;
     SynRef body;
+    Symbol recursive_sym;
+    bool is_recursive;
     bool preserve_dyn_memory;
 } SynProcedure;
 

--- a/include/pico/values/modular.h
+++ b/include/pico/values/modular.h
@@ -38,7 +38,13 @@ typedef struct {
 
 ARRAY_HEADER(InstanceSrc, inst_src, InstSrc)
 
-/* Declarations and Modules
+typedef struct {
+    U8Array data;
+    U8Array code;
+} Segments;
+
+/**
+ * Declarations and Modules
  * ------------------------
  * A declaration is simply some kind of data we want to attach to a symbol
  * in a module. At the moment, the only supported declaration is a 'type'
@@ -65,53 +71,6 @@ typedef struct {
     };
 } ModuleDecl;
 
-/* Definitions and codegen 
- * ------------------------
- * Codegen is relatively simple: given an expression e.g. (+ 2 3) and an
- * assembler, generate use the assembler to generate the code that corresponds
- * to the expression, e.g. "mov 2, rax; add rax, 3; push rax". Complexity is introduced because:
- * • Expressions may contain data such as strings. If the result is defined,
- *   these may need to be copied into the defining module. 
- * • Expressions may contain (or be) procedures, again, meaning that if defined
- *   then the procedure code needs to be copied by the defining module.
- * • Finally, an expression may define a trait instance that has implicit parameters.
- *   This is the most complex, as future type-generation phases may generate
- *   new values (a new instance/closure?). 
- * 
- * To accommodate this, code generation has two copyable targets as follows: 
- * • There is a 'eval segment' assembler, which is the entry-point to the experssion.
- * • There is a 'code-segment' assembler, where output of procedure code within the
- *   expression is put.
- * 
- * In order to facilitate copying of both code and data to new addresses,
- * internal (absolute) pointers must be updated, and so link information has to
- * be maintained.
- * 
- * As both the code and data are effectively byte-arrays, there are 4 pieces of
- * link data: 
- * | Matches chunks (addresses) in the | To indices in the | Name     |
- * |-----------------------------------|-------------------|----------|
- * | Eval Segment                      | Code Segment      | ec_links |
- * | Eval Segment                      | Data Segment      | ed_links |
- * | Code Segment                      | Code Segment      | cc_links |
- * | Code Segment                      | Data Segment      | cd_links |
- * | Data Segment                      | Code Segment      | N/A      |
- * | Data Segment                      | Data Segment      | N/A      |
- * 
- * Note that the data segment is only for strings, so cannot have any links to
- * other segments.
- * 
- * Finally, there are the 'external links', which are used to indicate locations
- * in the code segment which are addresses of specific symbols (values). These
- * locations need updating if the symbol is redefined.
- * 
- */
-
-typedef struct {
-    U8Array data;
-    U8Array code;
-} Segments;
-
 //     Package Interface
 // -----------------------------------------------------------------------------
 Package* mk_package(Name name, PiAllocator pico_allocator);
@@ -128,13 +87,6 @@ Module* get_module(Symbol symbol, Package* package);
 // -----------------------------------------------------------------------------
 Module* mk_module(ModuleHeader header, Package* pkg_parent, Module* parent);
 void delete_module(Module* module);
-
-/**
- * If we are going to define the result of evaluating (target), then it must be prepped
- * so that the code and data segments are owned by the module.
- * This needs to be done BEFORE evaluation
- */
-Segments prep_target(Module* module, Segments in_segments, Assembler* target, LinkData* links);
 
 /**
  * Add a value definition in to the module's namespace. Must be prepped (see above)
@@ -178,5 +130,64 @@ Package* get_package(Module* module);
 Module* get_parent(Module* module);
 Imports get_imports(Module* module);
 Exports get_exports(Module* module);
+
+/**
+ * Compiler Interface 
+ * ==============================
+ *
+ * The following functions provide limited access to the internals of a module
+ * for compilation/evaluation purposes. 
+ *
+ */
+
+/**
+ * Definitions and codegen 
+ * ========================
+ * Codegen is relatively simple: given an expression e.g. (+ 2 3) and an
+ * assembler, generate use the assembler to generate the code that corresponds
+ * to the expression, e.g. "mov 2, rax; add rax, 3; push rax". Complexity is introduced because:
+ * • Expressions may contain data such as strings. If the result is defined,
+ *   these may need to be copied into the defining module. 
+ * • Expressions may contain (or be) procedures, again, meaning that if defined
+ *   then the procedure code needs to be copied by the defining module.
+ * • Finally, an expression may define a trait instance that has implicit parameters.
+ *   This is the most complex, as future type-generation phases may generate
+ *   new values (a new instance/closure?). 
+ * 
+ * To accommodate this, code generation has two copyable targets as follows: 
+ * • There is a 'eval segment' assembler, which is the entry-point to the experssion.
+ * • There is a 'code-segment' assembler, where output of procedure code within the
+ *   expression is put.
+ * 
+ * In order to facilitate copying of both code and data to new addresses,
+ * internal (absolute) pointers must be updated, and so link information has to
+ * be maintained.
+ * 
+ * As both the code and data are effectively byte-arrays, there are 4 pieces of
+ * link data: 
+ * | Matches chunks (addresses) in the | To indices in the | Name     |
+ * |-----------------------------------|-------------------|----------|
+ * | Eval Segment                      | Code Segment      | ec_links |
+ * | Eval Segment                      | Data Segment      | ed_links |
+ * | Code Segment                      | Code Segment      | cc_links |
+ * | Code Segment                      | Data Segment      | cd_links |
+ * | Data Segment                      | Code Segment      | N/A      |
+ * | Data Segment                      | Data Segment      | N/A      |
+ * 
+ * Note that the data segment is only for strings, so cannot have any links to
+ * other segments.
+ * 
+ * Finally, there are the 'external links', which are used to indicate locations
+ * in the code segment which are addresses of specific symbols (values). These
+ * locations need updating if the symbol is redefined.
+ * 
+ */
+
+/**
+ * If we are going to define the result of evaluating (target), then it must be prepped
+ * so that the code and data segments are owned by the module.
+ * This needs to be done BEFORE evaluation
+ */
+Segments prep_target(Module* module, Segments in_segments, Assembler* target, LinkData* links);
 
 #endif

--- a/include/pico/values/modular.h
+++ b/include/pico/values/modular.h
@@ -169,6 +169,7 @@ Result add_decl(Module* module, Symbol symbol, ModuleDecl decl);
 void add_import_clause(ImportClause clause, Module* module);
 
 ModuleEntry* get_def(Symbol symbol, Module* module);
+SymbolArray get_exported_symbols(Module* module, Allocator* a);
 SymbolArray get_defined_symbols(Module* module, Allocator* a);
 PtrArray get_defined_instances(Module* module, Allocator* a);
 

--- a/include/pico/values/modular_build.h
+++ b/include/pico/values/modular_build.h
@@ -1,0 +1,82 @@
+#ifndef __PICO_VALUES_MODULAR_BULID_H
+#define __PICO_VALUES_MODULAR_BULID_H
+
+#include "data/meta/assoc_header.h"
+
+#include "pico/values/modular.h"
+#include "pico/data/path.h"
+
+/**
+ * Modular Build Interface
+ * ========================
+ * This is an interface that allows the build module (responsible for generating
+ * executable/linkable files) access to the binary and linkage data needed to
+ * produce a full executable.
+ *
+ * The Interface works in *fragments*. A fragment may consist whole or part of a
+ * module definition, and corresponds precisely to:
+ * • 1 code fragment = 1 proc
+ * • 1 data fragment = 1 string or 1 literal syntax tree
+ *
+ * For example, the definition:
+ * (def add-2 proc [x]
+ *   (let [add-1 proc [y] seq
+ *           (write-line "adding 1")
+ *           (+ y 1)]
+ *     (add-1 (add-1 x))))
+ * 
+ * Would break down into 3 fragments:
+ *  • Code-fragment: binary for add-2
+ *  • Code-fragment: binary for add-1
+ *  • Data-fragment: string "adding 1"
+ * 
+ * The way that the builer gathers these fragments from the module is via the
+ * iterator interface: the 'ModuleIndex' type represents the current fragment
+ * that the module is at, and is intended to ONLY be modified by code in this
+ * module - to create an index, use start_iterator, and to get the next
+ * fragment, use next_iterator, which will update the provided index, write the
+ * contents of the next fragment into the provided fragment pointer. The
+ * function will return true if there was another fragment, or false if all
+ * fragments have been iterated through and no value was written to the output
+ * pointers.
+ * 
+ */
+
+typedef struct {
+  size_t entry;           // module entry index
+  size_t component;       // is code/data?
+  size_t value;           // 1st/2nd/3rd function/string/...
+} ModuleIndex;
+
+typedef enum : uint8_t {
+  CodeFragment_t,
+  DataFragment_t,
+} FragmentType;
+
+ASSOC_HEADER(uint64_t, Path, u64_path, U64Path);
+
+typedef struct {
+  FragmentType type;
+  U8Array fragment;
+} ModuleFragment;
+
+
+/**
+ * Iterator Functions 
+ * ===================
+ * For a full rundown on the iteration interface, see the comment at the top of
+ * the file. 
+ * 
+ * As a quick overview, the intended is as follows:
+ * ------------------------------------------------
+ * ModuleIndex index = start_iterating(module);
+ * BuildFragment frag;
+ * while (next_iterator(&index, &frag, module)) {
+ *   // Loop Body
+ * }
+ * ------------------------------------------------
+ */
+ModuleIndex start_iterating(Module* module);
+bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module);
+
+#endif

--- a/include/pico/values/modular_build.h
+++ b/include/pico/values/modular_build.h
@@ -4,6 +4,7 @@
 #include "data/meta/assoc_header.h"
 
 #include "pico/values/modular.h"
+#include "pico/data/build_error.h"
 #include "pico/data/path.h"
 
 /**
@@ -51,13 +52,17 @@ typedef struct {
 typedef enum : uint8_t {
   CodeFragment_t,
   DataFragment_t,
+  ModuleFragment_t,
 } FragmentType;
 
 ASSOC_HEADER(uint64_t, Path, u64_path, U64Path);
 
 typedef struct {
   FragmentType type;
-  U8Array data;
+  union {
+    U8Array data;
+    Module* module;
+  };
 } ModuleFragment;
 
 
@@ -77,6 +82,6 @@ typedef struct {
  * ------------------------------------------------
  */
 ModuleIndex start_iterating(Module* module);
-bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module);
+bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module, BuildErrorPoint* point, Allocator* a);
 
 #endif

--- a/include/pico/values/modular_build.h
+++ b/include/pico/values/modular_build.h
@@ -57,7 +57,7 @@ ASSOC_HEADER(uint64_t, Path, u64_path, U64Path);
 
 typedef struct {
   FragmentType type;
-  U8Array fragment;
+  U8Array data;
 } ModuleFragment;
 
 

--- a/src/atlas/app/command_line_opts.c
+++ b/src/atlas/app/command_line_opts.c
@@ -37,12 +37,24 @@ static AtlasCommand internal_parse_command(StringArray args, ArenaAllocator* a) 
         if (args.len != 2) {
             return (AtlasCommand) {
                 .type = CInvalid,
-                .error_message = mv_string("'atlas run' must take exactly 1 argument."),
+                .error_message = mv_string("'atlas run' must take exactly 1 argument, the name of the target to run."),
             };
         } else {
             return (AtlasCommand) {
                 .type = CRun,
                 .run.target = args.data[1],
+            };
+        }
+    } else if (string_cmp(subcommand, mv_string("build")) == 0) {
+        if (args.len != 2) {
+            return (AtlasCommand) {
+                .type = CInvalid,
+                .error_message = mv_string("'atlas build' must take exactly 1 argument, the name of the target to build."),
+            };
+        } else {
+            return (AtlasCommand) {
+                .type = CBuild,
+                .build.target = args.data[1],
             };
         }
     } else if (string_cmp(subcommand, mv_string("help")) == 0) {

--- a/src/atlas/app/help_string.c
+++ b/src/atlas/app/help_string.c
@@ -19,7 +19,7 @@ void write_atlas_help_string(FormattedOStream *os) {
     write_fstring(mv_string("\n"), os);
     write_fstring(mv_string(" The Atlas build system is provided as part of the pico relic compiler. It works \n"), os);
     write_fstring(mv_string(" based an 'atlas_project' file in the root directory of your project, and with \n"), os);
-    write_fstring(mv_string(" 'atlas' files describing differrent build targets, scripts and so on."), os);
+    write_fstring(mv_string(" 'atlas' files describing differrent build targets, scripts and so on.\n"), os);
     write_fstring(mv_string("\n"), os);
 
     start_boldness(Bold, os);
@@ -37,6 +37,27 @@ void write_atlas_help_string(FormattedOStream *os) {
     write_fstring(mv_string(" The init command will create a new Relic project using Atlas, with a basic\n"), os);
     write_fstring(mv_string(" project structure including an executable and test-suite.\n"), os);
     write_fstring(mv_string("\n\n"), os);
+
+    start_boldness(Bold, os);
+    write_fstring(mv_string("\n                                      Build                                     "), os);
+    write_fstring(mv_string("\n           ──────────────────────────────────────────────────────────           "), os);
+    end_boldness(os);
+
+    write_fstring(mv_string("\n"), os);
+    write_fstring(mv_string("\n"), os);
+
+    write_fstring(mv_string(" Usage: "), os);
+    start_boldness(Dim, os);
+    write_fstring(mv_string("pico atlas build <target-name>\n"), os);
+    end_boldness(os);
+
+    write_fstring(mv_string("\n"), os);
+  
+    write_fstring(mv_string(" If there is an 'executable' target defined somewhere in the atlas project, then \n"), os);
+    write_fstring(mv_string(" this will produce an executable file which, when run, will start execution at\n"), os);
+    write_fstring(mv_string(" the designated 'entry-point' function..\n"), os);
+    write_fstring(mv_string("\n"), os);
+
     
 
     start_boldness(Bold, os);
@@ -58,7 +79,7 @@ void write_atlas_help_string(FormattedOStream *os) {
     write_fstring(mv_string(" atlas project, then this will build (if needed) and run the target. If the\n"), os);
     write_fstring(mv_string(" target is a script, then no executable will be produced.\n"), os);
     write_fstring(mv_string("\n"), os);
-    write_fstring(mv_string(" Any additional arguments are passed directly to the test suite, and are not \n"), os);
+    write_fstring(mv_string(" Any additional arguments are passed directly to the executable/script, and are not \n"), os);
     write_fstring(mv_string(" processed by Atlas.\n"), os);
 
     write_fstring(mv_string("\n"), os);
@@ -79,6 +100,9 @@ void write_atlas_help_string(FormattedOStream *os) {
     write_fstring(mv_string(" If there is a test target defined somewhere in the atlas project, then this\n"), os);
     write_fstring(mv_string(" command will run the matching test suite. Any additional arguments are passed\n"), os);
     write_fstring(mv_string(" directly to the test suite, and are not processed by Atlas.\n"), os);
+    write_fstring(mv_string("\n"), os);
+    write_fstring(mv_string(" Any additional arguments are passed directly to the test suite, and are not \n"), os);
+    write_fstring(mv_string(" processed by Atlas.\n"), os);
 
     write_fstring(mv_string("\n"), os);
 }

--- a/src/atlas/atlas.c
+++ b/src/atlas/atlas.c
@@ -160,6 +160,32 @@ void run_atlas(Package* package, StringArray args, FormattedOStream* out) {
         write_fstring(command.init.name, out);
         write_fstring(mv_string("\n"), out);
         break;
+    case CBuild: {
+        write_fstring(mv_string("WARNING: Atlas build is currently under development, and is unlikely to produce\n"), out);
+        write_fstring(mv_string("         a functioning executable file.\n"), out);
+        write_fstring(mv_string("\n"), out);
+        Allocator* stda = get_std_allocator();
+        AtlasInstance* instance = make_atlas_instance(stda);
+        register_package(instance, package);
+
+        RegionAllocator* region = make_region_allocator(4096, true, stda);
+        String cwd = get_current_directory(stda);
+        bool fail = load_atlas_files(cwd, out, instance, region);
+        mem_free(cwd.bytes, stda);
+        AtErrorPoint point;
+        if (catch_error(point)) {
+            Allocator ra = ra_to_gpa(region);
+            display_error(point.error.error, point.error.captured_file, out, point.error.filename, &ra);
+        } else {
+            if (!fail) {
+                atlas_build(instance, command.build.target, region, &point);
+            }
+        }
+        delete_region_allocator(region);
+        delete_atlas_instance(instance);
+
+        break;
+    }
     case CRun: {
         Allocator* stda = get_std_allocator();
         AtlasInstance* instance = make_atlas_instance(stda);

--- a/src/atlas/eval/instance.c
+++ b/src/atlas/eval/instance.c
@@ -283,8 +283,14 @@ void atlas_build(AtlasInstance* instance, String target_name, RegionAllocator* r
         if (pi_type_eql(check_ty, &e->type, &ra)) {
             // TODO: replace with proper allocator??
             RelicProgram* program = build_program(module, entry.value, &ra);
-            write_program(program, path_cat(mv_string("build"), target_name, &ra), &ra);
+            String image = path_cat(mv_string("build"), target_name, &ra);
+            write_program(program, image, &ra);
             //link_program(String program, String lib, String out_name);
+
+            FormattedOStream* fout = get_formatted_stdout();
+            write_fstring(mv_string("Wrote image to "), fout);
+            write_fstring(image, fout);
+            write_fstring(mv_string("\n"), fout);
         } else {
             PtrArray nodes = mk_ptr_array(5, &ra);
             {

--- a/src/atlas/eval/instance.c
+++ b/src/atlas/eval/instance.c
@@ -3,6 +3,7 @@
 #include <string.h>
 
 #include "platform/memory/executable.h"
+#include "platform/filesystem/filesystem.h"
 #include "platform/signals.h"
 
 #include "data/stream.h"
@@ -16,6 +17,7 @@
 #include "pico/typecheck/typecheck.h"
 #include "pico/codegen/codegen.h"
 #include "pico/eval/call.h"
+#include "pico/build/build.h"
 #include "pico/stdlib/platform/submodules.h"
 #include "pico/stdlib/meta/meta.h"
 
@@ -165,6 +167,124 @@ void atlas_run(AtlasInstance* instance, String target_name, RegionAllocator* reg
         PiType* check_ty = mk_proc_type(&pia, 0, mk_prim_type(&pia, Unit));
         if (pi_type_eql(check_ty, &e->type, &ra)) {
             call_unit_fn(*(void**)e->value, &ra);
+        } else {
+            PtrArray nodes = mk_ptr_array(5, &ra);
+            {
+                PtrArray ep_nodes = mk_ptr_array(5, &ra);
+                push_ptr(mk_str_doc(mv_string("Entry Point: '"), &ra), &ep_nodes);
+                push_ptr(mk_str_doc(view_symbol_string(target->entrypoint.value), &ra), &ep_nodes);
+                push_ptr(mk_str_doc(mv_string("' has type:"), &ra), &ep_nodes);
+                push_ptr(mv_cat_doc(ep_nodes, &ra), &nodes);
+            }
+            push_ptr(pretty_type(&e->type, default_ptp, &ra), &nodes);
+            push_ptr(mk_str_doc(mv_string("but entry points must have type"), &ra), &nodes);
+            push_ptr(pretty_type(check_ty, default_ptp, &ra), &nodes);
+            AtlasError err = {
+                .message = mv_sep_doc(nodes, &ra),
+            };
+            throw_at_error(point, err);
+        }
+    } else {
+        PtrArray nodes = mk_ptr_array(5, &ra);
+        push_ptr(mk_str_doc(mv_string("Unrecognized target: '"), &ra), &nodes);
+        push_ptr(mk_str_doc(target_name, &ra), &nodes);
+        push_ptr(mk_str_doc(mv_string("'"), &ra), &nodes);
+        AtlasError err = {
+            .message = mv_cat_doc(nodes, &ra),
+        };
+        throw_at_error(point, err);
+    }
+}
+
+void atlas_build(AtlasInstance* instance, String target_name, RegionAllocator* region, AtErrorPoint* point) {
+    Allocator ra = ra_to_gpa(region);
+    Symbol sym = string_to_symbol(target_name);
+
+    if (!instance->project_set) {
+        AtlasError err = {
+            .message = mk_str_doc(mv_string("No atlas project was found, please ensure there is an 'atlas-project' file in the current directory."), &ra),
+        };
+        throw_at_error(point, err);
+    }
+
+    size_t tidx;
+    if (sym_ptr_find(&tidx, sym, instance->targets)) {
+        AtlasTarget* target = instance->targets.data[tidx].val;
+        SymbolOption entry = target->entrypoint;
+        if (entry.type == None) {
+            PtrArray nodes = mk_ptr_array(5, &ra);
+            push_ptr(mk_str_doc(mv_string("Target '"), &ra), &nodes);
+            push_ptr(mk_str_doc(target_name, &ra), &nodes);
+            push_ptr(mk_str_doc(mv_string("' has no entry-point and is therefore cannot be built."), &ra), &nodes);
+
+            AtlasError err = {
+                .message = mv_cat_doc(nodes, &ra),
+            };
+            throw_at_error(point, err);
+        }
+
+        // First, create a new package for the project
+        PiAllocator pico_alloc = get_std_perm_allocator();
+        Package* package;
+        if (instance->project_package) {
+            package = instance->project_package;
+        } else {
+            package = mk_package(instance->project.package.name.name, pico_alloc);
+            set_instance_package(instance, package);
+        }
+
+        // Then, add all dependencies
+        SymbolArray deps = instance->project.package.dependencies;
+        PtrArray avail = instance->packages;
+        for (size_t i = 0; i < deps.len; i++) {
+            bool found_dep = false;
+            Name dep_name = deps.data[i].name;
+            for (size_t j = 0; j < avail.len; j++) {
+                Package* avail_package = avail.data[j];
+                Name pkg_name = package_name(avail_package);
+                if (dep_name == pkg_name) {
+                    add_dependency(package, avail_package);
+                    found_dep = true;
+                    break;
+                }
+            }
+
+            if (!found_dep) {
+                PtrArray nodes = mk_ptr_array(5, &ra);
+                push_ptr(mk_str_doc(mv_string("Dependency '"), &ra), &nodes);
+                push_ptr(mk_str_doc(view_name_string(dep_name), &ra), &nodes);
+                push_ptr(mk_str_doc(mv_string("' could not be found."), &ra), &nodes);
+
+                AtlasError err = {
+                    .message = mv_cat_doc(nodes, &ra),
+                };
+                throw_at_error(point, err);
+            }
+        }
+
+        Module* module = atlas_load_target(instance, package, target, region, point);
+        ModuleEntry* e = get_def(entry.value, module);
+        if (!e) {
+            PtrArray nodes = mk_ptr_array(5, &ra);
+            push_ptr(mk_str_doc(mv_string("Entry Point '"), &ra), &nodes);
+            push_ptr(mk_str_doc(view_symbol_string(target->entrypoint.value), &ra), &nodes);
+            push_ptr(mk_str_doc(mv_string("' in target '"), &ra), &nodes);
+            push_ptr(mk_str_doc(target_name, &ra), &nodes);
+            push_ptr(mk_str_doc(mv_string("' could not be found."), &ra), &nodes);
+
+            AtlasError err = {
+                .message = mv_cat_doc(nodes, &ra),
+            };
+            throw_at_error(point, err);
+        }
+
+        PiAllocator pia = convert_to_pallocator(&ra);
+        PiType* check_ty = mk_proc_type(&pia, 0, mk_prim_type(&pia, Unit));
+        if (pi_type_eql(check_ty, &e->type, &ra)) {
+            // TODO: replace with proper allocator??
+            RelicProgram* program = build_program(module, entry.value, &ra);
+            write_program(program, path_cat(mv_string("build"), target_name, &ra), &ra);
+            //link_program(String program, String lib, String out_name);
         } else {
             PtrArray nodes = mk_ptr_array(5, &ra);
             {

--- a/src/atlas/eval/instance.c
+++ b/src/atlas/eval/instance.c
@@ -281,8 +281,32 @@ void atlas_build(AtlasInstance* instance, String target_name, RegionAllocator* r
         PiAllocator pia = convert_to_pallocator(&ra);
         PiType* check_ty = mk_proc_type(&pia, 0, mk_prim_type(&pia, Unit));
         if (pi_type_eql(check_ty, &e->type, &ra)) {
+            BuildErrorPoint build_point;
+            if (catch_error(build_point)) {
+                if (build_point.multi.has_many) {
+                    PtrArray out = mk_ptr_array(build_point.multi.errors.len, &ra);
+                    for (size_t i = 0; i < build_point.multi.errors.len; i++) {
+                        BuildError* berr = build_point.multi.errors.data[i];
+                        AtlasError* err = mem_alloc(sizeof(AtlasError), &ra);
+                        *err = (AtlasError) {
+                            .message = berr->message,
+                        };
+                    }
+                    AtlasMultiError err = {
+                        .error.has_many = true,
+                        .error.errors = out,
+                    };
+                    throw_at_multi_error(point, err);
+                } else {
+                    AtlasError err = {
+                        .message = build_point.multi.error.message,
+                    };
+                    throw_at_error(point, err);
+                }
+            }
+
             // TODO: replace with proper allocator??
-            RelicProgram* program = build_program(module, entry.value, &ra);
+            RelicProgram* program = build_program(module, entry.value, &build_point, &ra);
             String image = path_cat(mv_string("build"), target_name, &ra);
             write_program(program, image, &ra);
             //link_program(String program, String lib, String out_name);

--- a/src/pico/abstraction/abstraction.c
+++ b/src/pico/abstraction/abstraction.c
@@ -28,7 +28,6 @@ typedef struct {
     };
 } ComptimeHead;
 
-
 // Internal functions declarations needed forthe  interface implementation 
 TopLevel abstract_i(RawTree raw, AbstractionICtx ctx);
 SynRef abstract_expr_i(RawTree raw, AbstractionICtx ctx);

--- a/src/pico/abstraction/abstraction.c
+++ b/src/pico/abstraction/abstraction.c
@@ -195,7 +195,11 @@ ModuleHeader* abstract_header(RawTree raw, Allocator* a, PiErrorPoint* point) {
         } else if (eq_symbol(&clauses.branch.nodes.data[0], string_to_symbol(mv_string("export")))) {
             for (size_t i = 1; i < clauses.branch.nodes.len; i++) {
                 ExportClause clause = abstract_export_clause(&clauses.branch.nodes.data[i], point, a);
-                push_export_clause(clause, &exports.clauses);
+                if (clause.type == ExportAll) {
+                    exports.export_all = true;
+                } else {
+                   push_export_clause(clause, &exports.clauses);
+                }
             }
         } else {
             err.range = clauses.range;

--- a/src/pico/binding/build_env.c
+++ b/src/pico/binding/build_env.c
@@ -1,0 +1,44 @@
+#include "platform/memory/allocator.h"
+
+#include "pico/binding/build_env.h"
+
+struct PathEnv {
+    Environment* env;
+    Allocator gpa;
+};
+
+PathEnv* mk_build_env(Allocator* a, Environment* env) {
+    PathEnv* out = mem_alloc(sizeof(PathEnv), a);
+    *out = (PathEnv) {
+        .env = env,
+        .gpa = *a,
+    };
+    return out;
+}
+
+void delete_path_env(PathEnv* env, Allocator* a) {
+    mem_free(env, a);
+}
+
+PathEntry path_env_lookup(Symbol sym, PathEnv* env) {
+    EnvEntry entry = env_lookup(sym, env->env);
+    if (entry.type != ICValid) return (PathEntry) {.type = PEErr,};
+    if (entry.is_module) return (PathEntry) {.type = PEErr,};
+
+    Path path = mk_u64_array(8, &env->gpa);
+    push_u64(sym.name, &path);
+
+    Module* module;
+    Module* parent = env_module(env->env);
+    do {
+        module = parent;
+        push_u64(module_name(module).name, &path);
+    } while ((parent = get_parent(module)) != NULL);
+    Package* package = get_package(module);
+    push_u64(package_name(package), &path);
+    
+    return (PathEntry) {
+        .type = PEPath,
+        .path = path,
+    };
+}

--- a/src/pico/binding/environment.c
+++ b/src/pico/binding/environment.c
@@ -165,6 +165,8 @@ Environment* env_from_module(Module* module, ErrorPoint* point, Allocator* a) {
     Package* package = get_package(module);
     Module* root_module = package_root_module(package);
 
+    // TODO: importing a specific sympol allows you to bypass which symbols
+    // are/aren't exported.
     for (size_t i = 0; i < imports.clauses.len; i++) {
         // TODO (BUG): currently, we only search in the package, not the parent
         // module's submodules!
@@ -258,7 +260,7 @@ Environment* env_from_module(Module* module, ErrorPoint* point, Allocator* a) {
         case ImportAll: {
             // Find the package
             Module* importee = path_all(clause.path, root_module, module, point, a);
-            SymbolArray syms = get_defined_symbols(importee, a);
+            SymbolArray syms = get_exported_symbols(importee, a);
             for (size_t j = 0; j < syms.len; j++ ) {
                 name_ptr_insert(syms.data[j].name, importee, &env->symbol_origins);
             }

--- a/src/pico/build/elf/build_elf.c
+++ b/src/pico/build/elf/build_elf.c
@@ -16,7 +16,7 @@ struct RelicProgram {
     U8Array segments;
 };
 
-RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a) {
+RelicProgram* build_program(Module* module, Symbol entry_point, BuildErrorPoint* point, Allocator* a) {
     RelicProgram* program = mem_alloc(sizeof(RelicProgram), a);
     /**
      * Two *segment* entries
@@ -41,7 +41,7 @@ RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a) {
      * Each of these entries stores link data with them
      */
 
-    ProgramFragments fragments = gather_fragments(entry_point, module, a);
+    ProgramFragments fragments = gather_fragments(entry_point, module, point, a);
 
     /** Step 2: Compress fragments
      *  Not that we have decomposed the program into fragments with link data,

--- a/src/pico/build/elf/build_elf.c
+++ b/src/pico/build/elf/build_elf.c
@@ -1,0 +1,67 @@
+#include "platform/machine_info.h"
+#if OS_FAMILY == UNIX
+
+#include "pico/build/build.h"
+#include "components/object_files/elf.h"
+
+struct RelicProgram {
+    Elf64_Header elf_header;
+};
+
+RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a) {
+    RelicProgram* program = mem_alloc(sizeof(RelicProgram), a);
+    program->elf_header = (Elf64_Header) {
+        .magic = {0x1, 'E', 'L', 'F'},
+        .class = Elf_64bit,
+        .endianness = Elf_Little_Endian,
+        .version = 1, // There is only one version of elf
+        // TODO: determine ABI based on machine_info
+        .osabi = SystemV,
+        .osabi_extra = 0,
+        .padding = {0, 0, 0, 0, 0, 0, 0},
+
+        // Object file that can be linked with others
+        .type = Elf_Relocatable,
+        // TODO: update based on machine_info!
+        .architecture = AMD64,
+        .version_2 = 1, // There is only one version of elf
+
+        // Skip a bunch of fields that we fill in later...
+        .header_size = sizeof(Elf64_Header),
+    };
+
+    /**
+     * Two *segment* entries
+     * - Code (executable)
+     * - Data (readable)
+     */
+
+    /**
+     * ?? *section* entries
+     * - Code (executable)
+     * - Data (readable)
+     */
+
+    /**
+     * Build Code and Data Segments
+     */
+
+    /** Step 1: gather dependencies
+     *  Decompose the program into a flat list of functions or data entries which are linked to either:
+     *  - Other functions
+     *  - Other data entries 
+     * Each of these entries stores link data with them
+     */
+
+    return program;
+}
+
+void write_program(RelicProgram* program, String filename) {
+    // 
+}
+
+void link_program(String program, String lib, String out_name) {
+
+}
+
+#endif

--- a/src/pico/build/elf/build_elf.c
+++ b/src/pico/build/elf/build_elf.c
@@ -11,31 +11,13 @@
 
 struct RelicProgram {
     Elf64_Header elf_header;
+    Elf64ProgramHeader code_segment_header;
+    Elf64ProgramHeader data_segment_header;
     U8Array segments;
 };
 
 RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a) {
     RelicProgram* program = mem_alloc(sizeof(RelicProgram), a);
-    program->elf_header = (Elf64_Header) {
-        .magic = {0x7f, 'E', 'L', 'F'},
-        .class = Elf_64bit,
-        .endianness = Elf_Little_Endian,
-        .version = 1, // There is only one version of elf
-        // TODO: determine ABI based on machine_info
-        .osabi = SystemV,
-        .osabi_extra = 0,
-        .padding = {0, 0, 0, 0, 0, 0, 0},
-
-        // Object file that can be linked with others
-        .type = Elf_Relocatable,
-        // TODO: update based on machine_info!
-        .architecture = AMD64,
-        .version_2 = 1, // There is only one version of elf
-
-        // Skip a bunch of fields that we fill in later...
-        .header_size = sizeof(Elf64_Header),
-    };
-
     /**
      * Two *segment* entries
      * • Code (executable)
@@ -72,6 +54,62 @@ RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a) {
 
     program->segments = serialize_fragments(fragments, a);
 
+    program->elf_header = (Elf64_Header) {
+        .magic = {0x7f, 'E', 'L', 'F'},
+        .class = Elf_64bit,
+        .endianness = Elf_Little_Endian,
+        .version = 1, // There is only one version of elf
+        // TODO: determine ABI based on machine_info
+        .osabi = SystemV,
+        .osabi_extra = 0,
+        .padding = {0, 0, 0, 0, 0, 0, 0},
+
+        // Object file that can be linked with others
+        .type = Elf_Relocatable,
+        // TODO: update based on machine_info!
+        .architecture = AMD64,
+        .version_2 = 1, // There is only one version of elf
+
+        /** The program header is immediately after the elf header, so the
+            program header table offset is the size of the elf header */
+        .program_header_table = sizeof(Elf64_Header),
+        .section_header_table = 0,
+
+        .flags = 0,
+        // Skip a bunch of fields that we fill in later...
+        .header_size = sizeof(Elf64_Header),
+
+        .program_header_entry_size = sizeof(Elf64ProgramHeader),
+        .num_program_header_entries = 2,
+
+        .section_hedaer_entry_size = 0,
+        .num_section_header_entries = 0,
+
+        .section_names = 0,
+    };
+
+
+    program->code_segment_header = (Elf64ProgramHeader) {
+        .type = PTLoad,
+        .flags = PFExecutable,
+        .offset = sizeof(Elf64_Header) + 2 * sizeof(Elf64ProgramHeader),
+        .virtual_address = 0x0,
+        .physical_address = 0x0,
+        .file_size = fragments.code_size,
+        .memory_size = fragments.code_size,
+        .alignment = 0,
+    };
+    program->data_segment_header = (Elf64ProgramHeader) {
+        .type = PTLoad,
+        .flags = PFReadable | PFWritable,
+        .offset = sizeof(Elf64_Header) + 2 * sizeof(Elf64ProgramHeader) + fragments.code_size,
+        .virtual_address = 0x0,
+        .physical_address = 0x0,
+        .file_size = fragments.data_size,
+        .memory_size = fragments.data_size,
+        .alignment = 0,
+    };
+
     return program;
 }
 
@@ -79,10 +117,11 @@ void write_program(RelicProgram* program, String filename, Allocator* a) {
     FileResult result = open_file(filename, Write, a);
     File* file = result.file;
 
+    size_t header_size = sizeof(Elf64_Header) + 2 * sizeof(Elf64ProgramHeader);
     U8Array header_bytes = {
         .data = (void*)&program->elf_header,
-        .len = sizeof(Elf64_Header),
-        .size = sizeof(Elf64_Header),
+        .len = header_size,
+        .size = header_size,
     };
 
     write_chunk(file, header_bytes);

--- a/src/pico/build/elf/build_win.c
+++ b/src/pico/build/elf/build_win.c
@@ -1,5 +1,5 @@
 #include "platform/machine_info.h"
-#if OS_FAMILY == UNIX
+#if OS_FAMILY == WINDOWS
 
 #include "platform/filesystem/filesystem.h"
 #include "platform/signals.h"
@@ -7,33 +7,24 @@
 #include "pico/build/build.h"
 #include "pico/build/gather.h"
 #include "pico/build/serialize.h"
-#include "components/object_files/elf.h"
+#include "components/object_files/coff_pe.h"
 
 struct RelicProgram {
-    Elf64_Header elf_header;
+    Coff_Header coff_header;
     U8Array segments;
 };
 
 RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a) {
     RelicProgram* program = mem_alloc(sizeof(RelicProgram), a);
-    program->elf_header = (Elf64_Header) {
-        .magic = {0x7f, 'E', 'L', 'F'},
-        .class = Elf_64bit,
-        .endianness = Elf_Little_Endian,
-        .version = 1, // There is only one version of elf
-        // TODO: determine ABI based on machine_info
-        .osabi = SystemV,
-        .osabi_extra = 0,
-        .padding = {0, 0, 0, 0, 0, 0, 0},
-
-        // Object file that can be linked with others
-        .type = Elf_Relocatable,
-        // TODO: update based on machine_info!
-        .architecture = AMD64,
-        .version_2 = 1, // There is only one version of elf
-
-        // Skip a bunch of fields that we fill in later...
-        .header_size = sizeof(Elf64_Header),
+    program->coff_header = (Elf64_Header) {
+        // TODO: also allow AARCH64
+        .machine = COFF_AMD64
+        .num_sections = 0,
+        .timestamp = 0, // TODO: populate with current time as time_t
+        .symtable_offset = 0,
+        .num_symbols = 0,
+        .optional_header_size = 0,
+        .characteristics = LargeAddressAware | NoDebugInfo,
     };
 
     /**
@@ -80,9 +71,9 @@ void write_program(RelicProgram* program, String filename, Allocator* a) {
     File* file = result.file;
 
     U8Array header_bytes = {
-        .data = (void*)&program->elf_header,
-        .len = sizeof(Elf64_Header),
-        .size = sizeof(Elf64_Header),
+        .data = (void*)&program->coff_header,
+        .len = sizeof(Coff_Header),
+        .size = sizeof(Coff_Header),
     };
 
     write_chunk(file, header_bytes);

--- a/src/pico/build/elf/build_win.c
+++ b/src/pico/build/elf/build_win.c
@@ -50,7 +50,7 @@ RelicProgram* build_program(Module* module, Symbol entry_point, BuildErrorPoint*
      * Each of these entries stores link data with them
      */
 
-    ProgramFragments fragments = gather_fragments(entry_point, module, a);
+    ProgramFragments fragments = gather_fragments(entry_point, module, point, a);
 
     /** Step 2: Compress fragments
      *  Not that we have decomposed the program into fragments with link data,

--- a/src/pico/build/elf/build_win.c
+++ b/src/pico/build/elf/build_win.c
@@ -10,15 +10,15 @@
 #include "components/object_files/coff_pe.h"
 
 struct RelicProgram {
-    Coff_Header coff_header;
+    CoffHeader coff_header;
     U8Array segments;
 };
 
 RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a) {
     RelicProgram* program = mem_alloc(sizeof(RelicProgram), a);
-    program->coff_header = (Elf64_Header) {
+    program->coff_header = (CoffHeader) {
         // TODO: also allow AARCH64
-        .machine = COFF_AMD64
+        .machine = CoffAMD64,
         .num_sections = 0,
         .timestamp = 0, // TODO: populate with current time as time_t
         .symtable_offset = 0,
@@ -72,8 +72,8 @@ void write_program(RelicProgram* program, String filename, Allocator* a) {
 
     U8Array header_bytes = {
         .data = (void*)&program->coff_header,
-        .len = sizeof(Coff_Header),
-        .size = sizeof(Coff_Header),
+        .len = sizeof(CoffHeader),
+        .size = sizeof(CoffHeader),
     };
 
     write_chunk(file, header_bytes);

--- a/src/pico/build/elf/build_win.c
+++ b/src/pico/build/elf/build_win.c
@@ -14,7 +14,7 @@ struct RelicProgram {
     U8Array segments;
 };
 
-RelicProgram* build_program(Module* module, Symbol entry_point, Allocator* a) {
+RelicProgram* build_program(Module* module, Symbol entry_point, BuildErrorPoint* point, Allocator* a) {
     RelicProgram* program = mem_alloc(sizeof(RelicProgram), a);
     program->coff_header = (CoffHeader) {
         // TODO: also allow AARCH64

--- a/src/pico/build/gather.c
+++ b/src/pico/build/gather.c
@@ -15,32 +15,53 @@ PATH_TABLE_HEADER(void*, ptr, Ptr);
 PATH_TABLE_IMPL(void*, ptr, Ptr);
 
 typedef struct {
-  CodeFragmentArray* code_frags;
-  DataFragmentArray* data_frags;
+  CodeFragmentArray code_frags;
+  DataFragmentArray data_frags;
+  size_t code_size;
+  size_t data_size;
 
-  PathPtrTable* terms_to_link;
-  PathU64Table* built_fragments;
+  PathPtrTable terms_to_link;
+  PathU64Table built_fragments;
   Allocator* a;
 } GatherState;
 
-void gather_package(Package* package, GatherState state) {
+void gather_package(Package* package, GatherState* state) {
 }
 
-void gather_module(Module* module, GatherState state) {
+void gather_module(Module* module, GatherState* state) {
   ModuleIndex index = start_iterating(module);
   ModuleFragment fragment;
   while (next_iterator(&index, &fragment, module)) {
       /** TODO: use module fragment to 
        */
+      switch (fragment.type) {
+      case CodeFragment_t: {
+          CodeFragment frag = {
+              .code_size = fragment.data.len,
+              .binary = fragment.data.data,
+          };
+          state->code_size += frag.code_size;
+          push_cf(frag, &state->code_frags);
+          break;
+      }
+      case DataFragment_t: {
+          DataFragment frag = {
+              .type = DFString,
+              .data_size = fragment.data.len,
+              .data = fragment.data.data,
+          };
+          state->data_size += frag.data_size;
+          push_df(frag, &state->data_frags);
+          break;
+      }
+      default:
+          panic(mv_string("Invalid module fragment generated during build gather process"));
+          break;
+      }
   }
 }
 
-GatherFragmentResult gather_fragments(Symbol entry_point, Module* module, Allocator* a) {
-  CodeFragmentArray code_frags = mk_cf_array(4096, a);
-  DataFragmentArray data_frags = mk_df_array(4096, a);
-
-  PathPtrTable terms_to_link = mk_ptr_path_table(4096, a);
-  PathU64Table built_fragments = mk_u64_path_table(4096, a);;
+ProgramFragments gather_fragments(Symbol entry_point, Module* module, Allocator* a) {
 
   /**
    * General overview of the gathering algorithm
@@ -62,17 +83,21 @@ GatherFragmentResult gather_fragments(Symbol entry_point, Module* module, Alloca
    * 
    */
   GatherState state = {
-    .code_frags = &code_frags,
-    .data_frags = &data_frags,
-    .terms_to_link = &terms_to_link,
-    .built_fragments = &built_fragments,
+    .code_frags = mk_cf_array(4096, a),
+    .data_frags = mk_df_array(4096, a),
+    .code_size = 0,
+    .data_size = 0,
+    .terms_to_link = mk_ptr_path_table(4096, a),
+    .built_fragments = mk_u64_path_table(4096, a),
     .a = a,
   };
 
-  gather_module(module, state);
+  gather_module(module, &state);
 
-  return (GatherFragmentResult) {
-    .code_frags = code_frags,
-    .data_frags = data_frags,
+  return (ProgramFragments) {
+    .code_frags = state.code_frags,
+    .data_frags = state.data_frags,
+    .code_size = state.code_size,
+    .data_size = state.data_size,
   };
 }

--- a/src/pico/build/gather.c
+++ b/src/pico/build/gather.c
@@ -22,16 +22,14 @@ typedef struct {
 
   PathPtrTable terms_to_link;
   PathU64Table built_fragments;
+  BuildErrorPoint* point;
   Allocator* a;
 } GatherState;
 
-void gather_package(Package* package, GatherState* state) {
-}
-
-void gather_module(Module* module, GatherState* state) {
+void gather_module(Module* module, GatherState* state, PtrArray* modules_to_process) {
   ModuleIndex index = start_iterating(module);
   ModuleFragment fragment;
-  while (next_iterator(&index, &fragment, module)) {
+  while (next_iterator(&index, &fragment, module, state->point, state->a)) {
       /** TODO: use module fragment to 
        */
       switch (fragment.type) {
@@ -54,6 +52,10 @@ void gather_module(Module* module, GatherState* state) {
           push_df(frag, &state->data_frags);
           break;
       }
+      case ModuleFragment_t: {
+          push_ptr(fragment.module, modules_to_process);
+          break;
+      }
       default:
           panic(mv_string("Invalid module fragment generated during build gather process"));
           break;
@@ -61,7 +63,17 @@ void gather_module(Module* module, GatherState* state) {
   }
 }
 
-ProgramFragments gather_fragments(Symbol entry_point, Module* module, Allocator* a) {
+void gather_package(Package* package, GatherState* state) {
+    Module* root = package_root_module(package);
+    PtrArray modules_to_process = mk_ptr_array(32, state->a);
+    gather_module(root, state, &modules_to_process);
+    while (modules_to_process.len != 0) {
+        Module* module = pop_ptr(&modules_to_process);
+        gather_module(module, state, &modules_to_process);
+    }
+}
+
+ProgramFragments gather_fragments(Symbol entry_point, Module* module, BuildErrorPoint* point, Allocator* a) {
 
   /**
    * General overview of the gathering algorithm
@@ -89,10 +101,12 @@ ProgramFragments gather_fragments(Symbol entry_point, Module* module, Allocator*
     .data_size = 0,
     .terms_to_link = mk_ptr_path_table(4096, a),
     .built_fragments = mk_u64_path_table(4096, a),
+    .point = point,
     .a = a,
   };
 
-  gather_module(module, &state);
+  Package* package = get_package(module);
+  gather_package(package, &state);
 
   return (ProgramFragments) {
     .code_frags = state.code_frags,

--- a/src/pico/build/gather.c
+++ b/src/pico/build/gather.c
@@ -1,0 +1,78 @@
+#include "data/meta/array_impl.h"
+
+#include "pico/data/meta/path_table_header.h"
+#include "pico/data/meta/path_table_impl.h"
+#include "pico/build/gather.h"
+#include "pico/values/modular_build.h"
+
+ARRAY_COMMON_IMPL(CodeFragment, cf, CodeFragment);
+ARRAY_COMMON_IMPL(DataFragment, df, DataFragment);
+
+PATH_TABLE_HEADER(uint64_t, u64, U64);
+PATH_TABLE_IMPL(uint64_t, u64, U64);
+
+PATH_TABLE_HEADER(void*, ptr, Ptr);
+PATH_TABLE_IMPL(void*, ptr, Ptr);
+
+typedef struct {
+  CodeFragmentArray* code_frags;
+  DataFragmentArray* data_frags;
+
+  PathPtrTable* terms_to_link;
+  PathU64Table* built_fragments;
+  Allocator* a;
+} GatherState;
+
+void gather_package(Package* package, GatherState state) {
+}
+
+void gather_module(Module* module, GatherState state) {
+  ModuleIndex index = start_iterating(module);
+  ModuleFragment fragment;
+  while (next_iterator(&index, &fragment, module)) {
+      /** TODO: use module fragment to 
+       */
+  }
+}
+
+GatherFragmentResult gather_fragments(Symbol entry_point, Module* module, Allocator* a) {
+  CodeFragmentArray code_frags = mk_cf_array(4096, a);
+  DataFragmentArray data_frags = mk_df_array(4096, a);
+
+  PathPtrTable terms_to_link = mk_ptr_path_table(4096, a);
+  PathU64Table built_fragments = mk_u64_path_table(4096, a);;
+
+  /**
+   * General overview of the gathering algorithm
+   * -------------------------------------------
+   * The global links in a module rely on there being for any given symbol
+   * a single term that it maps to in the import map of a module. As we are
+   * flattening all modules into a single array, we cannot rely on this
+   * mapping. Instead, we use two mappings:
+   * • For values that are still in modules, we use *paths*, which are
+   *   guaranteed to be unique.
+   * • For values that are in the fragment array, we use the index in that
+   *   array as a unique identifier
+   * 
+   * To establish the mapping of module definitions to fragments, we keep two
+   * hashmaps whose keys are paths:
+   * • The first maps terms which have been fragmented into their fragment(s) 
+   * • The sectond maps terms which have NOT been fragmented to which fragments
+   *   need to be linked to them.
+   * 
+   */
+  GatherState state = {
+    .code_frags = &code_frags,
+    .data_frags = &data_frags,
+    .terms_to_link = &terms_to_link,
+    .built_fragments = &built_fragments,
+    .a = a,
+  };
+
+  gather_module(module, state);
+
+  return (GatherFragmentResult) {
+    .code_frags = code_frags,
+    .data_frags = data_frags,
+  };
+}

--- a/src/pico/build/serialize.c
+++ b/src/pico/build/serialize.c
@@ -6,5 +6,16 @@
 #include "pico/values/modular_build.h"
 
 U8Array serialize_fragments(ProgramFragments fragments, Allocator* a) {
-    return mk_u8_array(8, a);
+    U8Array out = mk_u8_array(fragments.code_size + fragments.data_size, a);
+
+    for (size_t i = 0; i < fragments.code_frags.len; i++) {
+        CodeFragment frag = fragments.code_frags.data[i];
+        add_u8_chunk(frag.binary, frag.code_size, &out);
+    }
+    for (size_t i = 0; i < fragments.data_frags.len; i++) {
+        DataFragment frag = fragments.data_frags.data[i];
+        add_u8_chunk(frag.data, frag.data_size, &out);
+    }
+
+    return out;
 }

--- a/src/pico/build/serialize.c
+++ b/src/pico/build/serialize.c
@@ -1,0 +1,10 @@
+#include "data/meta/array_impl.h"
+
+#include "pico/data/meta/path_table_header.h"
+#include "pico/data/meta/path_table_impl.h"
+#include "pico/build/serialize.h"
+#include "pico/values/modular_build.h"
+
+U8Array serialize_fragments(ProgramFragments fragments, Allocator* a) {
+    return mk_u8_array(8, a);
+}

--- a/src/pico/codegen/backend-direct/address_env.c
+++ b/src/pico/codegen/backend-direct/address_env.c
@@ -6,35 +6,49 @@
 #include "pico/codegen/backend-direct/address_env.h"
 #include "pico/binding/type_env.h"
 
-// Address Environment: Implementation
-// -----------------------------------
-// There are several important types used in the implementation of the address
-// environment. These are: 
-// • Symbol Address (SAddr). This associates a symbol with a stack offset. This
-//   may be a direct offset (monomorphic functions) or indirect offset
-//   (polymorphic functions). A symbol address may also be a sentinel, which
-//   denotes the beginning of a group of variables  as bound by, e.g. a let
-//   expression, procedure or pattern match.
-//  
-// • Local Address Environment (LocalAddrs). This encapsulates the local namespace of
-//   one function. A local address environment will be either monomorphic or
-//   polymorphic.
+/**
+ * Address Environment: Implementation
+ * -----------------------------------
+ * There are several important types used in the implementation of the address
+ * environment. These are: 
+ * • Symbol Address (SAddr). This associates a symbol with a stack offset. This
+ *   may be a direct offset (monomorphic functions) or indirect offset
+ *   (polymorphic functions). A symbol address may also be a sentinel, which
+ *   denotes the beginning of a group of variables  as bound by, e.g. a let
+ *   expression, procedure or pattern match.
+ *  
+ * • Local Address Environment (LocalAddrs). This encapsulates the local namespace of
+ *   one function. A local address environment will be either monomorphic or
+ *   polymorphic.
+ */
 
 typedef enum {
-    // A direct variable is one whose value is stored as an offset RSP
+    /** A direct variable is one whose value is stored as an offset RSP */
     SADirect,
 
-    // An indexed variable is one which is stored on the data stack
-    // However, the offset is provided relative to $RSP, as the regular 
-    // stack stores an index into the variable stack. 
+    /**
+     * An indexed variable is one which is stored on the data stack
+     * However, the offset is provided relative to $RSP, as the regular 
+     * stack stores an index into the variable stack. 
+     */
     SAIndexed,
 
-    // This is a type variable - specifically, type a literal type variable
-    // for generating code to produce type literals, such as 'All [A] Proc [A] A'
+    /**
+     * Indicates that the value is a procedure that is currently being generated.
+     * The value should be stored/returned as an offset from the code segment.
+     */
+    SARecFn,
+
+    /**
+     * This is a type variable - specifically, type a literal type variable
+     * for generating code to produce type literals, such as 'All [A] Proc [A] A'
+     */
     SATypeVar,
 
-    // Inaccessible locals are used in type generation, in particular, if you
-    // are generating a type literal, it cannot reference run-time variables!
+    /**
+     * Inaccessible locals are used in type generation, in particular, if you
+     * are generating a type literal, it cannot reference run-time variables!
+     */
     SAInaccessibleLocal,
     SASentinel,
     SALabel,
@@ -43,7 +57,10 @@ typedef enum {
 typedef struct {
     SAddr_t type;
     Symbol symbol;
-    int64_t stack_offset;
+    union {
+        int64_t stack_offset;
+        uint64_t code_offset;
+    };
 } SAddr;
 
 int compare_saddr(SAddr lhs, SAddr rhs) {
@@ -79,20 +96,14 @@ typedef struct {
 struct AddressEnv {
     Environment* env;
 
-    // To handle recursive top level definitions.
-    bool rec;
-    Symbol recname;
-    
     PtrArray local_envs;
     PtrArray instance_types;
     PtrArray instance_implicits;
 };
 
-AddressEnv* mk_address_env(Environment* env, Symbol* sym, Allocator* a) {
+AddressEnv* mk_address_env(Environment* env, Allocator* a) {
     AddressEnv* a_env = (AddressEnv*)mem_alloc(sizeof(AddressEnv), a);
     *a_env = (AddressEnv) {
-      .rec = sym != NULL,
-      .recname = sym ? *sym: (Symbol){},
       .local_envs = mk_ptr_array(32, a),
       .instance_types = mk_ptr_array(8, a),
       .instance_implicits = mk_ptr_array(8, a),
@@ -110,11 +121,8 @@ AddressEnv* mk_address_env(Environment* env, Symbol* sym, Allocator* a) {
     return a_env; 
 }
 
-AddressEnv* mk_type_address_env(TypeEnv* env, Symbol* sym, Allocator* a) {
+AddressEnv* mk_type_address_env(TypeEnv* env, Allocator* a) {
     AddressEnv* a_env = (AddressEnv*)mem_alloc(sizeof(AddressEnv), a);
-    a_env->rec = sym != NULL;
-    if (a_env->rec)
-        a_env->recname = *sym;
     a_env->local_envs = mk_ptr_array(32, a);
     a_env->env = get_base(env);
     
@@ -201,18 +209,16 @@ AddressEntry address_env_lookup(Symbol s, AddressEnv* env) {
                 };
             }
         };
+        if (maddr.type == SARecFn && symbol_eq(maddr.symbol, s)) {
+            return (AddressEntry) {
+                .type = ACodeOffset,
+                .code_offset = maddr.code_offset,
+            };
+        }
 
         if (maddr.type == SATypeVar) {
             return (AddressEntry) {.type = ATypeVar};
         }
-    }
-
-    // Now search the recsym
-    if (env->rec && symbol_eq(env->recname, s)) {
-        return (AddressEntry) {
-            .type = AGlobal,
-            .value = NULL,
-        };
     }
 
     // TODO (BUG) this seemed to be returning ALocalIndirect 
@@ -288,7 +294,7 @@ LabelEntry label_env_lookup(Symbol s, AddressEnv* env) {
 
 /* void address_vars (sym_size_assoc vars, address_env* env, allocator a); */
 /* void pop_fn_vars(address_env* env); */
-void address_start_proc(SymSizeAssoc implicits, SymSizeAssoc vars, AddressEnv* env, Allocator* a) {
+void address_start_proc(RecBinding* rec, SymSizeAssoc implicits, SymSizeAssoc vars, AddressEnv* env, Allocator* a) {
     LocalAddrs* new_local = mem_alloc(sizeof(LocalAddrs), a);
     new_local->vars = mk_saddr_array(32, a);
     size_t stack_offset = 0;
@@ -301,6 +307,14 @@ void address_start_proc(SymSizeAssoc implicits, SymSizeAssoc vars, AddressEnv* e
     padding.stack_offset = stack_offset;
     push_saddr(padding, &new_local->vars);
 
+    if (rec) {
+        SAddr rec_saddr = {
+            .type = SARecFn,
+            .symbol = rec->sym,
+            .code_offset = rec->offset, 
+        };
+        push_saddr(rec_saddr, &new_local->vars);
+    }
     // Variables are in reverse order!
     // due to how the stack pushes/pops args.
     for (size_t i = vars.len; i > 0; i--) {

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -1539,10 +1539,11 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
         break;
     }
     case SInstance: {
-      /* From the perspective of a user, all instances are values where
+      /**
+       * From the perspective of a user, all instances are values where
        * (size-of i) == (size-of Address) for any instance i. From the
        * perspective of code-generation, however, there are two kinds of
-       *  instances:
+       * instances:
        *
        * Non-parametric instances
        * ------------------------
@@ -1564,7 +1565,7 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
        *  through their arguments while instantiating the type/instance
        *  arguments for the instance, i.e. they form a sort of closure.
        * 
-       *  Note: usage of local functions in this context won't work well? 
+       *  Note/TODO: usage of local functions in this context won't work well? 
        *   How to fix local functinos...
        *   - Make them local state and therad through
        *   - 
@@ -1599,59 +1600,61 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
             }
             build_binary_op(Mov, reg(RSI, sz_64), imm32(immediate_sz), ass, a, point);
             generate_tmp_malloc(reg(RAX, sz_64), reg(RSI, sz_64), ass, a, point);
-            build_binary_op(Mov, reg(RCX, sz_64), reg(RAX, sz_64), ass, a, point);
 
             // Grow by address size to account for the fact that the for loop
             // keeps an address for the current field, which is updated each iteration.
+            build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
             data_stack_grow(env, ADDRESS_SIZE);
-            build_unary_op(Push, reg(RCX, sz_64), ass, a, point);
 
-            // TODO (BUG): generate code that doesn't assume fields are in same order   
+            // To generate account for the fact that instance fields *may be*  out of order, 
+            // we first generate all fields (arbitrary order), THEN move the
+            // fields into the allocated memory
+            int64_t stack_head = get_stack_head(env);
+            for (size_t i = 0; i < syn.instance.fields.len; i++) {
+                SynRef val = syn.instance.fields.data[i].val;
+                generate_i(val, env, ictx);
+            }
+            size_t total_src_size = stack_head - get_stack_head(env);
 
             // Alignment
             size_t index_offset = 0;
             for (size_t i = 0; i < type->instance.fields.len; i++) {
-                // Generate field
-                SynRef val = syn.instance.fields.data[i].val;
-                generate_i(val, env, ictx);
+                Symbol field = type->instance.fields.data[i].key;
+                PiType* ty = type->instance.fields.data[i].val;
 
-                // The offset tells us how far up the stack we look to find the instance ptr
-                size_t val_sz = pi_size_of(*get_type(val, ictx.tape));
-                size_t val_stack_sz = pi_stack_align(val_sz);
-
-                // Retrieve index (ptr) 
-                // TODO (BUG): Check offset is < int8_t max.
-                build_binary_op(Mov, reg(RCX, sz_64), rref8(RSP, pi_stack_align(val_stack_sz), sz_64), ass, a, point);
-
-                // Align RCX
-                size_t aligned_offset = pi_size_align(index_offset, pi_align_of(*get_type(val, ictx.tape)));
-                if (index_offset != aligned_offset) {
-                    size_t align = aligned_offset - index_offset;
-                    build_binary_op(Add, reg(RCX, sz_64), imm32(align), ass, a, point);
+                size_t source_offset = 0;
+                for (size_t j = syn.instance.fields.len; j > 0; j--) {
+                    size_t idx = j - 1;
+                    if (symbol_eq(field, syn.instance.fields.data[idx].key)) { break; }
+                    PiType* field_ty = get_type(syn.instance.fields.data[idx].val, ictx.tape);
+                    source_offset += is_variable_in(field_ty, env) ? ADDRESS_SIZE : pi_stack_size_of(*field_ty);
                 }
+                size_t val_size = pi_size_of(*ty);
+                size_t val_align = pi_align_of(*ty);
+
+
+                // Retrieve index (ptr) and align it
+                // TODO (BUG): Check offset is < int8_t max.
+                build_binary_op(Mov, reg(RCX, sz_64), rref8(RSP, total_src_size, sz_64), ass, a, point);
+                size_t aligned_offset = pi_size_align(index_offset, val_align);
+                build_binary_op(Add, reg(RCX, sz_64), imm32(aligned_offset), ass, a, point);
+
+                // Retrieve Dest ptr
+                build_binary_op(Mov, reg(RDX, sz_64), reg(RSP, sz_64), ass, a, point);
+                build_binary_op(Add, reg(RDX, sz_64), imm32(source_offset), ass, a, point);
 
                 // TODO (check if should replace with stack copy/move)
-                generate_monomorphic_copy(RCX, RSP, val_sz, ass, a, point);
+                generate_monomorphic_copy(RCX, RDX, val_size, ass, a, point);
 
                 // We need to increment the current field index to be able to access
                 // the next
-                build_binary_op(Add, reg(RCX, sz_64), imm32(val_sz), ass, a, point);
-                index_offset += val_sz;
-
-                // Pop value from stack
-                build_binary_op(Add, reg(RSP, sz_64), imm32(pi_stack_align(val_stack_sz)), ass, a, point);
-                data_stack_shrink(env, val_stack_sz);
-
-                // Override index with new value
-                build_binary_op(Mov, rref8(RSP, 0, sz_64), reg(RCX, sz_64), ass, a, point);
+                index_offset += val_size;
             }
-
-            build_binary_op(Mov, reg(RCX, sz_64), rref8(RSP, 0, sz_64), ass, a, point);
-            build_binary_op(Sub, reg(RCX, sz_64), imm32(immediate_sz), ass, a, point);
-            build_binary_op(Mov, rref8(RSP, 0, sz_64), reg(RCX, sz_64), ass, a, point);
-
+            // Pop all values from stack
             // Note: we don't shrink as the final address (on stack) is accounted
             // for by the 'grow' prior to the above for-loop
+            build_binary_op(Add, reg(RSP, sz_64), imm32(total_src_size), ass, a, point);
+            data_stack_shrink(env, total_src_size);
         }
         break;
     }

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -712,6 +712,8 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
     case SProcedure: {
         // Generate procedure value (push the address onto the stack)
         AsmResult out = build_binary_op(Mov, reg(RAX, sz_64), imm64(0), ass, a, point);
+        build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
+        data_stack_grow(env, ADDRESS_SIZE);
         ProcDefer to_generate = {
           .proc = ref,
           .backlink_from = target.target,
@@ -723,8 +725,6 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
             to_generate.instance_args = get_instance_implicits(env);
         }
         push_proc_defer(to_generate, ictx.procs_to_generate);
-        build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
-        data_stack_grow(env, ADDRESS_SIZE);
         break;
     }
     case SAll: {
@@ -737,13 +737,17 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
         build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
         data_stack_grow(env, ADDRESS_SIZE);
 
-        // Now, change the target and the assembler, such that code is now
-        // generated in the 'code segment'. Then, generate the function body
-        ass = target.code_aux;
-        target.target = target.code_aux;
-        ictx.target = target;
-
-        generate_polymorphic(syn.all.args, syn.all.body, env, ictx);
+        ProcDefer to_generate = {
+          .proc = ref,
+          .backlink_from = target.target,
+          .backlink = out.backlink,
+          .in_poly_instance = false
+        };
+        if (in_poly_instance(env)) {
+            to_generate.in_poly_instance = true;
+            to_generate.instance_args = get_instance_implicits(env);
+        }
+        push_proc_defer(to_generate, ictx.procs_to_generate);
         break;
     }
     case SMacro:
@@ -3617,15 +3621,13 @@ void generate_deferred_proc(ProcDefer deferred, AddressEnv* env, InternalContext
         break;
     }
     case SAll: {
-        void* all_address = get_instructions(target.code_aux).data;
-        all_address += get_instructions(target.code_aux).len;
+        uint8_t* caller_loc = get_instructions(deferred.backlink_from).data + deferred.backlink; 
+        set_unaligned_ptr(caller_loc, get_instructions(target.code_aux).data + get_pos(target.code_aux));
 
-        // Generate procedure value (push the address onto the stack)
-        AsmResult out = build_binary_op(Mov, reg(RAX, sz_64), imm64((uint64_t)all_address), ass, a, point);
-        backlink_code(target, out.backlink, links);
-        build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
-        data_stack_grow(env, ADDRESS_SIZE);
-
+        if (!deferred.in_poly_instance) {
+            // We link differently for polymorphic instances
+            backlink_code(target, deferred.backlink, links);
+        }
         // Now, change the target and the assembler, such that code is now
         // generated in the 'code segment'. Then, generate the function body
         ass = target.code_aux;

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -61,9 +61,7 @@ LinkData bd_generate_toplevel(TopLevel top, Environment* env, CodegenContext ctx
     case TLDef: {
         // Note: types can only be recursive via 'Name', so we do not recursively bind if
         // generating a type.
-        Symbol* recsym = get_type(top.def.value, ctx.tape)->sort != TKind ? 
-            &top.def.bind : NULL;
-        AddressEnv* a_env = mk_address_env(env, recsym, a);
+        AddressEnv* a_env = mk_address_env(env, a);
         size_t out_sz = pi_size_of(*get_type(top.def.value, ctx.tape));
 
         ProcDeferArray procs_to_generate = mk_proc_defer_array(4, a);
@@ -99,7 +97,7 @@ LinkData bd_generate_toplevel(TopLevel top, Environment* env, CodegenContext ctx
         break;
     }
     case TLExpr: {
-        AddressEnv* a_env = mk_address_env(env, NULL, a);
+        AddressEnv* a_env = mk_address_env(env, a);
 
         ProcDeferArray procs_to_generate = mk_proc_defer_array(4, a);
         InternalContext ictx = {
@@ -153,7 +151,7 @@ LinkData bd_generate_toplevel(TopLevel top, Environment* env, CodegenContext ctx
 LinkData bd_generate_expr(SynRef syn, Environment* env, CodegenContext ctx) {
     Allocator* a = ctx.a;
     
-    AddressEnv* a_env = mk_address_env(env, NULL, a);
+    AddressEnv* a_env = mk_address_env(env, a);
     InternalLinkData links = (InternalLinkData) {
         .links = (LinkData) {
             .external_code_links = mk_sym_sarr_amap(8, a),
@@ -215,7 +213,7 @@ LinkData bd_generate_expr(SynRef syn, Environment* env, CodegenContext ctx) {
 
 void bd_generate_type_expr(SynRef syn, TypeEnv* env, CodegenContext ctx) {
     Allocator* a = ctx.a;
-    AddressEnv* a_env = mk_type_address_env(env, NULL, a);
+    AddressEnv* a_env = mk_type_address_env(env, a);
     InternalLinkData links = (InternalLinkData) {
         .links = (LinkData) {
             .external_code_links = mk_sym_sarr_amap(8, a),
@@ -609,6 +607,19 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
 
             // Finally, move the value from the source to the stack head
             generate_poly_move(reg(VSTACK_HEAD, sz_64), reg(R8, sz_64), reg(R9, sz_64), ass, a, point);
+            break;
+        }
+        case ACodeOffset: {
+            void* fn_address = get_instructions(target.code_aux).data;
+            fn_address += e.code_offset;
+            AsmResult out = build_binary_op(Mov, reg(R9, sz_64), imm64((uint64_t)fn_address), ass, a, point);
+            LinkMetaData link = (LinkMetaData) {
+                .source_offset = out.backlink,
+                .dest_offset = e.code_offset,
+            };
+            push_link_meta(link, &links->links.cc_links);
+            build_unary_op(Push, reg(R9, sz_64), ass, a, point);
+            data_stack_grow(env, ADDRESS_SIZE);
             break;
         }
         case ATypeVar: {
@@ -3518,6 +3529,8 @@ void generate_deferred_proc(ProcDefer deferred, AddressEnv* env, InternalContext
                 .procedure.implicits = implicits,
                 .procedure.body = syn.procedure.body,
                 .procedure.preserve_dyn_memory = syn.procedure.preserve_dyn_memory,
+                .procedure.is_recursive = syn.procedure.is_recursive,
+                .procedure.recursive_sym = syn.procedure.recursive_sym,
             };
             SynRef new_ref = new_syntax(ictx.tape);
             set_syntax(new_ref, new_proc, ictx.tape);
@@ -3528,6 +3541,16 @@ void generate_deferred_proc(ProcDefer deferred, AddressEnv* env, InternalContext
             return;
         }
 
+
+        RecBinding* rec = NULL; 
+        RecBinding rbind; 
+        if (syn.procedure.is_recursive) {
+            rec = &rbind; 
+            rbind = (RecBinding) {
+                .sym = syn.procedure.recursive_sym,
+                .offset = get_pos(ass),
+            };
+        }
         // Codegen function setup
         build_unary_op(Push, reg(VSTACK_HEAD, sz_64), ass, a, point);
         build_unary_op(Push, reg(DMEM_REGISTER, sz_64), ass, a, point);
@@ -3550,7 +3573,7 @@ void generate_deferred_proc(ProcDefer deferred, AddressEnv* env, InternalContext
             sym_size_bind(syn.procedure.args.data[i].key , arg_size , &arg_sizes);
         }
 
-        address_start_proc(impl_sizes, arg_sizes, env, a);
+        address_start_proc(rec, impl_sizes, arg_sizes, env, a);
         generate_i(syn.procedure.body, env, ictx);
         address_end_proc(env, a);
 

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -47,11 +47,12 @@ LinkData bd_generate_toplevel(TopLevel top, Environment* env, CodegenContext ctx
     InternalLinkData links = (InternalLinkData) {
         .links = (LinkData) {
             .external_code_links = mk_sym_sarr_amap(8, a),
-            .ec_links = mk_link_meta_array(32, a),
+            .ec_links = mk_link_meta_array(8, a),
             .ed_links = mk_link_meta_array(8, a),
-            .cc_links = mk_link_meta_array(32, a),
+            .code_starts = mk_u64_array(8, a),
+            .cc_links = mk_link_meta_array(8, a),
             .cd_links = mk_link_meta_array(8, a),
-            .dd_links = mk_link_meta_array(8, a),
+            .data_starts = mk_u64_array(8, a), .dd_links = mk_link_meta_array(8, a),
             .closure_links = mk_closure_link_array(8, a),
         },
         .gotolinks = mk_sym_sarr_assoc(8, a),
@@ -157,8 +158,10 @@ LinkData bd_generate_expr(SynRef syn, Environment* env, CodegenContext ctx) {
             .external_code_links = mk_sym_sarr_amap(8, a),
             .ec_links = mk_link_meta_array(8, a),
             .ed_links = mk_link_meta_array(8, a),
+            .code_starts = mk_u64_array(8, a),
             .cc_links = mk_link_meta_array(8, a),
             .cd_links = mk_link_meta_array(8, a),
+            .data_starts = mk_u64_array(8, a),
             .dd_links = mk_link_meta_array(8, a),
             .closure_links = mk_closure_link_array(8, a),
         },
@@ -184,6 +187,7 @@ LinkData bd_generate_expr(SynRef syn, Environment* env, CodegenContext ctx) {
 
     while (procs_to_generate.len != 0) {
         ProcDefer deferred = pop_proc_defer(&procs_to_generate);
+        push_u64(get_pos(ctx.target.code_aux), &links.links.code_starts);
         generate_deferred_proc(deferred, a_env, ictx);
     }
 
@@ -219,8 +223,10 @@ void bd_generate_type_expr(SynRef syn, TypeEnv* env, CodegenContext ctx) {
             .external_code_links = mk_sym_sarr_amap(8, a),
             .ec_links = mk_link_meta_array(8, a),
             .ed_links = mk_link_meta_array(8, a),
+            .code_starts = mk_u64_array(8, a),
             .cc_links = mk_link_meta_array(8, a),
             .cd_links = mk_link_meta_array(8, a),
+            .data_starts = mk_u64_array(8, a),
             .dd_links = mk_link_meta_array(8, a),
             .closure_links = mk_closure_link_array(8, a),
         },
@@ -565,6 +571,7 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
 
         // Backlink the data & copy the bytes into the data-segment.
         backlink_data(target, out.backlink, links);
+        push_u64(target.data_aux->len, &links->links.data_starts);
         add_u8_chunk(immediate.bytes, immediate.memsize, target.data_aux);
 
         build_unary_op(Push, reg(RAX, sz_64), ass, a, point);
@@ -3349,6 +3356,7 @@ void generate_i(SynRef ref, AddressEnv* env, InternalContext ictx) {
 
         // Backlink the data & copy the bytes into the data-segment.
         backlink_data(target, out.backlink, links);
+        push_u64(target.data_aux->len, &links->links.data_starts);
         add_u8_chunk(immediate.bytes, immediate.memsize, target.data_aux);
 
         build_unary_op(Push, reg(RAX, sz_64), ass, a, point);

--- a/src/pico/codegen/backend-direct/amd64/generate.c
+++ b/src/pico/codegen/backend-direct/amd64/generate.c
@@ -83,6 +83,7 @@ LinkData bd_generate_toplevel(TopLevel top, Environment* env, CodegenContext ctx
 
         while (procs_to_generate.len != 0) {
             ProcDefer deferred = pop_proc_defer(&procs_to_generate);
+            push_u64(get_pos(ctx.target.code_aux), &links.links.code_starts);
             generate_deferred_proc(deferred, a_env, ictx);
         }
 
@@ -119,6 +120,7 @@ LinkData bd_generate_toplevel(TopLevel top, Environment* env, CodegenContext ctx
 
         while (procs_to_generate.len != 0) {
             ProcDefer deferred = pop_proc_defer(&procs_to_generate);
+            push_u64(get_pos(ctx.target.code_aux), &links.links.code_starts);
             generate_deferred_proc(deferred, a_env, ictx);
         }
 

--- a/src/pico/codegen/backend-direct/amd64/polymorphic.c
+++ b/src/pico/codegen/backend-direct/amd64/polymorphic.c
@@ -280,6 +280,9 @@ void generate_size_of(Regname dest, PiType* type, AddressEnv* env, Assembler* as
             case ALocalIndexed:
                 panic(mv_string("Cannot generate code for size of local indexed."));
                 break;
+            case ACodeOffset:
+                panic(mv_string("Unexpected type variable sort: Recursive Function Binding."));
+                break;
             case AGlobal:
                 panic(mv_string("Unexpected type variable sort: Global."));
                 break;
@@ -390,6 +393,9 @@ void generate_align_of(Regname dest, PiType* type, AddressEnv* env, Assembler* a
                 break;
             case ALocalIndexed:
                 panic(mv_string("cannot generate align-of code for local indexed variable."));
+                break;
+            case ACodeOffset:
+                panic(mv_string("Unexpected type variable sort: Recursive Function Binding."));
                 break;
             case AGlobal:
                 panic(mv_string("Unexpected type variable sort: Global."));
@@ -551,6 +557,9 @@ void generate_stack_size_of(Regname dest, PiType* type, AddressEnv* env, Assembl
                 break;
             case ALocalIndexed:
                 panic(mv_string("cannot generate code for local indexed."));
+                break;
+            case ACodeOffset:
+                panic(mv_string("Unexpected type variable sort: Recursive Function Binding."));
                 break;
             case AGlobal:
                 panic(mv_string("Unexpected type variable sort: Global."));

--- a/src/pico/codegen/packend-pvm/generate_pvm.c
+++ b/src/pico/codegen/packend-pvm/generate_pvm.c
@@ -42,12 +42,8 @@ LinkData pvm_generate_toplevel(TopLevel top, Environment* env, CodegenContext ct
 
     switch(top.type) {
     case TLDef: {
-        // Note: types can only be recursive via 'Name', so we do not recursively bind if
-        // generating a type.
-        Symbol* recsym = get_type(top.def.value, ctx.tape)->sort != TKind ? 
-            &top.def.bind : NULL;
         // TODO: no address env should be here... use a pvm environment instead...
-        AddressEnv* a_env = mk_address_env(env, recsym, a);
+        AddressEnv* a_env = mk_address_env(env, a);
         generate(top.def.value, ctx.tape, a_env, ctx.target, &links, a, ctx.point);
         delete_address_env(a_env, a);
         break;
@@ -61,7 +57,7 @@ LinkData pvm_generate_toplevel(TopLevel top, Environment* env, CodegenContext ct
         break;
     }
     case TLExpr: {
-        AddressEnv* a_env = mk_address_env(env, NULL, a);
+        AddressEnv* a_env = mk_address_env(env, a);
         generate(top.expr, ctx.tape, a_env, ctx.target, &links, a, ctx.point);
         delete_address_env(a_env, a);
         break;
@@ -92,7 +88,7 @@ LinkData pvm_generate_toplevel(TopLevel top, Environment* env, CodegenContext ct
 
 LinkData pvm_generate_expr(SynRef ref, Environment* env, CodegenContext ctx) {
     Allocator* a = ctx.a;
-    AddressEnv* a_env = mk_address_env(env, NULL, a);
+    AddressEnv* a_env = mk_address_env(env, a);
     LinkData links = (LinkData) {
         .external_code_links = mk_sym_sarr_amap(8, a),
         .ec_links = mk_link_meta_array(8, a),
@@ -128,7 +124,7 @@ LinkData pvm_generate_expr(SynRef ref, Environment* env, CodegenContext ctx) {
 
 void pvm_generate_type_expr(SynRef syn, TypeEnv* env, CodegenContext ctx) {
     Allocator* a = ctx.a;
-    AddressEnv* a_env = mk_type_address_env(env, NULL, a);
+    AddressEnv* a_env = mk_type_address_env(env, a);
     LinkData links = (LinkData) {
         .external_code_links = mk_sym_sarr_amap(8, a),
         .ec_links = mk_link_meta_array(8, a),

--- a/src/pico/data/build_error.c
+++ b/src/pico/data/build_error.c
@@ -1,0 +1,47 @@
+#include "platform/terminal/terminal.h"
+
+#include "components/pretty/document.h"
+#include "components/pretty/stream_printer.h"
+
+#include "pico/data/build_error.h"
+
+const Colour build_message_colour = (Colour){.r = 200, .g = 20, .b = 20};
+
+void display_build_error(MultiBuildError multi, FormattedOStream* fos, Allocator* a) {
+    if (multi.has_many) {
+        write_fstring(mv_string("Errors encountered during the build process:\n"), fos);
+        for (size_t i = 0; i < multi.errors.len; i++) {
+            BuildError error = *(BuildError*)multi.errors.data[i];
+
+            write_fstring(mv_string("\n"), fos);
+            start_coloured_text(build_message_colour, fos);
+            Document* iderr = mv_nest_doc(2, error.message, a);
+            write_doc_formatted(iderr, 120, fos);
+            mem_free(iderr, a); // TODO: fix me! (fix mk doc & replace the mv with mk)
+            end_coloured_text(fos);
+            write_fstring(mv_string("\n\n"), fos);
+        }
+    } else {
+        write_fstring(mv_string("Error encountered during the build process:\n"), fos);
+        start_coloured_text(build_message_colour, fos);
+        Document* iderr = mv_nest_doc(2, multi.error.message, a);
+        write_doc_formatted(iderr, 120, fos);
+        mem_free(iderr, a); // TODO: fix me! (fix mk doc & replace the mv with mk)
+
+        end_coloured_text(fos);
+        write_fstring(mv_string("\n\n"), fos);
+    }
+}
+
+_Noreturn void throw_build_error(BuildErrorPoint* point, BuildError err) {
+    point->multi.has_many = false;
+    point->multi.error = err;
+    long_jump(point->buf, 1);
+}
+
+_Noreturn void throw_build_errors(BuildErrorPoint* point, PtrArray errors) {
+    point->multi.has_many = true;
+    point->multi.errors = errors;
+    long_jump(point->buf, 1);
+}
+

--- a/src/pico/data/path.c
+++ b/src/pico/data/path.c
@@ -1,0 +1,47 @@
+/**
+ * The path table is a specific type of hashtable mapping paths to values of
+ * type void* (may add more specific variants via macros at a later date).
+ */
+
+#include <string.h>
+
+#include "pico/data/path.h"
+
+uint64_t hash_path(Path path) {
+    // 64-bit FNV offsets and primes
+    uint64_t h = 14695981039346656037ULL;
+    const uint64_t FNV_prime = 1099511628211; 
+
+    for (size_t i = 0; i < path.len; i++) {
+        h = h ^ path.data[i];
+        h = h * FNV_prime;
+    }
+
+    /**
+     * As the keys are paths, and the integers in a path are themselves
+     * indices into a string array, they will overwhelmingly cluster towards
+     * smaller values (those that are actually allocated). Unless we are
+     * using 16 exabytes JUST for the strings, we would expect to never 
+     * see larger values. As such, we use a 'round' of a Murmur-stlye hashing
+     * algorithm to spread the distribution
+     *
+     * TODO (PERFORMANCE) do some IRL performance testing when we have a large enough
+     * codebase to compile, and see what happens.
+     */
+    h ^= (h >> 33);
+    h = (h * 0xff51afd7ed558ccd);
+    h ^= (h >> 33);
+    
+    return h;
+}
+
+bool path_eq(Path lhs, Path rhs) {
+    if (lhs.len != rhs.len) {
+        return false;
+    }
+    bool out = true;
+    for (size_t i = 0; i < lhs.len; i++) {
+        out &= (lhs.data[i] != rhs.data[i]);
+    }
+    return out;
+}

--- a/src/pico/data/symbol_table.c
+++ b/src/pico/data/symbol_table.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "platform/signals.h"
 
 #include "pico/data/symbol_table.h"
@@ -10,7 +11,7 @@ void init_symbol_table(SymbolTable* table, Allocator* a) {
         // Start with 1MB memory for strings
         .string_memory = mem_alloc(STR_CAPACITY, a),
         .string_len = 8, // 8, so we can use 0 as a null value :)
-        .string_capacity = 1048576,
+        .string_capacity = STR_CAPACITY,
 
         .capacity = CELL_CAPACITY,
         .cells = mem_alloc(sizeof(Cell) * CELL_CAPACITY, a),

--- a/src/pico/typecheck/typecheck.c
+++ b/src/pico/typecheck/typecheck.c
@@ -29,7 +29,6 @@ void type_check(TopLevel* top, Environment* env, TypeCheckContext ctx) {
     TypeEnv *t_env = mk_type_env(env, ctx.a);
     switch (top->type) {
     case TLDef: {
-        PiType* check_against;
         PiType* ty = env_lookup_tydecl(top->def.bind, env);
         SynRef term = top->def.value;
 
@@ -42,15 +41,13 @@ void type_check(TopLevel* top, Environment* env, TypeCheckContext ctx) {
             log_str(mv_string("\n--------------------------------------------------------------------------------\n"), ctx.logger);
         }
 
-        if (ty != NULL) {
-            check_against = ty;
-        } else {
-            check_against = mk_uvar(ctx.pia);
-        }
-        // TODO (BUG): only bind self if procedure/all etc.
-        //type_var(top->def.bind, check_against, t_env);
         mark_recur(term, top->def.bind, ctx);
-        type_check_expr(term, *check_against, t_env, ctx);
+        if (ty) {
+            type_check_expr(term, *ty, t_env, ctx);
+        } else {
+            type_infer_expr(term, t_env, ctx);
+        }
+
         post_unify(term, t_env, ctx);
         pop_type(t_env);
         break;

--- a/src/pico/typecheck/typecheck.c
+++ b/src/pico/typecheck/typecheck.c
@@ -17,6 +17,7 @@
 #include "pico/stdlib/foreign.h"
 
 // forward declarations
+void mark_recur(SynRef syn, Symbol self, TypeCheckContext ctx);
 void type_check_expr(SynRef untyped, PiType type, TypeEnv* env, TypeCheckContext ctx);
 void type_infer_expr(SynRef untyped, TypeEnv* env, TypeCheckContext ctx);
 void post_unify(SynRef untyped, TypeEnv* env, TypeCheckContext ctx);
@@ -47,7 +48,8 @@ void type_check(TopLevel* top, Environment* env, TypeCheckContext ctx) {
             check_against = mk_uvar(ctx.pia);
         }
         // TODO (BUG): only bind self if procedure/all etc.
-        type_var(top->def.bind, check_against, t_env);
+        //type_var(top->def.bind, check_against, t_env);
+        mark_recur(term, top->def.bind, ctx);
         type_check_expr(term, *check_against, t_env, ctx);
         post_unify(term, t_env, ctx);
         pop_type(t_env);
@@ -76,7 +78,7 @@ void type_check(TopLevel* top, Environment* env, TypeCheckContext ctx) {
         for (size_t i = 0; i < top->import.clauses.len; i++) {
             ImportClause clause = top->import.clauses.data[i];
             ImportClauseStatus status = import_clause_valid(env, clause);
-            if (!status.type == ICValid) {
+            if (status.type != ICValid) {
                 type_error_invalid_import(clause, status.bad_symbol, status.type != ICNotExists, top->import.range, ctx);
             }
         }
@@ -358,9 +360,33 @@ void type_infer_i(SynRef ref, TypeEnv* env, TypeCheckContext ctx) {
             push_addr(aty, &proc_ty->proc.args);
         }
 
+        if (untyped.procedure.is_recursive) {
+            proc_ty->proc.ret = mk_uvar(ctx.pia);
+            type_var(untyped.procedure.recursive_sym, proc_ty, env);
+        }
         type_infer_i(untyped.procedure.body, env, ctx); 
         pop_types(env, untyped.procedure.args.len + untyped.procedure.implicits.len);
-        proc_ty->proc.ret = get_type(untyped.procedure.body, ctx.tape);
+
+        if (untyped.procedure.is_recursive) {
+            pop_type(env);
+            UnifyContext uctx = (UnifyContext) {
+                .a = ctx.a,
+                .pia = ctx.pia,
+                .current_module = type_env_module(env),
+                .logger = ctx.logger,
+            };
+            PiType* expected = get_type(untyped.procedure.body, ctx.tape);
+            UnifyResult out = unify(expected, proc_ty->proc.ret, uctx);
+            UnifyReason reason = {
+                .type = URCheck,
+                .check.range = get_range(ref, ctx.tape).term,
+                .check.expected = expected,
+                .check.actual = proc_ty->proc.ret,
+            };
+            check_result_out(out, get_range(ref, ctx.tape).term, reason, ctx.a, ctx.point);
+        } else {
+            proc_ty->proc.ret = get_type(untyped.procedure.body, ctx.tape);
+        }
         break;
     }
     case SAll: {
@@ -2811,5 +2837,21 @@ PiType* eval_type(SynRef ref, TypeEnv* env, TypeCheckContext ctx) {
     set_syntax(ref, syn, ctx.tape);
 
     return *result;
+}
+
+/**
+ * Mark a syntactic term as potentialy recursive
+ */
+void mark_recur(SynRef ref, Symbol self, TypeCheckContext ctx) {
+    Syntax syn = get_syntax(ref, ctx.tape);
+    switch (syn.type) {
+    case SProcedure:
+        syn.procedure.is_recursive = true;
+        syn.procedure.recursive_sym = self;
+        set_syntax(ref, syn, ctx.tape);
+        break;
+    default:
+        break;
+    }
 }
 

--- a/src/pico/typecheck/typecheck.c
+++ b/src/pico/typecheck/typecheck.c
@@ -1326,8 +1326,8 @@ void type_infer_i(SynRef ref, TypeEnv* env, TypeCheckContext ctx) {
                     aty = eval_type(*(SynRef*)arg.val, env, ctx);
                 } else  {
                     aty = mk_uvar(ctx.pia);
-                    branch->args.data[i].val = aty;
                 }
+                branch->args.data[i].val = aty;
                 push_ptr(aty, arr);
             }
             sym_ptr_bind(untyped.labels.terms.data[i].key, arr, &labels);

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -1,7 +1,9 @@
 #include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
+
 #include "platform/machine_info.h"
+#include "platform/signals.h"
 #include "platform/memory/executable.h"
 
 #include "data/num.h"
@@ -13,6 +15,7 @@
 #include "pico/codegen/codegen.h"
 #include "pico/values/values.h"
 #include "pico/values/modular.h"
+#include "pico/values/modular_build.h"
 #include "pico/syntax/header.h"
 #include "pico/data/sym_sarr_amap.h"
 #include "pico/data/sym_ptr_amap.h"
@@ -33,7 +36,10 @@ typedef struct {
   PiType type;
   PtrArray* declarations;
 
+  U64Array code_starts;
   U8Array* code_segment;
+
+  U64Array data_starts;
   U8Array* data_segment;
 
   // For parametric instances, need to keep track of specific instantiations. 
@@ -248,6 +254,8 @@ void delete_module_entry(ModuleEntryInternal entry, Module* module) {
         delete_sym_sarr_amap(*entry.backlinks,
                              delete_symbol,
                              sdelete_size_array);
+        sdelete_u64_array(entry.code_starts);
+        sdelete_u64_array(entry.data_starts);
         call_free(entry.backlinks, &module->pico_allocator);
     }
     if (entry.code_segment) {
@@ -396,6 +404,8 @@ Result add_def(Module* module, Symbol symbol, PiType type, void* data, Segments 
                                                 scopy_size_array,
                                                 &module->allocator);
 
+        entry.code_starts = scopy_u64_array(links->code_starts, &module->allocator);
+        entry.data_starts = scopy_u64_array(links->data_starts, &module->allocator);
         if (segments.code.len != 0) {
             // Move this to the code segment bit?
             // swap out self-references
@@ -678,3 +688,103 @@ void update_function(uint8_t* val, SymPtrAMap new_vals, SymSArrAMap links) {
         }
     }
 }
+
+/**
+ * Implementation of the 'Modular Build' interface/header, see 
+ * pico/values/modular_build.h for full specification/intended behaviour.
+ */
+
+ModuleIndex start_iterating(Module* module) {
+  return (ModuleIndex) {
+      .entry = 0,
+      .component = 0,
+      .value = 0,
+  };
+}
+
+typedef enum {
+  CodeComponent,
+  DataComponent,
+  InstanceComponent,
+} ComponentIndex;
+
+bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module) {
+    size_t entry_index = index->entry;
+    ComponentIndex component_index = index->component;
+    size_t value_index = index->value;
+    if (entry_index == module->entries.len) {
+        return false;
+    }
+
+    ModuleEntryInternal entry = module->entries.data[entry_index].val;
+    if (component_index == CodeComponent) {
+    } else if (component_index == DataComponent) {
+
+    } else  {
+
+    }
+
+    /**
+     * Index Increment logic
+     */
+    switch (component_index) {
+    case CodeComponent:
+      goto inc_code;
+    case DataComponent:
+      goto inc_data;
+    case InstanceComponent:
+      goto inc_instance;
+    default:
+      panic(mv_string("Invalid Module Index"));
+    }
+
+ inc_code:
+    value_index++;
+    goto cascade_code;
+ cascade_code:
+    if (value_index == entry.code_starts.len) {
+      value_index = 0;
+      component_index = DataComponent;
+      goto cascade_data;
+    }
+    goto write_index;
+
+ inc_data:
+    value_index++;
+    goto cascade_data;
+ cascade_data:
+    if (value_index == entry.data_starts.len) {
+      value_index = 0;
+      component_index = InstanceComponent;
+      goto cascade_instance;
+    }
+    goto write_index;
+
+ inc_instance:
+    value_index++;
+    goto cascade_instance;
+ cascade_instance:
+    if (entry.instances) {
+      if (entry.instances->instantiations.len == value_index) {
+        entry_index++;
+        value_index = 0;
+        component_index = CodeComponent;
+      } 
+    } else {
+      entry_index++;
+      value_index = 0;
+      component_index = CodeComponent;
+    }
+    goto write_index;
+
+ write_index:
+    *index = (ModuleIndex) {
+      .entry = entry_index,
+      .component = component_index,
+      .value = value_index,
+    };
+
+    return true;
+}
+    
+    

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -736,8 +736,9 @@ void cascade_iterator(ModuleIndex* index, Module* module) {
     if (value_index >= 1) {
       value_index = 0;
       component_index = CodeComponent;
-      goto cascade_data;
+      goto cascade_code;
     }
+    goto end_loop;
 
   cascade_code:
     if (value_index >= entry.code_starts.len) {
@@ -788,7 +789,7 @@ ModuleIndex start_iterating(Module* module) {
   return start;
 }
 
-bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module) {
+bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module, BuildErrorPoint* point, Allocator* a) {
     size_t entry_index = index->entry;
     //ComponentIndex component_index = index->component;
     //size_t value_index = index->value;
@@ -805,23 +806,48 @@ bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module)
 
     switch (component_index) {
     case ValueComponent: {
-        size_t size = pi_size_of(entry.type);
-        U8Array frag_data = {
-            .data = entry.value,
-            .len = size,
-            .size = size,
-        };
-        *fragment = (ModuleFragment) {
-            .type = DataFragment_t,
-            .data = frag_data,
-        };
+        if (entry.value == NULL) {
+            Symbol name = module->entries.data[entry_index].key;
+            PtrArray nodes = mk_ptr_array(3, a);
+
+            push_ptr(mv_cstr_doc("Symbol", a), &nodes);
+            push_ptr(mk_paren_doc("'", "'", mv_str_doc(view_symbol_string(name), a), a), &nodes);
+            push_ptr(mv_cstr_doc("is declared in module", a), &nodes);
+            push_ptr(mv_cstr_doc("<TODO: add module name>", a), &nodes);
+            push_ptr(mv_cstr_doc("but is lacking definition", a), &nodes);
+
+            BuildError err = {
+                .message = mv_hsep_doc(nodes, a),
+                .module = module,
+                .definition = name,
+            };
+            throw_build_error(point, err);
+        }
+
+        if (entry.is_module) {
+            *fragment = (ModuleFragment) {
+                .type = ModuleFragment_t,
+                .module = entry.value,
+            };
+        } else {
+            size_t size = pi_size_of(entry.type);
+            U8Array frag_data = {
+                .data = entry.value,
+                .len = size,
+                .size = size,
+            };
+            *fragment = (ModuleFragment) {
+                .type = DataFragment_t,
+                .data = frag_data,
+            };
+        }
         break;
     }
     case CodeComponent: {
         size_t fn_start = entry.code_starts.data[index->value];
         size_t fn_end = (entry.code_starts.len == index->value + 1)
-            ? (entry.code_starts.data[index->value + 1])
-            : entry.code_segment->len;
+            ? entry.code_segment->len
+            : (entry.code_starts.data[index->value + 1]);
         U8Array frag_data = {
             .data = entry.code_segment->data + fn_start,
             .len = fn_end - fn_start,
@@ -836,8 +862,8 @@ bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module)
     case DataComponent: {
         size_t data_start = entry.data_starts.data[index->value];
         size_t data_end = (entry.data_starts.len == index->value + 1)
-            ? (entry.data_starts.data[index->value + 1])
-            : entry.data_segment->len;
+            ? entry.data_segment->len
+            : (entry.data_starts.data[index->value + 1]);
         U8Array frag_data = {
             .data = entry.data_segment->data + data_start,
             .len = data_end - data_start,
@@ -860,4 +886,3 @@ bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module)
     cascade_iterator(index, module);
     return true;
 }
-    

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -694,13 +694,6 @@ void update_function(uint8_t* val, SymPtrAMap new_vals, SymSArrAMap links) {
  * pico/values/modular_build.h for full specification/intended behaviour.
  */
 
-ModuleIndex start_iterating(Module* module) {
-  return (ModuleIndex) {
-      .entry = 0,
-      .component = 0,
-      .value = 0,
-  };
-}
 
 typedef enum {
   CodeComponent,
@@ -708,83 +701,95 @@ typedef enum {
   InstanceComponent,
 } ComponentIndex;
 
-bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module) {
-    size_t entry_index = index->entry;
-    ComponentIndex component_index = index->component;
-    size_t value_index = index->value;
+/**
+ * cascade_iterator is, in a sense, the bulk of the index increment logic. The
+ * goal of 'cascade' is to advande the iterator until the next valid entry (or
+ * to the end of the module, whichever comes first.
+ */
+void cascade_iterator(ModuleIndex* index, Module* module) {
+  bool running = true;
+  size_t entry_index = index->entry;
+  ComponentIndex component_index = index->component;
+  size_t value_index = index->value;
+
+  while (running) {
     if (entry_index == module->entries.len) {
-        return false;
+      goto end_loop;
     }
-
     ModuleEntryInternal entry = module->entries.data[entry_index].val;
-    if (component_index == CodeComponent) {
-    } else if (component_index == DataComponent) {
 
-    } else  {
-
-    }
-
-    /**
-     * Index Increment logic
-     */
     switch (component_index) {
     case CodeComponent:
-      goto inc_code;
+      goto cascade_code;
     case DataComponent:
-      goto inc_data;
+      goto cascade_data;
     case InstanceComponent:
-      goto inc_instance;
+      goto cascade_instance;
     default:
       panic(mv_string("Invalid Module Index"));
     }
 
- inc_code:
-    value_index++;
-    goto cascade_code;
- cascade_code:
-    if (value_index == entry.code_starts.len) {
+  cascade_code:
+    if (value_index >= entry.code_starts.len) {
       value_index = 0;
       component_index = DataComponent;
       goto cascade_data;
     }
-    goto write_index;
+    goto end_loop;
 
- inc_data:
-    value_index++;
-    goto cascade_data;
- cascade_data:
-    if (value_index == entry.data_starts.len) {
+  cascade_data:
+    if (value_index >= entry.data_starts.len) {
       value_index = 0;
       component_index = InstanceComponent;
       goto cascade_instance;
     }
-    goto write_index;
+    goto end_loop;
 
- inc_instance:
-    value_index++;
-    goto cascade_instance;
- cascade_instance:
-    if (entry.instances) {
-      if (entry.instances->instantiations.len == value_index) {
-        entry_index++;
-        value_index = 0;
-        component_index = CodeComponent;
-      } 
-    } else {
+  cascade_instance:
+    if (!entry.instances || (entry.instances->instantiations.len == value_index)) {
       entry_index++;
       value_index = 0;
       component_index = CodeComponent;
+      goto continue_loop;
+    } 
+    goto end_loop;
+
+  end_loop:
+    running = false;
+
+  continue_loop:
+    continue;
+  }
+
+  *index = (ModuleIndex) {
+    .entry = entry_index,
+    .component = component_index,
+    .value = value_index,
+  };
+}
+
+ModuleIndex start_iterating(Module* module) {
+  ModuleIndex start = {
+    .entry = 0,
+    .component = 0,
+    .value = 0,
+  };
+  cascade_iterator(&start, module);
+  return start;
+}
+
+bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module) {
+    size_t entry_index = index->entry;
+    //ComponentIndex component_index = index->component;
+    //size_t value_index = index->value;
+    if (entry_index == module->entries.len) {
+        return false;
     }
-    goto write_index;
 
- write_index:
-    *index = (ModuleIndex) {
-      .entry = entry_index,
-      .component = component_index,
-      .value = value_index,
-    };
+    //ModuleEntryInternal entry = module->entries.data[entry_index].val;
 
+    index->value++;
+    cascade_iterator(index, module);
     return true;
 }
-    
     

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -599,6 +599,26 @@ SymbolArray get_defined_symbols(Module* module, Allocator* a) {
     return symbols;
 }
 
+SymbolArray get_exported_symbols(Module* module, Allocator* a) {
+    SymbolArray symbols; 
+    if (module->header.exports.export_all) {
+        symbols = mk_symbol_array(module->entries.len, a);
+        for (size_t i = 0; i < module->entries.len; i++) {
+            push_symbol(module->entries.data[i].key, &symbols);
+        };
+    } else {
+        ExportClauseArray clauses = module->header.exports.clauses;
+        symbols = mk_symbol_array(clauses.len, a);
+        for (size_t i = 0; i < clauses.len; i++) {
+            ExportClause clause = clauses.data[i]; 
+            if (clause.type == ExportName && get_def(clause.name, module)) {
+                push_symbol(clause.name, &symbols);
+            }
+        }
+    }
+    return symbols;
+}
+
 PtrArray get_defined_instances(Module* module, Allocator* a) {
     PtrArray instances = mk_ptr_array(module->entries.len, a);
     for (size_t i = 0; i < module->entries.len; i++) {

--- a/src/pico/values/modular.c
+++ b/src/pico/values/modular.c
@@ -696,6 +696,7 @@ void update_function(uint8_t* val, SymPtrAMap new_vals, SymSArrAMap links) {
 
 
 typedef enum {
+  ValueComponent,
   CodeComponent,
   DataComponent,
   InstanceComponent,
@@ -719,6 +720,8 @@ void cascade_iterator(ModuleIndex* index, Module* module) {
     ModuleEntryInternal entry = module->entries.data[entry_index].val;
 
     switch (component_index) {
+    case ValueComponent:
+      goto cascade_val;
     case CodeComponent:
       goto cascade_code;
     case DataComponent:
@@ -727,6 +730,13 @@ void cascade_iterator(ModuleIndex* index, Module* module) {
       goto cascade_instance;
     default:
       panic(mv_string("Invalid Module Index"));
+    }
+
+  cascade_val:
+    if (value_index >= 1) {
+      value_index = 0;
+      component_index = CodeComponent;
+      goto cascade_data;
     }
 
   cascade_code:
@@ -749,7 +759,7 @@ void cascade_iterator(ModuleIndex* index, Module* module) {
     if (!entry.instances || (entry.instances->instantiations.len == value_index)) {
       entry_index++;
       value_index = 0;
-      component_index = CodeComponent;
+      component_index = ValueComponent;
       goto continue_loop;
     } 
     goto end_loop;
@@ -786,7 +796,65 @@ bool next_iterator(ModuleIndex* index, ModuleFragment* fragment, Module* module)
         return false;
     }
 
-    //ModuleEntryInternal entry = module->entries.data[entry_index].val;
+    ModuleEntryInternal entry = module->entries.data[entry_index].val;
+    ComponentIndex component_index = index->component;
+
+    /**
+     * TODO: add component for the value itself...
+     */
+
+    switch (component_index) {
+    case ValueComponent: {
+        size_t size = pi_size_of(entry.type);
+        U8Array frag_data = {
+            .data = entry.value,
+            .len = size,
+            .size = size,
+        };
+        *fragment = (ModuleFragment) {
+            .type = DataFragment_t,
+            .data = frag_data,
+        };
+        break;
+    }
+    case CodeComponent: {
+        size_t fn_start = entry.code_starts.data[index->value];
+        size_t fn_end = (entry.code_starts.len == index->value + 1)
+            ? (entry.code_starts.data[index->value + 1])
+            : entry.code_segment->len;
+        U8Array frag_data = {
+            .data = entry.code_segment->data + fn_start,
+            .len = fn_end - fn_start,
+            .size = fn_end - fn_start,
+        };
+        *fragment = (ModuleFragment) {
+            .type = CodeFragment_t,
+            .data = frag_data,
+        };
+        break;
+    }
+    case DataComponent: {
+        size_t data_start = entry.data_starts.data[index->value];
+        size_t data_end = (entry.data_starts.len == index->value + 1)
+            ? (entry.data_starts.data[index->value + 1])
+            : entry.data_segment->len;
+        U8Array frag_data = {
+            .data = entry.data_segment->data + data_start,
+            .len = data_end - data_start,
+            .size = data_end - data_start,
+        };
+        *fragment = (ModuleFragment) {
+            .type = DataFragment_t,
+            .data = frag_data,
+        };
+        break;
+    }
+    case InstanceComponent:
+        // TODO: setup instance...
+        break;
+    default:
+      panic(mv_string("Invalid Module Index"));
+    }
 
     index->value++;
     cascade_iterator(index, module);

--- a/src/platform/filesystem/filesystem.c
+++ b/src/platform/filesystem/filesystem.c
@@ -272,15 +272,18 @@ String get_current_directory(Allocator* a) {
 #if OS_FAMILY == WINDOWS
     size_t mem_required = GetCurrentDirectory(0, NULL);
     String out = {
-        .memsize = mem_required,
-        .bytes = mem_alloc(mem_required, a),
+      .memsize = mem_required,
+      .bytes = mem_alloc(mem_required, a),
     };
     // TODO: convert to valid path (consider encoding)
     GetCurrentDirectory(mem_required, (char*)out.bytes);
     return out;
 #else
     char cwd[PATH_MAX];
-    getcwd(cwd, PATH_MAX);
+    char* buf = getcwd(cwd, PATH_MAX);
+    if (buf == NULL) {
+      panic(mv_string("getcwd failed. TODO: add proper error return types to getcwd"));
+    }
     String dir = mv_string(cwd);
     return copy_string(dir, a);
 #endif
@@ -293,7 +296,9 @@ void set_current_directory(String path) {
 #if OS_FAMILY == WINDOWS
     SetCurrentDirectory(c_path);
 #else
-    chdir(c_path);
+    if (chdir(c_path)) {
+      panic(mv_string("chdir failed. TODO: add proper error return types to chdir"));
+    }
 #endif
     mem_free(c_path, get_std_allocator());
 }

--- a/src/platform/terminal/terminal.c
+++ b/src/platform/terminal/terminal.c
@@ -536,7 +536,9 @@ void send_output_terminal_event(OutTermEvent event) {
 void terminal_write_string_unbuffered(String string) {
 #if OS_FAMILY == UNIX
     fflush(stdout);
-    write(STDOUT_FILENO, string.bytes, string.memsize);
+    size_t written = write(STDOUT_FILENO, string.bytes, string.memsize);
+    if (written != string.memsize)
+        panic(mv_string("failed to write some bytes. TODO: make this error a proper return value"));
 #elif OS_FAMILY == WINDOWS
     fflush(stdout);
     HANDLE std_cout = GetStdHandle(STD_OUTPUT_HANDLE);

--- a/src/platform/window/impl_x11.c
+++ b/src/platform/window/impl_x11.c
@@ -7,10 +7,12 @@
 #include "platform/window/window.h"
 #include "platform/window/internal.h"
 #include "platform/signals.h"
+#include "platform/window/xkb_translate.h"
 
 #include "data/stringify.h"
 
 #include <X11/Xlib.h>
+#include <X11/XKBlib.h>
 #include <unistd.h>
 
 static Allocator* wsa;
@@ -103,6 +105,13 @@ WinMessageArray pl_poll_events(PlWindow* window, Allocator* a) {
             }
             break;
         }
+        case KeyPress:
+        case KeyRelease:
+            if (event.type == KeyPress) {
+
+            } else {
+            }
+            break;
 
         // The following events are ones that we have determined can be safely
         // ignored, i.e. they do not need to be acted on AND are not exposed in
@@ -148,6 +157,39 @@ WinMessageArray pl_poll_events(PlWindow* window, Allocator* a) {
         }
     }
     return out;
+}
+
+// Key handling: 
+struct KeyboardState {
+    uint8_t keys[256];
+};
+
+
+KeyboardState* create_keyboard_state(KeyMap *keymap) {
+    KeyboardState* keystate = mem_alloc(sizeof(KeyboardState), wsa);
+    for (size_t i = 0; i < 256; i++) {
+        keystate->keys[i] = 0;
+    }
+    return keystate;
+}
+
+void destroy_keyboard_state(KeyboardState* state) {
+    mem_free(state, wsa);
+}
+
+void update_keystate_key(RawKey raw, uint32_t modifier_mask, bool is_pressed, KeyboardState *state) {
+    state->keys[raw] = is_pressed << 7;
+}
+void update_keystate_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group, KeyboardState *state) {
+    // TODO: implement me!
+}
+
+Key get_key(RawKey raw, KeyboardState* state) {
+    //KeyboardState* kstate = (void*)state;
+    // TODO: get shift state from keyboard...
+    KeyCode keycode = raw;
+    KeySym keysym = XkbKeycodeToKeysym(x11_display, keycode, 0, 0);
+    return translate_xkb_keycode(keysym);
 }
 
 #endif

--- a/src/platform/window/impl_x11.c
+++ b/src/platform/window/impl_x11.c
@@ -19,6 +19,8 @@ static Allocator* wsa;
 
 static Display* x11_display = NULL;
 
+static bool initialized = false;
+
 Atom WM_DELETE_WINDOW;
 
 // Internal
@@ -86,6 +88,31 @@ bool pl_window_should_close(PlWindow *window) {
 WinMessageArray pl_poll_events(PlWindow* window, Allocator* a) {
     WinMessageArray out = mk_wm_array(8, a);
     XEvent event;
+    if (!initialized) {
+        initialized = true;
+        // 1. Initialize the XKB extension
+        int xkb_major = XkbMajorVersion;
+        int xkb_minor = XkbMinorVersion;
+        int xkb_opcode, xkb_event, xkb_error;
+
+        if (XkbQueryExtension(x11_display, &xkb_opcode, &xkb_event, &xkb_error, &xkb_major, &xkb_minor)) {
+            // 2. Fetch the initial keymap description
+            XkbDescPtr xkb_desc = XkbGetMap(x11_display, XkbAllMapComponentsMask, XkbUseCoreKbd);
+    
+            if (xkb_desc) {
+                // 3. Manually trigger your internal event so it matches Wayland's startup behavior
+                WinMessage message = (WinMessage) {
+                    .type = KeymapChanged,
+                    .keymap = (KeyMap*)xkb_desc,
+                };
+                push_wm(message, &out);
+        
+                // Clean up description if your internal event copies what it needs
+                XkbFreeKeyboard(xkb_desc, XkbAllComponentsMask, True);
+            }
+        }
+    }
+    
     while (XCheckWindowEvent(x11_display, window->x11_window, ButtonPressMask | StructureNotifyMask, &event)) {
         switch (event.type) {
         case DestroyNotify:
@@ -105,13 +132,6 @@ WinMessageArray pl_poll_events(PlWindow* window, Allocator* a) {
             }
             break;
         }
-        case KeyPress:
-        case KeyRelease:
-            if (event.type == KeyPress) {
-
-            } else {
-            }
-            break;
 
         // The following events are ones that we have determined can be safely
         // ignored, i.e. they do not need to be acted on AND are not exposed in
@@ -139,12 +159,23 @@ WinMessageArray pl_poll_events(PlWindow* window, Allocator* a) {
                          event.xany.window,
                          x11.context,
                          (XPointer*) &pl_window) != 0) {
-        // This is an event for a window that has already been destroyed
             return;
         }
         */
-
         switch (event.type) {
+        case KeyPress:
+        case KeyRelease: {
+            WinMessage message = {
+                .type = KeyEvent,
+                .key_event.key_id = scancode_to_rawkey(event.xkey.keycode - 8),
+                .key_event.modifier_key_mask = 0,
+                .key_event.key_pressed = event.type == KeyPress,
+            };
+            push_wm(message, &out);
+            break;
+        }
+
+        // This is an event for a window that has already been destroyed
         case ClientMessage: {
             if ((Atom)event.xclient.data.l[0] == WM_DELETE_WINDOW) {
                 window->should_close = 1;
@@ -178,7 +209,7 @@ void destroy_keyboard_state(KeyboardState* state) {
 }
 
 void update_keystate_key(RawKey raw, uint32_t modifier_mask, bool is_pressed, KeyboardState *state) {
-    state->keys[raw] = is_pressed << 7;
+    state->keys[raw] = is_pressed;
 }
 void update_keystate_modifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group, KeyboardState *state) {
     // TODO: implement me!
@@ -187,7 +218,7 @@ void update_keystate_modifiers(uint32_t depressed, uint32_t latched, uint32_t lo
 Key get_key(RawKey raw, KeyboardState* state) {
     //KeyboardState* kstate = (void*)state;
     // TODO: get shift state from keyboard...
-    KeyCode keycode = raw;
+    KeyCode keycode = rawkey_to_scancode(raw) + 8;
     KeySym keysym = XkbKeycodeToKeysym(x11_display, keycode, 0, 0);
     return translate_xkb_keycode(keysym);
 }

--- a/test/include/test_pico/parse/parse_helper.h
+++ b/test/include/test_pico/parse/parse_helper.h
@@ -6,6 +6,7 @@
 
 #include "test_pico/helper.h"
 
+
 void test_parse_eq(const char *string, RawTree expected, TestContext context);
 
 bool rawtree_eql(RawTree lhs, RawTree rhs);

--- a/test/src/test_pico/eval/literals.c
+++ b/test/src/test_pico/eval/literals.c
@@ -60,4 +60,9 @@ void run_pico_eval_literals_tests(TestLog *log, Module* module, Environment* env
         int64_t expected = 520;
         TEST_EQ("#o_1010");
     }
+
+    if (test_start(log, mv_string("character literal"))) {
+        int64_t expected = 'q';
+        TEST_EQ("#q");
+    }
 }

--- a/test/src/test_pico/eval/modular.c
+++ b/test/src/test_pico/eval/modular.c
@@ -1,9 +1,6 @@
 #include "test_pico/eval/components.h"
 #include "test_pico/helper.h"
 
-#define RUN(str) run_toplevel(str, module, context); refresh_env(env)
-#define TEST_EQ(str) test_toplevel_eq(str, &expected, module, context); reset_subregion(region)
-
 void run_pico_eval_modular_tests(TestLog *log, Module* module, Environment* env, Target target, RegionAllocator* region) {
     TestContext context = (TestContext) {
         .env = env,
@@ -36,11 +33,13 @@ void run_pico_eval_modular_tests(TestLog *log, Module* module, Environment* env,
         RUN("(def f1 proc [] -78)");
         TEST_EQ("(f1)");
     }
-    // TODO: re-enable this test once typechecking bug fixed
-    /* if (test_start(log, mv_string("function-recursive"))) { */
-    /*     int64_t expected = 4; */
-    /*     RUN("(def recur proc [(n I64)] (if (i64.< n 1) n (i64.+ n (recur (i64.- n 1)))))"); */
-    /*     TEST_EQ("(recur 10)"); */
-    /* } */
+     
+    /* TODO: this test reflects a typechecking bug!
+    if (test_start(log, mv_string("function-recursive"))) {
+        int64_t expected = 4;
+        RUN("(def recur proc [(n I64)] (if (i64.< n 1) n (i64.+ n (recur (i64.- n 1)))))");
+        TEST_EQ("(recur 10)");
+    }
+    */
 
 }

--- a/test/src/test_pico/eval/modular.c
+++ b/test/src/test_pico/eval/modular.c
@@ -34,12 +34,10 @@ void run_pico_eval_modular_tests(TestLog *log, Module* module, Environment* env,
         TEST_EQ("(f1)");
     }
      
-    /* TODO: this test reflects a typechecking bug!
     if (test_start(log, mv_string("function-recursive"))) {
-        int64_t expected = 4;
-        RUN("(def recur proc [(n I64)] (if (i64.< n 1) n (i64.+ n (recur (i64.- n 1)))))");
+        int64_t expected = 55;
+        RUN("(def recur proc [(n I64)] \n"
+            "  (if (i64.< n 1) n (i64.+ n (recur (i64.- n 1)))))");
         TEST_EQ("(recur 10)");
     }
-    */
-
 }

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -95,37 +95,29 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
     // -------------------------------------------------------------------------
 
     if (test_start(log, mv_string("poly-trait"))) {
-      RUN("(def Eql Trait Eql [A] [.eql Proc [A A] Bool])\n");
-      RUN("(def eql-i64 instance (Eql I64) [.eql proc [l r] (i64.= l r)])\n");
-      RUN("(def eql-arr2 instance [A] {(eq (Eql A))} (Eql (Array [2] A))\n"
-          "  [.eql proc [l r]\n"
-          "      (bool.and (eq.eql (aelt 0 l) (aelt 0 r))\n"
-          "           (eq.eql (aelt 1 l) (aelt 1 r)))])\n");
-      RUN("(def eql all [A] proc {(eql (Eql A))} [(l A) (r A)] (eql.eql l r))\n");
-      bool expected = true;
-      TEST_EQ("(eql (array [1 2]) (array [1 2]))");
+        RUN("(def Eql Trait Eql [A] [.eql Proc [A A] Bool])\n");
+        RUN("(def eql-i64 instance (Eql I64) [.eql proc [l r] (i64.= l r)])\n");
+        RUN("(def eql-arr2 instance [A] {(eq (Eql A))} (Eql (Array [2] A))\n"
+            "  [.eql proc [l r]\n"
+            "      (bool.and (eq.eql (aelt 0 l) (aelt 0 r))\n"
+            "           (eq.eql (aelt 1 l) (aelt 1 r)))])\n");
+        RUN("(def eql all [A] proc {(eql (Eql A))} [(l A) (r A)] (eql.eql l r))\n");
+        bool expected = true;
+        TEST_EQ("(eql (array [1 2]) (array [1 2]))");
     }
 
     /*
     if (test_start(log, mv_string("poly-trait-multi-inline-proc"))) {
-      RUN("(def Eql Trait Eql [A] [.= Proc [A A] Bool] [.!= Proc [A A] Bool])\n");
-      RUN("(def eql-i64 instance (Eql I64) [.= proc [l r] (i64.= l r)] [.!= proc [l r] (i64.= l r)])\n");
-      RUN("(def eq-arr4 instance [A] {(eq (Eql A))} (Eql (Array [4] A))"
-          "  [.= proc [l r]"
-          "    (->    (eq.= (aelt 0 l) (aelt 0 r))"
-          "      (bool.and (eq.= (aelt 1 l) (aelt 1 r)))"
-          "      (bool.and (eq.= (aelt 2 l) (aelt 2 r)))"
-          "      (bool.and (eq.= (aelt 3 l) (aelt 3 r))))]"
-          "  [.!= proc [l r] seq"
-          "    (->    (eq.!= (aelt 0 l) (aelt 0 r))"
-          "     (bool.or  (eq.!= (aelt 1 l) (aelt 1 r)))"
-          "     (bool.or  (eq.!= (aelt 2 l) (aelt 2 r)))"
-          "     (bool.or  (eq.!= (aelt 3 l) (aelt 3 r))))])");
-     RUN("(def = all [A] proc {(e Eql A)} [l r] (e.= l r))");
-     RUN("(def != all [A] proc {(e Eql A)} [l r] (e.!= l r))");
+        RUN("(def Eql Trait Eql [A] [.= Proc [A A] Bool] [.!= Proc [A A] Bool])\n");
+        RUN("(def eql-i64 instance (Eql I64) [.= proc [l r] (i64.= l r)] [.!= proc [l r] (i64.= l r)])\n");
+        RUN("(def eq-arr4 instance [A] {(eq (Eql A))} (Eql (Array [1] A))"
+            "  [.= proc [l r] (eq.= (aelt 0 l) (aelt 0 r))]"
+            "  [.!= proc [l r] (eq.!= (aelt 0 l) (aelt 0 r))])");
+        RUN("(def = all [A] proc {(e Eql A)} [l r] (e.= l r))");
+        RUN("(def != all [A] proc {(e Eql A)} [l r] (e.!= l r))");
 
-     bool expected = false;
-     TEST_EQ("(!= (array [#q #o #i #f]) (array [#q #o #i #f]))");
+        bool expected = false;
+        TEST_EQ("(!= (array [#q]) (array [#q]))");
     }
     */
 

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -106,10 +106,9 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
         TEST_EQ("(eql (array [1 2]) (array [1 2]))");
     }
 
-    /*
     if (test_start(log, mv_string("poly-trait-multi-inline-proc"))) {
         RUN("(def Eql Trait Eql [A] [.= Proc [A A] Bool] [.!= Proc [A A] Bool])\n");
-        RUN("(def eql-i64 instance (Eql I64) [.= proc [l r] (i64.= l r)] [.!= proc [l r] (i64.= l r)])\n");
+        RUN("(def eql-i64 instance (Eql I64) [.= proc [l r] (i64.= l r)] [.!= proc [l r] (i64.!= l r)])\n");
         RUN("(def eq-arr4 instance [A] {(eq (Eql A))} (Eql (Array [1] A))"
             "  [.= proc [l r] (eq.= (aelt 0 l) (aelt 0 r))]"
             "  [.!= proc [l r] (eq.!= (aelt 0 l) (aelt 0 r))])");
@@ -119,7 +118,6 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
         bool expected = false;
         TEST_EQ("(!= (array [#q]) (array [#q]))");
     }
-    */
 
     // -------------------------------------------------------------------------
     //

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -218,21 +218,21 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
         TEST_EQ("((all [A] labels (go-to loop 0) [loop [x] (if (i64.< x 10) (go-to loop (i64.+ x 1)) x)]) {Unit})");
     }
 
-    // TODO: fix the typechecking error here!
-    /* if (test_start(log, mv_string("apply-label-seq"))) { */
-    /*     int64_t expected = -510; */
-    /*     RUN("(def label-seq all [A] proc [x I64] (labels (go-to call-1) [call-1 (go-to call-2)] [call-2 x]))"); */
-    /*     TEST_EQ("(label-seq {Unit} -510)"); */
-    /* } */
+    if (test_start(log, mv_string("apply-label-seq"))) {
+        int64_t expected = -510;
+        RUN("(def label-seq all [A] proc [(x I64)] (labels (go-to call-1) [call-1 (go-to call-2)] [call-2 x]))");
+        TEST_EQ("(label-seq {Unit} -510)");
+    }
 
-    /* if (test_start(log, mv_string("apply-label-seq"))) { */
-    /*     char* expected = "510"; */
+    if (test_start(log, mv_string("apply-label-seq"))) {
+        char* expected = "510";
 
-    /*     /\* was accessing function 'fn' as -0x18(rbp) then as -0x10(rbp) *\/ */
-    /*     /\* when stepping through code, fn seems to be 40 0x28(rbp) ?? *\/ */
-    /*     RUN("(def label-seq-2 all [A] proc [(fn (Proc [A] Unit)) (x A) (y A)] (labels (go-to call-1) [call-1 (seq (fn x) (go-to call-2))] [call-2 (fn y)]))"); */
-    /*     TEST_STDOUT("(label-seq-2 (proc [x] terminal.write-string (i64.to-string x)) 5 10)"); */
-    /* } */
+        RUN("(def label-seq-2 all [A] proc [(fn (Proc [A] Unit)) (x A) (y A)] (labels (go-to call-1) [call-1 (seq (fn x) (go-to call-2))] [call-2 (fn y)]))");
+        PiAllocator pia = convert_to_pallocator(&ra);
+        PiAllocator old = set_std_current_allocator(pia);
+        TEST_STDOUT("(label-seq-2 (proc [x] terminal.write-string (i64.to-string x)) 5 10)");
+        set_std_current_allocator(old);
+    }
 
 
     /* if (test_start(log, mv_string("apply-label"))) { */

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -458,5 +458,12 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
         TEST_MEM("(seq [let! addr (alloc (size-of I64))] (str 12 0 addr) (str -67 0 addr))");
     }
 
+    /*
+    if (test_start(log, mv_string("poly-proc-in-proc"))) {
+        int64_t expected = 72;
+        TEST_EQ("((proc [x] (let [id (all [A] proc [(y A)] y)] (id {I64} x))) 72)");
+    }
+    */
+
     set_std_current_allocator(old);
 }

--- a/test/src/test_pico/eval/polymorphic.c
+++ b/test/src/test_pico/eval/polymorphic.c
@@ -458,12 +458,10 @@ void run_pico_eval_polymorphic_tests(TestLog *log, Module* module, Environment* 
         TEST_MEM("(seq [let! addr (alloc (size-of I64))] (str 12 0 addr) (str -67 0 addr))");
     }
 
-    /*
     if (test_start(log, mv_string("poly-proc-in-proc"))) {
         int64_t expected = 72;
         TEST_EQ("((proc [x] (let [id (all [A] proc [(y A)] y)] (id {I64} x))) 72)");
     }
-    */
 
     set_std_current_allocator(old);
 }

--- a/test/src/test_pico/eval/proc.c
+++ b/test/src/test_pico/eval/proc.c
@@ -6,9 +6,6 @@
 #include "test_pico/eval/components.h"
 #include "test_pico/helper.h"
 
-#define RUN(str) run_toplevel(str, module, context); refresh_env(env)
-#define TEST_EQ(str) test_toplevel_eq(str, &expected, module, context)
-#define TEST_STDOUT(str) test_toplevel_stdout(str, expected, module, context)
 #define TEST_MEM(str) test_toplevel_mem(str, &expected, start, sizeof(expected), module, context)
 
 void run_pico_eval_proc_tests(TestLog *log, Module* module, Environment* env, Target target, RegionAllocator* region) {

--- a/test/src/test_pico/eval/proc.c
+++ b/test/src/test_pico/eval/proc.c
@@ -1,7 +1,4 @@
-#include <string.h>
-#include "platform/memory/static.h"
-
-#include "pico/stdlib/extra.h"
+#include "pico/stdlib/platform/submodules.h"
 
 #include "test_pico/eval/components.h"
 #include "test_pico/helper.h"
@@ -15,6 +12,7 @@ void run_pico_eval_proc_tests(TestLog *log, Module* module, Environment* env, Ta
         .log = log,
         .target = target,
     };
+    Allocator ra = ra_to_gpa(region);
 
     // Literals
     if (test_start(log, mv_string("const-return"))) {
@@ -29,15 +27,14 @@ void run_pico_eval_proc_tests(TestLog *log, Module* module, Environment* env, Ta
         Quad expected = (Quad) {.x = -5, .y = 10, .z = -676, .p = -897};
         TEST_EQ("((proc [(s Quad)] s) (struct Quad [.x -5] [.y 10] [.z -676] [.p -897]))");
     }
-
-    /* (def my-func proc [] seq */
-    /*   [let! my-list (list.mk-list {I64} 4 4)] */
-    /*   ;;(list.each print-fn my-list) */
-    /*   my-list) */
     
-    /* if (test_start(log, mv_string("large-static-argument"))) { */
-    /*     uint64_t expected = 4; */
-    /*     RUN("(def my-func proc [] seq [let! my-list (list.mk-list {I64} 4 4)] my-list)"); */
-    /*     TEST_EQ("(my-func).len"); */
-    /* } */
+    if (test_start(log, mv_string("large-static-argument"))) {
+        uint64_t expected = 4;
+        RUN("(def my-func proc [] seq [let! my-list (list.mk-list {I64} 4 4)] my-list)");
+
+        PiAllocator pia = convert_to_pallocator(&ra);
+        PiAllocator old = set_std_current_allocator(pia);
+        TEST_EQ("(my-func).len");
+        set_std_current_allocator(old);
+    }
 }

--- a/test/src/test_pico/parse/parse.c
+++ b/test/src/test_pico/parse/parse.c
@@ -8,7 +8,7 @@
 #include "test_pico/parse/parse_helper.h"
 
 
-//void test_parse_eq(const char *string, RawTree expected, Environment* env, TestContext context);
+#undef TEST_EQ
 #define TEST_EQ(str) test_parse_eq(str, expected, context)
 
 void run_pico_parse_tests(TestLog* log, RegionAllocator* region) {

--- a/test/src/test_pico/stdlib/core/core.c
+++ b/test/src/test_pico/stdlib/core/core.c
@@ -127,12 +127,12 @@ void run_pico_stdlib_core_tests(TestLog *log, Module* module, Environment* env, 
         TEST_EQ("(labels (go-to start) [start (labels (go-to end) [end 4])] [end 3])");
     }
 
-    /* TODO (BUG): this generate a panic - fix it
+    /*
     if (test_start(log, mv_string("nested-labels-with-bind"))) {
         int64_t expected = 4;
         TEST_EQ(""
                 "(labels (go-to start 3) "
-                "  [start [y] (seq [let! x 4] (labels (go-to end) [end x]))]"
+                "  [start [(y I64)] (seq [let! x 4] (labels (go-to end) [end x]))]"
                 "  [end 3])");
     }
     */

--- a/test/src/test_pico/stdlib/core/core.c
+++ b/test/src/test_pico/stdlib/core/core.c
@@ -127,15 +127,12 @@ void run_pico_stdlib_core_tests(TestLog *log, Module* module, Environment* env, 
         TEST_EQ("(labels (go-to start) [start (labels (go-to end) [end 4])] [end 3])");
     }
 
-    /*
-    if (test_start(log, mv_string("nested-labels-with-bind"))) {
+    if (test_start(log, mv_string("nested-labels-with-let"))) {
         int64_t expected = 4;
-        TEST_EQ(""
-                "(labels (go-to start 3) "
+        TEST_EQ("(labels (go-to start 3) "
                 "  [start [(y I64)] (seq [let! x 4] (labels (go-to end) [end x]))]"
                 "  [end 3])");
     }
-    */
 
     // -------------------------------------------------------------------------
     //

--- a/test/src/test_pico/stdlib/core/core.c
+++ b/test/src/test_pico/stdlib/core/core.c
@@ -644,18 +644,29 @@ void run_pico_stdlib_core_tests(TestLog *log, Module* module, Environment* env, 
         TEST_EQ("(get-value {I64} 5)");
     }
 
-    if (test_start(log, mv_string("instance-mval"))) {
+    if (test_start(log, mv_string("instance-multi-val"))) {
         int64_t expected = -77;
         RUN("(def MultiInhabited Trait MultiInhabited [A] [.val-1 A] [.val-2 A])");
         // TODO (BUG)
         // swapping the order of below statements gives an 'ambiguous instance' error?
         RUN("(def get-second-value all [A] proc {(in (MultiInhabited A))} [(x A)] in.val-2)");
-        RUN("(def i64-multi-inhabited instance (MultiInhabited I64) [.val-1 77] [.val-2 -77])");
+        RUN("(def i64-multi-inhabited instance (MultiInhabited I64) [.val-1 237] [.val-2 -77])");
 
         TEST_EQ("(get-second-value {I64} 5)");
     }
 
-    if (test_start(log, mv_string("instance-mval"))) {
+    if (test_start(log, mv_string("instance-out-of-order"))) {
+        int64_t expected = -77;
+        RUN("(def MultiInhabited Trait MultiInhabited [A] [.val-1 A] [.val-2 A])");
+        // TODO (BUG)
+        // swapping the order of below statements gives an 'ambiguous instance' error?
+        RUN("(def get-second-value all [A] proc {(in (MultiInhabited A))} [(x A)] in.val-2)");
+        RUN("(def i64-multi-inhabited instance (MultiInhabited I64) [.val-2 -77] [.val-1 237])");
+
+        TEST_EQ("(get-second-value {I64} 5)");
+    }
+
+    if (test_start(log, mv_string("instance-const-single"))) {
         uint64_t expected = 43;
         RUN("(def MultiConstInhabited Trait MultiConstInhabited [A] [.val-1 A] [.val-2 U64])");
         RUN("(def get-snd-const-value all [A] proc {(in (MultiConstInhabited A))} [(x A)] in.val-2)");
@@ -701,8 +712,7 @@ void run_pico_stdlib_core_tests(TestLog *log, Module* module, Environment* env, 
         TEST_EQ("(poly-eq :false :true)");
     }
 
-    /*
-    if (test_start(log, mv_string("instance-out-of-order"))) {
+    if (test_start(log, mv_string("instance-inline-proc-out-of-order"))) {
         RUN("(def Eql Trait Eql [A] [.eql Proc [A A] Bool] [.not-eql Proc [A A] Bool])");
         RUN("(def eql-bool instance (Eql Bool)"
             "  [.not-eql proc [a b] (bool.not (bool.or (bool.and a b) (bool.not (bool.or a b))))]"
@@ -712,7 +722,6 @@ void run_pico_stdlib_core_tests(TestLog *log, Module* module, Environment* env, 
         bool expected = false;
         TEST_EQ("(poly-eq :false :true)");
     }
-    */
 
     // -----------------------------------------------------
     // 

--- a/test/src/test_pico/stdlib/num.c
+++ b/test/src/test_pico/stdlib/num.c
@@ -42,12 +42,6 @@ void run_pico_stdlib_num_tests(TestLog *log, Module* module, Environment* env, T
         TEST_EQ("(u64./ 20594361 9231)");
     }
 
-    // TODO: something like this crashed qoi.rl: see index code.
-    /* if (test_start(log, mv_string("test-widening"))) { */
-    /*     uint8_t expected = 2; */
-    /*     TEST_EQ("(u8.mod (u8.* 255 11) 64)"); */
-    /* } */
-
     if (test_start(log, mv_string("small-unsigned-divide"))) {
         uint8_t expected = 16;
         TEST_EQ("(u8./ 128 8)");

--- a/test/src/test_pico/typecheck.c
+++ b/test/src/test_pico/typecheck.c
@@ -9,7 +9,6 @@
 #include "test_pico/helper.h"
 #include "test_pico/typecheck.h"
 
-#define RUN(str) run_toplevel(str, module, context); refresh_env(env)
 #define TEST_TYPE(str) test_typecheck_eq(str, expected, env, context)
 #define TEST_TYPE_FAIL(str) test_typecheck_fail(str, env, context)
 


### PR DESCRIPTION
## Features
- Added rename support to imports
- Added proper support for recursive functions
- Added support for/interpretation of the 'exports' module header field.

## Fixes
- Can add polymorphic (all) `procs` inside other procs.
- Added support for key events on X11 (+ got it building again).
- Polymorphic Instance codegen: now correctly generates when
  - There is > 1 field
- Instance Codegen: now correctly generates when
  - Instances have out of order fields
- Fix parsing of `:all` clause in module exports.

## Development
- Started work on functions for generating on-disk executables from images.